### PR TITLE
Add multi-agent workspace isolation docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Each Swift CLI is a standalone binary that reads from macOS frameworks, validate
 ## Configuration (PIMConfig)
 
 - Config lives at `~/.config/apple-pim/config.json` (base) with optional profiles at `~/.config/apple-pim/profiles/{name}.json`.
-- **`APPLE_PIM_CONFIG_DIR`** env var overrides the config root directory. When set, all config paths (base config, profiles) resolve relative to this directory instead of `~/.config/apple-pim/`. Useful for workspace-isolated agent configs.
+- **`APPLE_PIM_CONFIG_DIR`** env var overrides the config root directory. When set, all config paths (base config, profiles) resolve relative to this directory instead of `~/.config/apple-pim/`. Useful for workspace-isolated agent configs. See [`docs/multi-agent-setup.md`](docs/multi-agent-setup.md) for the full pattern.
 - All four CLIs share the `PIMConfig` library for allowlist/blocklist filtering, domain enable/disable, and defaults.
 - Profile selection: `--profile` flag > `APPLE_PIM_PROFILE` env var > base config only.
 - **Fail-closed profiles:** If a profile is explicitly requested (via `--profile` or `APPLE_PIM_PROFILE`) but the file doesn't exist, the CLI exits with an error instead of falling back to the base config.

--- a/docs/multi-agent-setup.md
+++ b/docs/multi-agent-setup.md
@@ -1,0 +1,85 @@
+# Multi-Agent Workspace Isolation
+
+Give each agent its own base config by setting `APPLE_PIM_CONFIG_DIR`. Each agent gets independent access control without needing profiles — just a separate `config.json` per workspace.
+
+## How It Works
+
+The PIM CLIs resolve their config directory in this order:
+
+1. **`APPLE_PIM_CONFIG_DIR` env var** (if set) — CLIs read `$APPLE_PIM_CONFIG_DIR/config.json`
+2. **Default** — CLIs read `~/.config/apple-pim/config.json`
+
+This overrides the **base config**, not a profile. Profiles are a separate, optional layer on top (see [Configuration in CLAUDE.md](../CLAUDE.md#configuration-pimconfig)).
+
+```
+Default:                ~/.config/apple-pim/config.json
+With env var override:  $APPLE_PIM_CONFIG_DIR/config.json
+```
+
+## Directory Layout
+
+A typical multi-agent workspace looks like this:
+
+```
+~/agents/
+├── agent-a/
+│   ├── apple-pim/
+│   │   └── config.json          # agent-a's base config
+│   └── bin/
+│       ├── calendar-cli          # wrapper script
+│       ├── reminder-cli
+│       └── contacts-cli
+├── agent-b/
+│   ├── apple-pim/
+│   │   └── config.json          # agent-b's base config (different access)
+│   └── bin/
+│       ├── calendar-cli
+│       ├── reminder-cli
+│       └── contacts-cli
+```
+
+## Wrapper Script Template
+
+Each wrapper sets the env var and delegates to the real CLI:
+
+```bash
+#!/bin/bash
+export APPLE_PIM_CONFIG_DIR="$(dirname "$0")/../apple-pim"
+exec ~/GitHub/Apple-PIM-Agent-Plugin/swift/.build/release/calendar-cli "$@"
+```
+
+Create one per CLI (`calendar-cli`, `reminder-cli`, `contacts-cli`), replacing the binary name in the `exec` line.
+
+## Config Examples
+
+**Full access** (`config.json` — agent can see everything):
+
+```json
+{
+  "calendars": { "mode": "all" },
+  "reminders": { "mode": "all" },
+  "contacts": { "mode": "all" }
+}
+```
+
+**Restricted** (`config.json` — agent blocked from specific calendars):
+
+```json
+{
+  "calendars": {
+    "mode": "blocklist",
+    "blocked": ["Private", "Family"]
+  },
+  "reminders": { "mode": "all" },
+  "contacts": {
+    "mode": "allowlist",
+    "allowed": ["Work"]
+  },
+  "defaultCalendar": "Work",
+  "defaultReminderList": "Tasks"
+}
+```
+
+## Common Mistake
+
+> **This uses base configs, not profiles.** There is no `profiles/` directory involved in workspace isolation. Each agent's `APPLE_PIM_CONFIG_DIR` points to a directory containing a plain `config.json` — that's the base config for that agent. Profiles (`~/.config/apple-pim/profiles/*.json`) are a separate optional feature for switching access within a single config root.


### PR DESCRIPTION
## Summary

- Adds `docs/multi-agent-setup.md` explaining the `APPLE_PIM_CONFIG_DIR` workspace isolation pattern: directory layout, wrapper script template, config examples, and a common-mistake callout clarifying that this uses base configs (not profiles)
- Adds a pointer from CLAUDE.md's Configuration section to the new doc

## Context

An agent got confused about how PIM config works in the workspace isolation setup — it saw `APPLE_PIM_CONFIG_DIR` referenced and went looking for a `profiles/` directory, not understanding that workspace isolation uses isolated base configs (not profiles). The existing docs didn't bridge the gap.

## Test plan

- [ ] Read `docs/multi-agent-setup.md` end-to-end and confirm it answers "where are the profiles?"
- [ ] Verify CLAUDE.md link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)