### PR TITLE
feat: Add mail-cli for Apple Mail.app via JXA

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "apple-pim",
-  "version": "1.0.2",
-  "description": "Native macOS integration for Calendar, Reminders, and Contacts using EventKit and Contacts frameworks",
+  "version": "1.1.0",
+  "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
   "author": {
     "name": "Omar Shahine",
     "email": "omar@shahine.com"
   },
   "license": "MIT",
-  "keywords": ["calendar", "reminders", "contacts", "eventkit", "macos", "pim"],
+  "keywords": ["calendar", "reminders", "contacts", "mail", "eventkit", "jxa", "macos", "pim"],
   "mcpServers": {
     "apple-pim": {
       "type": "stdio",

--- a/agents/pim-assistant.md
+++ b/agents/pim-assistant.md
@@ -1,11 +1,12 @@
 ---
 description: |
-  Personal Information Management assistant for calendars, reminders, and contacts. Use this agent when:
+  Personal Information Management assistant for calendars, reminders, contacts, and local mail. Use this agent when:
   - User mentions scheduling, appointments, meetings, events, or calendar
   - User mentions reminders, tasks, todos, "remind me", or "don't forget"
   - User asks about contacts, people, email addresses, phone numbers
   - User wants to manage their calendar, reminders, or address book
   - User needs help with time management or task tracking
+  - User wants to check local Mail.app messages, search mail, or triage inbox
 
   <example>
   user: "Schedule a meeting with the team for next Tuesday at 2pm"
@@ -31,6 +32,11 @@ description: |
   user: "Mark the grocery shopping reminder as done"
   assistant: "I'll use the pim-assistant agent to complete the grocery shopping reminder."
   </example>
+
+  <example>
+  user: "Check my Mail.app inbox for unread messages"
+  assistant: "I'll use the pim-assistant agent to list unread messages from Mail.app."
+  </example>
 tools:
   - mcp__apple-pim__calendar_list
   - mcp__apple-pim__calendar_events
@@ -52,12 +58,20 @@ tools:
   - mcp__apple-pim__contact_create
   - mcp__apple-pim__contact_update
   - mcp__apple-pim__contact_delete
+  - mcp__apple-pim__mail_accounts
+  - mcp__apple-pim__mail_mailboxes
+  - mcp__apple-pim__mail_messages
+  - mcp__apple-pim__mail_get
+  - mcp__apple-pim__mail_search
+  - mcp__apple-pim__mail_update
+  - mcp__apple-pim__mail_move
+  - mcp__apple-pim__mail_delete
 color: blue
 ---
 
 # PIM Assistant
 
-You are a Personal Information Management assistant that helps users manage their calendars, reminders, and contacts on macOS.
+You are a Personal Information Management assistant that helps users manage their calendars, reminders, contacts, and local mail on macOS.
 
 ## Capabilities
 
@@ -87,6 +101,17 @@ You have access to the Apple PIM MCP tools for:
 - Create new contacts
 - Update existing contacts
 - Delete contacts
+
+### Local Mail (Mail.app)
+- List mail accounts and mailboxes with unread counts
+- View messages in any mailbox with filtering (unread, flagged)
+- Get full message content by message ID
+- Search messages by subject, sender, or content
+- Update message flags (read/unread, flagged, junk)
+- Move messages between mailboxes
+- Delete messages (move to Trash)
+
+**Note:** Mail tools access Mail.app's local state. Mail.app must be running. For cloud email operations (sending, composing), use the Fastmail MCP instead.
 
 ## Guidelines
 
@@ -134,6 +159,18 @@ When creating reminders:
 - Confirm the due date/time if provided
 - Suggest a list if the user has organized lists
 - Ask about priority for urgent items
+
+### Local Mail
+When working with Mail.app:
+- **Mail.app must be running** — if you get an "app not running" error, tell the user to open Mail.app
+- **Message IDs are RFC 2822** — stable across mailbox moves, used for get/update/move/delete
+- **Use filters for efficiency** — use `filter: "unread"` instead of fetching all and filtering client-side
+- **Scope**: This accesses local Mail.app state. For sending email, composing drafts, or server-side folder management, direct the user to Fastmail MCP tools
+- "Check my mail" → `mail_messages` with default INBOX
+- "Show unread messages" → `mail_messages` with filter: unread
+- "Find emails from X" → `mail_search` with field: sender
+- "Mark as read" → `mail_update` with read: true
+- "Archive this" → `mail_move` to Archive mailbox
 
 ### Contact Lookups
 When searching contacts:

--- a/commands/mail.md
+++ b/commands/mail.md
@@ -1,0 +1,127 @@
+---
+description: Manage macOS Mail.app - list mailboxes, read messages, search, update flags, move, delete
+argument-hint: "[accounts|mailboxes|messages|get|search|update|move|delete] [options]"
+allowed-tools:
+  - mcp__apple-pim__mail_accounts
+  - mcp__apple-pim__mail_mailboxes
+  - mcp__apple-pim__mail_messages
+  - mcp__apple-pim__mail_get
+  - mcp__apple-pim__mail_search
+  - mcp__apple-pim__mail_update
+  - mcp__apple-pim__mail_move
+  - mcp__apple-pim__mail_delete
+---
+
+# Mail Management
+
+Manage macOS Mail.app messages via JXA (JavaScript for Automation). Mail.app must be running.
+
+## Available Operations
+
+When the user runs this command, determine which operation they need and use the appropriate MCP tool:
+
+### List Accounts
+Use `mail_accounts` to show all configured mail accounts.
+
+### List Mailboxes
+Use `mail_mailboxes` to list mailboxes with unread and total message counts:
+- Optional: `account` (filter by account name)
+
+### List Messages
+Use `mail_messages` to list messages in a mailbox:
+- Default mailbox: INBOX
+- Parameters: `mailbox`, `account`, `limit` (default: 25), `filter` (unread, flagged, all)
+
+### Get Message
+Use `mail_get` to get a single message with full body content:
+- Required: `id` (RFC 2822 message ID)
+
+### Search Messages
+Use `mail_search` to find messages by subject, sender, or content:
+- Required: `query` (search term)
+- Optional: `field` (subject, sender, all), `mailbox`, `account`, `limit`
+
+### Update Message
+Use `mail_update` to change message flags:
+- Required: `id` (message ID)
+- Optional: `read` (true/false), `flagged` (true/false), `junk` (true/false)
+
+### Move Message
+Use `mail_move` to move a message to a different mailbox:
+- Required: `id` (message ID), `toMailbox` (destination)
+- Optional: `toAccount` (destination account)
+
+### Delete Message
+Use `mail_delete` to delete a message (moves to Trash):
+- Required: `id` (message ID)
+
+## Examples
+
+**List accounts:**
+```
+/apple-pim:mail accounts
+```
+
+**List mailboxes:**
+```
+/apple-pim:mail mailboxes
+/apple-pim:mail mailboxes --account "iCloud"
+```
+
+**List messages:**
+```
+/apple-pim:mail messages
+/apple-pim:mail messages --mailbox INBOX --limit 10
+/apple-pim:mail messages --filter unread
+```
+
+**Read a message:**
+```
+/apple-pim:mail get --id <message-id>
+```
+
+**Search messages:**
+```
+/apple-pim:mail search "invoice"
+/apple-pim:mail search "John" --field sender
+/apple-pim:mail search "project update" --mailbox INBOX
+```
+
+**Mark as read:**
+```
+/apple-pim:mail update --id <message-id> --read true
+```
+
+**Flag a message:**
+```
+/apple-pim:mail update --id <message-id> --flagged true
+```
+
+**Move to archive:**
+```
+/apple-pim:mail move --id <message-id> --to-mailbox Archive
+```
+
+**Delete a message:**
+```
+/apple-pim:mail delete --id <message-id>
+```
+
+## Parsing User Intent
+
+When a user provides natural language, map to the appropriate operation:
+- "Check my mail" -> `mail_messages` with default INBOX
+- "Show unread messages" -> `mail_messages` with filter: unread
+- "Find emails from John" -> `mail_search` with field: sender
+- "Search for invoices" -> `mail_search` with query "invoice"
+- "Read that email" -> `mail_get` with the message ID
+- "Mark it as read" -> `mail_update` with read: true
+- "Archive this" -> `mail_move` to Archive mailbox
+- "Delete that email" -> `mail_delete`
+
+## Important Notes
+
+- **Mail.app must be running** for all operations. If not running, the CLI returns a clear error.
+- **Message IDs** are RFC 2822 message IDs (stable across mailbox moves).
+- **For cloud email operations** (sending, composing, folder management), use the Fastmail MCP instead.
+- This tool accesses Mail.app's local state — "On My Mac" mailboxes, locally cached messages, and local search.

--- a/skills/apple-pim/SKILL.md
+++ b/skills/apple-pim/SKILL.md
@@ -1,17 +1,18 @@
 ---
 description: |
-  Provides knowledge about Apple's EventKit and Contacts frameworks for managing calendars, reminders, and contacts on macOS. Use this skill when discussing EventKit APIs, calendar data models, reminder structures, contact fields, or best practices for personal information management.
+  Provides knowledge about Apple's EventKit, Contacts, and Mail.app scripting for managing calendars, reminders, contacts, and local mail on macOS. Use this skill when discussing EventKit APIs, calendar data models, reminder structures, contact fields, Mail.app JXA scripting, or best practices for personal information management.
 ---
 
-# Apple PIM (EventKit & Contacts)
+# Apple PIM (EventKit, Contacts & Mail)
 
 ## Overview
 
-Apple provides two frameworks for personal information management:
+Apple provides frameworks and scripting interfaces for personal information management:
 - **EventKit**: Calendars and Reminders
 - **Contacts**: Address book management
+- **Mail.app**: Local email via JXA (JavaScript for Automation)
 
-Both require explicit user permission via privacy prompts.
+EventKit and Contacts require explicit user permission via privacy prompts. Mail.app requires Automation permission and must be running.
 
 ## EventKit Framework
 
@@ -255,3 +256,74 @@ Support flexible input:
 - Limit date ranges for event queries
 - Use predicates to filter server-side
 - Fetch only needed contact keys
+
+## Mail.app via JXA
+
+### Why JXA?
+
+Mail.app has no native Swift framework (unlike EventKit/Contacts). JXA (JavaScript for Automation) provides:
+- Native JSON output via `JSON.stringify()`
+- Full access to Mail.app's scripting dictionary
+- Array-level property access for batch operations
+
+The Swift CLI (`mail-cli`) wraps JXA via `Process` calling `osascript -l JavaScript`.
+
+### Key Constraint
+
+**Mail.app must be running.** Unlike EventKit/Contacts which work headlessly, Mail.app is a GUI application. The CLI checks `NSWorkspace.shared.runningApplications` upfront and returns a clear error.
+
+### Message Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `messageId` | String | RFC 2822 message ID (stable identifier) |
+| `subject` | String | Message subject |
+| `sender` | String | Sender address |
+| `dateReceived` | Date | When received |
+| `dateSent` | Date | When sent |
+| `readStatus` | Bool | Read/unread |
+| `flaggedStatus` | Bool | Flagged/unflagged |
+| `junkMailStatus` | Bool | Junk/not junk |
+| `content` | String | Plain text body |
+| `mailbox` | Mailbox | Parent mailbox |
+
+### Batch Property Fetching
+
+JXA's scripting bridge supports array-level property access — much faster than per-message iteration:
+
+```javascript
+// FAST: One IPC call per property, returns array
+const subjects = mbox.messages.subject();
+const senders = mbox.messages.sender();
+const dates = mbox.messages.dateReceived();
+
+// SLOW: N IPC calls (one per message)
+for (const msg of mbox.messages()) {
+    msg.subject(); // individual IPC call
+}
+```
+
+### Message ID
+
+Uses RFC 2822 `messageId` property as the stable identifier. This persists across mailbox moves, unlike internal Mail.app IDs. Use `.whose({messageId: targetId})` for lookups.
+
+### Permissions
+
+Mail.app requires Automation permission:
+- System Settings > Privacy & Security > Automation
+- The terminal/app must be allowed to control Mail.app
+- First run triggers a system permission dialog
+
+### Scope vs Fastmail MCP
+
+| Capability | mail-cli (local) | Fastmail MCP (cloud) |
+|------------|-----------------|---------------------|
+| Read messages | Yes | Yes |
+| Search | Local index | Server-side |
+| Update flags | Yes | Yes |
+| Move/delete | Yes | Yes |
+| Send email | No | Yes |
+| Compose drafts | No | Yes |
+| Folder management | No | Yes |
+| "On My Mac" mailboxes | Yes | No |
+| Offline access | Yes | No |

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .executable(name: "calendar-cli", targets: ["CalendarCLI"]),
         .executable(name: "reminder-cli", targets: ["ReminderCLI"]),
         .executable(name: "contacts-cli", targets: ["ContactsCLI"]),
+        .executable(name: "mail-cli", targets: ["MailCLI"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
@@ -35,6 +36,13 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "Sources/ContactsCLI"
+        ),
+        .executableTarget(
+            name: "MailCLI",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources/MailCLI"
         ),
     ]
 )

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -1,0 +1,806 @@
+import ArgumentParser
+import AppKit
+import Foundation
+
+@main
+struct MailCLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mail-cli",
+        abstract: "Manage macOS Mail.app via JXA (JavaScript for Automation)",
+        subcommands: [
+            ListAccounts.self,
+            ListMailboxes.self,
+            ListMessages.self,
+            GetMessage.self,
+            SearchMessages.self,
+            UpdateMessage.self,
+            MoveMessage.self,
+            DeleteMessage.self,
+        ]
+    )
+}
+
+// MARK: - Shared Utilities
+
+enum CLIError: Error, LocalizedError {
+    case appNotRunning(String)
+    case jxaError(String)
+    case notFound(String)
+    case invalidInput(String)
+    case timeout(String)
+    case accessDenied(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .appNotRunning(let msg): return msg
+        case .jxaError(let msg): return msg
+        case .notFound(let msg): return msg
+        case .invalidInput(let msg): return msg
+        case .timeout(let msg): return msg
+        case .accessDenied(let msg): return msg
+        }
+    }
+}
+
+func outputJSON(_ value: Any) {
+    if let data = try? JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted, .sortedKeys]),
+       let string = String(data: data, encoding: .utf8) {
+        print(string)
+    }
+}
+
+/// Escape a string for safe interpolation into JXA string literals (single or double quoted).
+/// Escapes backslashes first, then quotes and control characters.
+func escapeForJXA(_ s: String) -> String {
+    return s
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "'", with: "\\'")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+        .replacingOccurrences(of: "\n", with: "\\n")
+        .replacingOccurrences(of: "\r", with: "\\r")
+        .replacingOccurrences(of: "\t", with: "\\t")
+}
+
+func ensureMailRunning() throws {
+    let running = NSWorkspace.shared.runningApplications.contains {
+        $0.bundleIdentifier == "com.apple.mail"
+    }
+    guard running else {
+        throw CLIError.appNotRunning("Mail.app is not running. Please open Mail.app first.")
+    }
+}
+
+func runJXA(_ script: String) throws -> Any {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+    proc.arguments = ["-l", "JavaScript", "-e", script]
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    proc.standardOutput = stdoutPipe
+    proc.standardError = stderrPipe
+
+    try proc.run()
+
+    // Read pipe data concurrently BEFORE waitUntilExit to prevent deadlock.
+    // If output exceeds the ~64KB pipe buffer and we wait first, the child
+    // blocks on write and never exits — classic pipe deadlock.
+    var stdoutData = Data()
+    var stderrData = Data()
+    let readGroup = DispatchGroup()
+
+    readGroup.enter()
+    DispatchQueue.global().async {
+        stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        readGroup.leave()
+    }
+    readGroup.enter()
+    DispatchQueue.global().async {
+        stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        readGroup.leave()
+    }
+
+    // 30-second timeout
+    let deadline = DispatchTime.now() + .seconds(30)
+    let waitGroup = DispatchGroup()
+    waitGroup.enter()
+    DispatchQueue.global().async {
+        proc.waitUntilExit()
+        waitGroup.leave()
+    }
+    let result = waitGroup.wait(timeout: deadline)
+    if result == .timedOut {
+        proc.terminate()
+        throw CLIError.timeout("Mail.app did not respond within 30 seconds")
+    }
+
+    // Wait for pipe reads to finish (they will, since the process has exited)
+    readGroup.wait()
+
+    let stderrStr = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+    guard proc.terminationStatus == 0 else {
+        if stderrStr.contains("not allowed to send keystrokes") || stderrStr.contains("not allowed assistive access") {
+            throw CLIError.accessDenied("Grant access in System Settings > Privacy & Security > Automation")
+        }
+        throw CLIError.jxaError(stderrStr.isEmpty ? "JXA script failed with exit code \(proc.terminationStatus)" : stderrStr)
+    }
+
+    let stdoutStr = String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+    guard !stdoutStr.isEmpty else {
+        return [String: Any]()
+    }
+
+    guard let data = stdoutStr.data(using: .utf8),
+          let json = try? JSONSerialization.jsonObject(with: data) else {
+        throw CLIError.jxaError("Failed to parse JXA output as JSON: \(stdoutStr.prefix(200))")
+    }
+
+    return json
+}
+
+// Shared JXA helper for finding a message by ID.
+// Accepts optional mailbox/account to narrow the search.
+// Priority order: specified mailbox > INBOX/Sent/Archive/Drafts > all mailboxes.
+func findMessageJXA(targetId: String, mailbox: String?, account: String?) -> String {
+    let escapedId = escapeForJXA(targetId)
+    let mailboxFilter = mailbox.map { "'\(escapeForJXA($0))'" } ?? "null"
+    let accountFilter = account.map { "'\(escapeForJXA($0))'" } ?? "null"
+
+    return """
+    function findMessage() {
+        const Mail = Application("Mail");
+        const targetId = '\(escapedId)';
+        const mboxHint = \(mailboxFilter);
+        const acctHint = \(accountFilter);
+
+        function searchInMailbox(mbox) {
+            try {
+                const found = mbox.messages.whose({messageId: targetId})();
+                if (found.length > 0) return found[0];
+            } catch(e) {}
+            return null;
+        }
+
+        // Search priority mailboxes first, then remaining mailboxes
+        const priority = ['INBOX', 'Sent Messages', 'Archive', 'Drafts', 'Deleted Messages', 'Junk'];
+        const accounts = acctHint ? Mail.accounts.whose({name: acctHint})() : Mail.accounts();
+        const searched = new Set();
+
+        // If mailbox hint given, try it first (optimization, not a hard filter)
+        if (mboxHint) {
+            for (let a = 0; a < accounts.length; a++) {
+                const mbs = accounts[a].mailboxes.whose({name: mboxHint})();
+                for (let m = 0; m < mbs.length; m++) {
+                    searched.add(accounts[a].name() + '/' + mbs[m].name());
+                    const r = searchInMailbox(mbs[m]);
+                    if (r) return r;
+                }
+            }
+        }
+
+        for (let a = 0; a < accounts.length; a++) {
+            for (let p = 0; p < priority.length; p++) {
+                const mbs = accounts[a].mailboxes.whose({name: priority[p]})();
+                for (let m = 0; m < mbs.length; m++) {
+                    searched.add(accounts[a].name() + '/' + mbs[m].name());
+                    const r = searchInMailbox(mbs[m]);
+                    if (r) return r;
+                }
+            }
+        }
+
+        // Search remaining mailboxes (non-priority)
+        for (let a = 0; a < accounts.length; a++) {
+            const mbs = accounts[a].mailboxes();
+            for (let m = 0; m < mbs.length; m++) {
+                const key = accounts[a].name() + '/' + mbs[m].name();
+                if (searched.has(key)) continue;
+                const r = searchInMailbox(mbs[m]);
+                if (r) return r;
+            }
+        }
+        return null;
+    }
+    """
+}
+
+// MARK: - Commands
+
+struct ListAccounts: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "accounts",
+        abstract: "List all mail accounts"
+    )
+
+    func run() async throws {
+        try ensureMailRunning()
+
+        let script = """
+        const Mail = Application("Mail");
+        const accounts = Mail.accounts();
+        const result = accounts.map(a => ({
+            name: a.name(),
+            id: a.id(),
+            enabled: a.enabled(),
+            userName: a.userName(),
+            accountType: a.accountType()
+        }));
+        JSON.stringify(result);
+        """
+
+        let result = try runJXA(script)
+        outputJSON([
+            "success": true,
+            "accounts": result
+        ])
+    }
+}
+
+struct ListMailboxes: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mailboxes",
+        abstract: "List mailboxes with unread counts"
+    )
+
+    @Option(name: .long, help: "Filter by account name")
+    var account: String?
+
+    func run() async throws {
+        try ensureMailRunning()
+
+        let accountFilter = account.map { "'\(escapeForJXA($0))'" } ?? "null"
+
+        let script = """
+        const Mail = Application("Mail");
+        const accountFilter = \(accountFilter);
+        const results = [];
+
+        function collectMailboxes(mailboxes, accountName) {
+            for (let i = 0; i < mailboxes.length; i++) {
+                const mb = mailboxes[i];
+                results.push({
+                    name: mb.name(),
+                    account: accountName,
+                    unreadCount: mb.unreadCount(),
+                    messageCount: mb.messages.length
+                });
+            }
+        }
+
+        if (accountFilter) {
+            const accts = Mail.accounts.whose({name: accountFilter})();
+            if (accts.length === 0) {
+                JSON.stringify({error: "Account not found: " + accountFilter});
+            } else {
+                collectMailboxes(accts[0].mailboxes(), accountFilter);
+                JSON.stringify(results);
+            }
+        } else {
+            const accounts = Mail.accounts();
+            for (let a = 0; a < accounts.length; a++) {
+                const acct = accounts[a];
+                collectMailboxes(acct.mailboxes(), acct.name());
+            }
+            JSON.stringify(results);
+        }
+        """
+
+        let raw = try runJXA(script)
+
+        // Check for error from JXA
+        if let dict = raw as? [String: Any], let error = dict["error"] as? String {
+            throw CLIError.notFound(error)
+        }
+
+        outputJSON([
+            "success": true,
+            "mailboxes": raw
+        ])
+    }
+}
+
+struct ListMessages: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "messages",
+        abstract: "List messages in a mailbox"
+    )
+
+    @Option(name: .long, help: "Mailbox name (default: INBOX)")
+    var mailbox: String = "INBOX"
+
+    @Option(name: .long, help: "Account name (searches all accounts if omitted)")
+    var account: String?
+
+    @Option(name: .long, help: "Maximum messages to return (default: 25)")
+    var limit: Int = 25
+
+    @Option(name: .long, help: "Filter: unread, flagged, or all (default: all)")
+    var filter: String?
+
+    func run() async throws {
+        try ensureMailRunning()
+
+        let accountFilter = account.map { "'\(escapeForJXA($0))'" } ?? "null"
+        let mailboxName = escapeForJXA(mailbox)
+        let filterVal = filter.map { "'\(escapeForJXA($0))'" } ?? "null"
+
+        let script = """
+        const Mail = Application("Mail");
+        const accountFilter = \(accountFilter);
+        const mailboxName = '\(mailboxName)';
+        const limit = \(limit);
+        const filterType = \(filterVal);
+
+        function findMailbox() {
+            const accounts = accountFilter
+                ? Mail.accounts.whose({name: accountFilter})()
+                : Mail.accounts();
+            for (let a = 0; a < accounts.length; a++) {
+                const mbs = accounts[a].mailboxes.whose({name: mailboxName})();
+                if (mbs.length > 0) return mbs[0];
+            }
+            return null;
+        }
+
+        const mbox = findMailbox();
+        if (!mbox) {
+            JSON.stringify({error: "Mailbox not found: " + mailboxName});
+        } else {
+            const msgs = mbox.messages;
+            const count = msgs.length;
+            if (count === 0) {
+                JSON.stringify({messages: [], mailbox: mailboxName, totalInMailbox: 0});
+            } else {
+                const results = [];
+                // Scan cap: when filtering, scan up to 10x limit to find enough matches.
+                // Without a filter, scan exactly limit messages.
+                const scanCap = filterType ? Math.min(count, limit * 10) : Math.min(count, limit);
+
+                // Per-message fetching with error handling (batch .slice can fail on null dates)
+                for (let i = 0; i < scanCap && results.length < limit; i++) {
+                    try {
+                        const m = msgs[i];
+                        const isRead = m.readStatus();
+                        const isFlagged = m.flaggedStatus();
+                        if (filterType === 'unread' && isRead) continue;
+                        if (filterType === 'flagged' && !isFlagged) continue;
+                        const dr = m.dateReceived();
+                        results.push({
+                            messageId: m.messageId(),
+                            sender: m.sender(),
+                            subject: m.subject(),
+                            dateReceived: dr ? dr.toISOString() : null,
+                            isRead: isRead,
+                            isFlagged: isFlagged,
+                            isJunk: m.junkMailStatus()
+                        });
+                    } catch(e) { /* skip messages that fail to read */ }
+                }
+
+                JSON.stringify({
+                    messages: results,
+                    mailbox: mailboxName,
+                    totalInMailbox: count
+                });
+            }
+        }
+        """
+
+        let raw = try runJXA(script)
+
+        if let dict = raw as? [String: Any], let error = dict["error"] as? String {
+            throw CLIError.notFound(error)
+        }
+
+        guard let dict = raw as? [String: Any] else {
+            outputJSON(["success": true, "messages": [] as [Any], "count": 0])
+            return
+        }
+
+        let messages = dict["messages"] as? [Any] ?? []
+        outputJSON([
+            "success": true,
+            "mailbox": dict["mailbox"] ?? mailbox,
+            "messages": messages,
+            "count": messages.count,
+            "totalInMailbox": dict["totalInMailbox"] ?? 0
+        ])
+    }
+}
+
+struct GetMessage: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "get",
+        abstract: "Get a single message by message ID"
+    )
+
+    @Option(name: .long, help: "RFC 2822 message ID")
+    var id: String
+
+    @Option(name: .long, help: "Mailbox name hint (speeds up lookup)")
+    var mailbox: String?
+
+    @Option(name: .long, help: "Account name hint (speeds up lookup)")
+    var account: String?
+
+    func run() async throws {
+        try ensureMailRunning()
+
+        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+
+        let script = """
+        \(findHelper)
+
+        const msg = findMessage();
+        if (!msg) {
+            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
+        } else {
+            const result = {
+                messageId: msg.messageId(),
+                subject: msg.subject(),
+                sender: msg.sender(),
+                dateReceived: msg.dateReceived() ? msg.dateReceived().toISOString() : null,
+                dateSent: msg.dateSent() ? msg.dateSent().toISOString() : null,
+                isRead: msg.readStatus(),
+                isFlagged: msg.flaggedStatus(),
+                isJunk: msg.junkMailStatus(),
+                replyTo: msg.replyTo(),
+                mailbox: msg.mailbox().name(),
+                account: msg.mailbox().account().name(),
+                content: msg.content()
+            };
+
+            // Get recipients
+            try {
+                const toRecips = msg.toRecipients();
+                result.to = toRecips.map(r => ({name: r.name(), address: r.address()}));
+            } catch(e) { result.to = []; }
+
+            try {
+                const ccRecips = msg.ccRecipients();
+                result.cc = ccRecips.map(r => ({name: r.name(), address: r.address()}));
+            } catch(e) { result.cc = []; }
+
+            // Get headers if available
+            try {
+                result.allHeaders = msg.allHeaders();
+            } catch(e) {}
+
+            JSON.stringify(result);
+        }
+        """
+
+        let raw = try runJXA(script)
+
+        if let dict = raw as? [String: Any], let error = dict["error"] as? String {
+            throw CLIError.notFound(error)
+        }
+
+        outputJSON([
+            "success": true,
+            "message": raw
+        ])
+    }
+}
+
+struct SearchMessages: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "search",
+        abstract: "Search messages by subject, sender, or content"
+    )
+
+    @Argument(help: "Search query")
+    var query: String
+
+    @Option(name: .long, help: "Search field: subject, sender, content, or all (default: all)")
+    var field: String = "all"
+
+    @Option(name: .long, help: "Mailbox name to search in (searches all if omitted)")
+    var mailbox: String?
+
+    @Option(name: .long, help: "Account name")
+    var account: String?
+
+    @Option(name: .long, help: "Maximum results (default: 25)")
+    var limit: Int = 25
+
+    func run() async throws {
+        try ensureMailRunning()
+
+        let escapedQuery = escapeForJXA(query.lowercased())
+        let accountFilter = account.map { "'\(escapeForJXA($0))'" } ?? "null"
+        let mailboxFilter = mailbox.map { "'\(escapeForJXA($0))'" } ?? "null"
+        let escapedField = escapeForJXA(field)
+
+        let script = """
+        const Mail = Application("Mail");
+        const query = '\(escapedQuery)';
+        const searchField = '\(escapedField)';
+        const accountFilter = \(accountFilter);
+        const mailboxFilter = \(mailboxFilter);
+        const limit = \(limit);
+        const results = [];
+
+        function searchMailbox(mbox, accountName) {
+            if (results.length >= limit) return;
+
+            const msgs = mbox.messages;
+            const count = msgs.length;
+            const batchSize = Math.min(count, 500);
+
+            for (let i = 0; i < batchSize && results.length < limit; i++) {
+                try {
+                    const m = msgs[i];
+                    const subj = (m.subject() || '').toLowerCase();
+                    const sndr = (m.sender() || '').toLowerCase();
+
+                    let match = false;
+                    if (searchField === 'subject') match = subj.includes(query);
+                    else if (searchField === 'sender') match = sndr.includes(query);
+                    else if (searchField === 'content') {
+                        try { match = (m.content() || '').toLowerCase().includes(query); } catch(e2) {}
+                    } else {
+                        // 'all': search subject + sender (content is too slow for all-field scan)
+                        match = subj.includes(query) || sndr.includes(query);
+                    }
+
+                    if (match) {
+                        const dr = m.dateReceived();
+                        results.push({
+                            messageId: m.messageId(),
+                            sender: m.sender(),
+                            subject: m.subject(),
+                            dateReceived: dr ? dr.toISOString() : null,
+                            isRead: m.readStatus(),
+                            isFlagged: m.flaggedStatus(),
+                            mailbox: mbox.name(),
+                            account: accountName
+                        });
+                    }
+                } catch(e) { /* skip messages that fail to read */ }
+            }
+        }
+
+        const accounts = accountFilter
+            ? Mail.accounts.whose({name: accountFilter})()
+            : Mail.accounts();
+
+        for (let a = 0; a < accounts.length && results.length < limit; a++) {
+            const acct = accounts[a];
+            const mbs = mailboxFilter
+                ? acct.mailboxes.whose({name: mailboxFilter})()
+                : acct.mailboxes();
+            for (let m = 0; m < mbs.length && results.length < limit; m++) {
+                searchMailbox(mbs[m], acct.name());
+            }
+        }
+
+        JSON.stringify(results);
+        """
+
+        let raw = try runJXA(script)
+        let messages = raw as? [Any] ?? []
+
+        outputJSON([
+            "success": true,
+            "query": query,
+            "field": field,
+            "messages": messages,
+            "count": messages.count
+        ])
+    }
+}
+
+struct UpdateMessage: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "update",
+        abstract: "Update message flags (read/unread, flagged, junk)"
+    )
+
+    @Option(name: .long, help: "RFC 2822 message ID")
+    var id: String
+
+    @Option(name: .long, help: "Set read status (true/false)")
+    var read: String?
+
+    @Option(name: .long, help: "Set flagged status (true/false)")
+    var flagged: String?
+
+    @Option(name: .long, help: "Set junk status (true/false)")
+    var junk: String?
+
+    @Option(name: .long, help: "Mailbox name hint (speeds up lookup)")
+    var mailbox: String?
+
+    @Option(name: .long, help: "Account name hint (speeds up lookup)")
+    var account: String?
+
+    func run() async throws {
+        try ensureMailRunning()
+
+        var updates = [String]()
+        if let read = read {
+            updates.append("msg.readStatus = \(read == "true" ? "true" : "false");")
+        }
+        if let flagged = flagged {
+            updates.append("msg.flaggedStatus = \(flagged == "true" ? "true" : "false");")
+        }
+        if let junk = junk {
+            updates.append("msg.junkMailStatus = \(junk == "true" ? "true" : "false");")
+        }
+
+        guard !updates.isEmpty else {
+            throw CLIError.invalidInput("No updates specified. Use --read, --flagged, or --junk.")
+        }
+
+        let updateCode = updates.joined(separator: "\n            ")
+        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+
+        let script = """
+        \(findHelper)
+
+        const msg = findMessage();
+        if (!msg) {
+            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
+        } else {
+            \(updateCode)
+            JSON.stringify({
+                messageId: msg.messageId(),
+                subject: msg.subject(),
+                isRead: msg.readStatus(),
+                isFlagged: msg.flaggedStatus(),
+                isJunk: msg.junkMailStatus()
+            });
+        }
+        """
+
+        let raw = try runJXA(script)
+
+        if let dict = raw as? [String: Any], let error = dict["error"] as? String {
+            throw CLIError.notFound(error)
+        }
+
+        outputJSON([
+            "success": true,
+            "message": "Message updated successfully",
+            "result": raw
+        ])
+    }
+}
+
+struct MoveMessage: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "move",
+        abstract: "Move message to a different mailbox"
+    )
+
+    @Option(name: .long, help: "RFC 2822 message ID")
+    var id: String
+
+    @Option(name: .long, help: "Destination mailbox name")
+    var toMailbox: String
+
+    @Option(name: .long, help: "Destination account name (uses same account if omitted)")
+    var toAccount: String?
+
+    @Option(name: .long, help: "Source mailbox name hint (speeds up lookup)")
+    var mailbox: String?
+
+    @Option(name: .long, help: "Source account name hint (speeds up lookup)")
+    var account: String?
+
+    func run() async throws {
+        try ensureMailRunning()
+
+        let escapedMailbox = escapeForJXA(toMailbox)
+        let toAccountFilter = toAccount.map { "'\(escapeForJXA($0))'" } ?? "null"
+        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+
+        let script = """
+        \(findHelper)
+
+        const Mail = Application("Mail");
+        const destMailboxName = '\(escapedMailbox)';
+        const destAccountName = \(toAccountFilter);
+
+        function findDestMailbox(sourceAccount) {
+            const accounts = destAccountName
+                ? Mail.accounts.whose({name: destAccountName})()
+                : [sourceAccount];
+            for (let a = 0; a < accounts.length; a++) {
+                const mbs = accounts[a].mailboxes.whose({name: destMailboxName})();
+                if (mbs.length > 0) return mbs[0];
+            }
+            return null;
+        }
+
+        const msg = findMessage();
+        if (!msg) {
+            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
+        } else {
+            const sourceAccount = msg.mailbox().account();
+            const destMbox = findDestMailbox(sourceAccount);
+            if (!destMbox) {
+                JSON.stringify({error: "Destination mailbox not found: " + destMailboxName});
+            } else {
+                const fromMailbox = msg.mailbox().name();
+                Mail.move(msg, {to: destMbox});
+                JSON.stringify({
+                    messageId: '\(escapeForJXA(id))',
+                    from: fromMailbox,
+                    to: destMailboxName,
+                    moved: true
+                });
+            }
+        }
+        """
+
+        let raw = try runJXA(script)
+
+        if let dict = raw as? [String: Any], let error = dict["error"] as? String {
+            throw CLIError.notFound(error)
+        }
+
+        outputJSON([
+            "success": true,
+            "message": "Message moved successfully",
+            "result": raw
+        ])
+    }
+}
+
+struct DeleteMessage: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "Delete message (move to Trash)"
+    )
+
+    @Option(name: .long, help: "RFC 2822 message ID")
+    var id: String
+
+    @Option(name: .long, help: "Mailbox name hint (speeds up lookup)")
+    var mailbox: String?
+
+    @Option(name: .long, help: "Account name hint (speeds up lookup)")
+    var account: String?
+
+    func run() async throws {
+        try ensureMailRunning()
+
+        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+
+        let script = """
+        \(findHelper)
+
+        const Mail = Application("Mail");
+        const msg = findMessage();
+        if (!msg) {
+            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
+        } else {
+            const subject = msg.subject();
+            const mboxName = msg.mailbox().name();
+            Mail.delete(msg);
+            JSON.stringify({
+                messageId: '\(escapeForJXA(id))',
+                subject: subject,
+                fromMailbox: mboxName,
+                deleted: true
+            });
+        }
+        """
+
+        let raw = try runJXA(script)
+
+        if let dict = raw as? [String: Any], let error = dict["error"] as? String {
+            throw CLIError.notFound(error)
+        }
+
+        outputJSON([
+            "success": true,
+            "message": "Message deleted (moved to Trash)",
+            "result": raw
+        ])
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `mail-cli` Swift executable that accesses Mail.app through JXA (JavaScript for Automation) — Mail.app has no native Swift framework
- 8 new commands: `accounts`, `mailboxes`, `messages`, `get`, `search`, `update`, `move`, `delete`
- 8 new MCP tools (`mail_accounts` through `mail_delete`) in server.js
- New `/apple-pim:mail` slash command
- Updated agent, skill docs, and plugin version (1.1.0)

## Design Decisions

- **Per-message JXA access** with try/catch instead of batch `.slice()` — the latter fails with `-1700` type coercion errors on messages with null dates
- **Priority mailbox search** (INBOX, Sent, Archive, Drafts, etc.) before full-account scan for fast message lookups
- **Optional `--mailbox`/`--account` hints** on ID-based commands — when provided (from prior list/search results), lookups are instant
- **30-second timeout** on JXA execution with clear error messaging
- **Mail.app must be running** — checked via `NSWorkspace.shared.runningApplications`
- **RFC 2822 `messageId`** as stable identifier (persists across mailbox moves)

## Test plan

- [x] `swift build -c release` — all 4 CLIs compile
- [x] `mail-cli accounts` — lists accounts
- [x] `mail-cli mailboxes --account iCloud` — lists mailboxes with counts
- [x] `mail-cli messages --mailbox "Sent Messages" --limit 3` — lists messages
- [x] `mail-cli get --id <id> --mailbox "Sent Messages"` — full message with body
- [x] `mail-cli search "feedback" --limit 3` — search works
- [ ] `mail-cli update --id <id> --read true` — marks read
- [ ] `mail-cli move --id <id> --to-mailbox Archive` — moves message
- [ ] `mail-cli delete --id <id>` — moves to Trash
- [ ] Test via MCP tools in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new local email read/search/update/move/delete capabilities via Mail.app automation (JXA), which can be sensitive and error-prone due to permissions, app-running requirements, and message lookup/mutation behavior.
> 
> **Overview**
> Adds **local Mail.app support** to the `apple-pim` plugin by introducing a new Swift executable `mail-cli` (JXA/`osascript`-backed) with commands to list accounts/mailboxes/messages, fetch full message content, search, update flags, move, and delete messages.
> 
> Wires these operations into the MCP server by registering new tools (`mail_accounts`…`mail_delete`) and routing them to `mail-cli`, and adds a new `/apple-pim:mail` command plus agent/skill/plugin metadata updates (version bump to `1.1.0`) to expose Mail capabilities and usage guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee7f19e2ab692ba4cfdb807c1b14a2f4bac5e0f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->