### PR TITLE
feat: add attendee write support for calendar events

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -56,6 +56,10 @@ export const tools = [
         allDay: { type: "boolean", description: "All-day event" },
         alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before event" },
         url: { type: "string", description: "URL" },
+        attendees: {
+          type: "string",
+          description: "JSON array of attendees for create/update: [{\"email\":\"a@b.com\",\"name\":\"Name\",\"role\":\"required|optional\"}]",
+        },
         recurrence: recurrenceSchema,
         futureEvents: { type: "boolean", description: "Apply to future occurrences (update/delete recurring)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only — ignored by MCP server)" },
@@ -76,6 +80,19 @@ export const tools = [
               url: { type: "string" },
               allDay: { type: "boolean" },
               alarm: { type: "array", items: { type: "number" } },
+              attendees: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    email: { type: "string" },
+                    name: { type: "string" },
+                    role: { type: "string", description: "required, optional, chair, or nonParticipant" },
+                  },
+                  required: ["email"],
+                },
+                description: "Event attendees (batch_create)",
+              },
               recurrence: recurrenceSchema,
             },
             required: ["title", "start"],

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -57,8 +57,17 @@ export const tools = [
         alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before event" },
         url: { type: "string", description: "URL" },
         attendees: {
-          type: "string",
-          description: "JSON array of attendees for create/update: [{\"email\":\"a@b.com\",\"name\":\"Name\",\"role\":\"required|optional\"}]",
+          type: "array",
+          description: "Event attendees (create/update). Replaces all existing attendees on update.",
+          items: {
+            type: "object",
+            properties: {
+              email: { type: "string", description: "Email address (required)" },
+              name: { type: "string", description: "Display name" },
+              role: { type: "string", description: "required, optional, chair, or nonParticipant" },
+            },
+            required: ["email"],
+          },
         },
         recurrence: recurrenceSchema,
         futureEvents: { type: "boolean", description: "Apply to future occurrences (update/delete recurring)" },

--- a/lib/tool-args.js
+++ b/lib/tool-args.js
@@ -22,7 +22,7 @@ export function buildCalendarCreateArgs(args, targetCalendar) {
     cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
   }
   if (args.attendees) {
-    cliArgs.push("--attendees", args.attendees);
+    cliArgs.push("--attendees", JSON.stringify(args.attendees));
   }
   return cliArgs;
 }
@@ -36,7 +36,7 @@ export function buildCalendarUpdateArgs(args) {
   if (args.notes) cliArgs.push("--notes", args.notes);
   if (args.url) cliArgs.push("--url", args.url);
   if (args.recurrence) cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
-  if (args.attendees) cliArgs.push("--attendees", args.attendees);
+  if (args.attendees) cliArgs.push("--attendees", JSON.stringify(args.attendees));
   if (args.futureEvents) cliArgs.push("--future-events");
   return cliArgs;
 }

--- a/lib/tool-args.js
+++ b/lib/tool-args.js
@@ -21,6 +21,9 @@ export function buildCalendarCreateArgs(args, targetCalendar) {
   if (args.recurrence) {
     cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
   }
+  if (args.attendees) {
+    cliArgs.push("--attendees", args.attendees);
+  }
   return cliArgs;
 }
 
@@ -33,6 +36,7 @@ export function buildCalendarUpdateArgs(args) {
   if (args.notes) cliArgs.push("--notes", args.notes);
   if (args.url) cliArgs.push("--url", args.url);
   if (args.recurrence) cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
+  if (args.attendees) cliArgs.push("--attendees", args.attendees);
   if (args.futureEvents) cliArgs.push("--future-events");
   return cliArgs;
 }

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -292,6 +292,17 @@ func addAttendeesToEvent(_ event: EKEvent, attendees attendeeInputs: [AttendeeJS
     try setAttendeesOnEvent(event, attendees: attendeeInputs)
 }
 
+/// Safely set a value via KVC, checking that the setter exists first.
+/// Returns true if the setter was found and called, false otherwise.
+/// This avoids uncatchable NSException crashes from setValue:forUndefinedKey:.
+@discardableResult
+private func safeSetValue(_ object: NSObject, _ value: Any?, forKey key: String) -> Bool {
+    let setter = NSSelectorFromString("set\(key.prefix(1).uppercased())\(key.dropFirst()):")
+    guard object.responds(to: setter) else { return false }
+    object.setValue(value, forKey: key)
+    return true
+}
+
 private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [AttendeeJSON]) throws {
     guard let ekAttendeeClass = NSClassFromString("EKAttendee") as? NSObject.Type else {
         throw CLIError.invalidInput(
@@ -300,21 +311,29 @@ private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [At
         )
     }
 
+    // Verify required KVC keys are available on this macOS version
+    let probe = ekAttendeeClass.init()
+    guard probe.responds(to: NSSelectorFromString("setEmailAddress:")) else {
+        throw CLIError.invalidInput(
+            "EKAttendee on this macOS version does not support setEmailAddress:. " +
+            "Attendee write support is not available."
+        )
+    }
+
     var attendeeObjects: [NSObject] = []
 
     for input in attendeeInputs {
         let attendee = ekAttendeeClass.init()
 
-        // Set email via emailAddress property (KVC)
-        attendee.setValue(input.email, forKey: "emailAddress")
+        safeSetValue(attendee, input.email, forKey: "emailAddress")
 
         // Set display name if provided (EKParticipant exposes firstName/lastName as
         // settable properties; the read-only "name" property returns them combined)
         if let name = input.name {
             let parts = name.split(separator: " ", maxSplits: 1)
-            attendee.setValue(String(parts[0]), forKey: "firstName")
+            safeSetValue(attendee, String(parts[0]), forKey: "firstName")
             if parts.count > 1 {
-                attendee.setValue(String(parts[1]), forKey: "lastName")
+                safeSetValue(attendee, String(parts[1]), forKey: "lastName")
             }
         }
 
@@ -330,12 +349,12 @@ private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [At
         default:
             role = EKParticipantRole.required.rawValue
         }
-        attendee.setValue(role, forKey: "participantRole")
+        safeSetValue(attendee, role, forKey: "participantRole")
 
         attendeeObjects.append(attendee)
     }
 
-    // Set attendees on the event via KVC
+    // Set attendees on the event via KVC (replaces any existing attendees)
     event.setValue(attendeeObjects, forKey: "attendees")
 }
 
@@ -803,7 +822,7 @@ struct UpdateEvent: AsyncParsableCommand {
     @Option(name: .long, help: "Recurrence rule as JSON (e.g., '{\"frequency\":\"weekly\",\"interval\":1}')")
     var recurrence: String?
 
-    @Option(name: .long, help: "Attendees as JSON array (e.g., '[{\"email\":\"a@b.com\",\"name\":\"Name\"}]')")
+    @Option(name: .long, help: "Attendees as JSON array (replaces all existing attendees)")
     var attendees: String?
 
     @Flag(name: .long, help: "Apply changes to all future events in a recurring series")

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -278,6 +278,62 @@ func participantRoleString(_ role: EKParticipantRole) -> String {
     }
 }
 
+// MARK: - Attendee Write Support (Private API)
+
+func addAttendeesToEvent(_ event: EKEvent, json: String) throws {
+    guard let data = json.data(using: .utf8) else {
+        throw CLIError.invalidInput("Invalid attendees JSON encoding")
+    }
+    let attendeeInputs = try JSONDecoder().decode([AttendeeJSON].self, from: data)
+    try setAttendeesOnEvent(event, attendees: attendeeInputs)
+}
+
+func addAttendeesToEvent(_ event: EKEvent, attendees attendeeInputs: [AttendeeJSON]) throws {
+    try setAttendeesOnEvent(event, attendees: attendeeInputs)
+}
+
+private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [AttendeeJSON]) throws {
+    guard let ekAttendeeClass = NSClassFromString("EKAttendee") as? NSObject.Type else {
+        throw CLIError.invalidInput(
+            "EKAttendee class not available on this macOS version. " +
+            "Attendee write support requires the private EKAttendee class."
+        )
+    }
+
+    var attendeeObjects: [NSObject] = []
+
+    for input in attendeeInputs {
+        let attendee = ekAttendeeClass.init()
+
+        // Set email via emailAddress property (KVC)
+        attendee.setValue(input.email, forKey: "emailAddress")
+
+        // Set display name if provided
+        if let name = input.name {
+            attendee.setValue(name, forKey: "commonName")
+        }
+
+        // Set participant role (default: required)
+        let role: Int
+        switch input.role?.lowercased() {
+        case "optional":
+            role = EKParticipantRole.optional.rawValue
+        case "chair":
+            role = EKParticipantRole.chair.rawValue
+        case "nonparticipant":
+            role = EKParticipantRole.nonParticipant.rawValue
+        default:
+            role = EKParticipantRole.required.rawValue
+        }
+        attendee.setValue(role, forKey: "participantRole")
+
+        attendeeObjects.append(attendee)
+    }
+
+    // Set attendees on the event via KVC
+    event.setValue(attendeeObjects, forKey: "attendees")
+}
+
 // MARK: - Config Helpers
 
 /// Get only the calendars allowed by the current PIM config.
@@ -644,6 +700,9 @@ struct CreateEvent: AsyncParsableCommand {
     @Option(name: .long, help: "Recurrence rule as JSON (e.g., '{\"frequency\":\"weekly\",\"interval\":1}')")
     var recurrence: String?
 
+    @Option(name: .long, help: "Attendees as JSON array (e.g., '[{\"email\":\"a@b.com\",\"name\":\"Name\"}]')")
+    var attendees: String?
+
     func run() async throws {
         try await requestCalendarAccess()
 
@@ -692,6 +751,11 @@ struct CreateEvent: AsyncParsableCommand {
             event.addRecurrenceRule(rule)
         }
 
+        // Add attendees if specified
+        if let attendeesJSON = attendees {
+            try addAttendeesToEvent(event, json: attendeesJSON)
+        }
+
         try eventStore.save(event, span: .thisEvent)
 
         outputJSON([
@@ -733,6 +797,9 @@ struct UpdateEvent: AsyncParsableCommand {
 
     @Option(name: .long, help: "Recurrence rule as JSON (e.g., '{\"frequency\":\"weekly\",\"interval\":1}')")
     var recurrence: String?
+
+    @Option(name: .long, help: "Attendees as JSON array (e.g., '[{\"email\":\"a@b.com\",\"name\":\"Name\"}]')")
+    var attendees: String?
 
     @Flag(name: .long, help: "Apply changes to all future events in a recurring series")
     var futureEvents: Bool = false
@@ -787,6 +854,11 @@ struct UpdateEvent: AsyncParsableCommand {
             }
         }
 
+        // Update attendees if specified
+        if let attendeesJSON = attendees {
+            try addAttendeesToEvent(event, json: attendeesJSON)
+        }
+
         // Only use futureEvents span when explicitly requested by user
         let span: EKSpan = futureEvents ? .futureEvents : .thisEvent
         try eventStore.save(event, span: span)
@@ -838,6 +910,12 @@ struct DeleteEvent: AsyncParsableCommand {
 
 // MARK: - Batch Operations
 
+struct AttendeeJSON: Codable {
+    let email: String
+    let name: String?
+    let role: String?
+}
+
 struct BatchEventInput: Codable {
     let title: String
     let start: String
@@ -850,6 +928,7 @@ struct BatchEventInput: Codable {
     let allDay: Bool?
     let alarm: [Int]?
     let recurrence: RecurrenceJSON?
+    let attendees: [AttendeeJSON]?
 }
 
 func decodeBatchEvents(_ json: String) throws -> [BatchEventInput] {
@@ -942,6 +1021,11 @@ struct BatchCreateEvent: AsyncParsableCommand {
                        let rule = parseRecurrenceRule(recurrenceStr) {
                         event.addRecurrenceRule(rule)
                     }
+                }
+
+                // Add attendees if specified
+                if let attendeeInputs = eventInput.attendees {
+                    try addAttendeesToEvent(event, attendees: attendeeInputs)
                 }
 
                 // Save with commit: false to batch changes

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -325,6 +325,9 @@ private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [At
     for input in attendeeInputs {
         let attendee = ekAttendeeClass.init()
 
+        // UUID is required — EventKit's _addNewAttendeesToRecentsIfNeeded
+        // uses it as a dictionary key and crashes with nil if missing
+        safeSetValue(attendee, UUID().uuidString, forKey: "UUID")
         safeSetValue(attendee, input.email, forKey: "emailAddress")
 
         // Set display name if provided (EKParticipant exposes firstName/lastName as

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -308,9 +308,14 @@ private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [At
         // Set email via emailAddress property (KVC)
         attendee.setValue(input.email, forKey: "emailAddress")
 
-        // Set display name if provided
+        // Set display name if provided (EKParticipant exposes firstName/lastName as
+        // settable properties; the read-only "name" property returns them combined)
         if let name = input.name {
-            attendee.setValue(name, forKey: "commonName")
+            let parts = name.split(separator: " ", maxSplits: 1)
+            attendee.setValue(String(parts[0]), forKey: "firstName")
+            if parts.count > 1 {
+                attendee.setValue(String(parts[1]), forKey: "lastName")
+            }
         }
 
         // Set participant role (default: required)


### PR DESCRIPTION
## Summary

- Adds `--attendees` flag to `calendar-cli create`, `update`, and `batch-create` commands
- Uses the private `EKAttendee` class (stable 13+ years, used by Fantastical/BusyCal) to set attendees via KVC on `EKEvent`
- When attendees are added to events on CalDAV-backed calendars (e.g. Google Calendar), the server handles sending invitation emails

## Implementation Details

### Private API safety
- `NSClassFromString("EKAttendee")` guard: throws descriptive error if class unavailable
- `safeSetValue()` helper: checks `responds(to:)` for the KVC setter before calling `setValue:forKey:`, preventing uncatchable `NSException` crashes from undefined keys
- UUID generation: EventKit's internal `_addNewAttendeesToRecentsIfNeeded` requires a non-nil UUID on each attendee — we generate one per attendee

### KVC keys used
- `emailAddress` — email (required)
- `firstName` / `lastName` — display name (the read-only `name` property returns them combined)
- `participantRole` — role enum value
- `UUID` — required by EventKit internals during save

### Schema consistency
- `attendees` is `type: "array"` of `{email, name?, role?}` objects everywhere (create, update, batch_create)
- `tool-args.js` applies `JSON.stringify` before passing to CLI, matching the `recurrence` pattern
- No `oneOf`/`anyOf` — safe for OpenClaw's schema normalizer

### Update behavior
- `--attendees` on update **replaces** all existing attendees (documented in help text and schema description)

## Changes

| File | Change |
|------|--------|
| `CalendarCLI.swift` | `AttendeeJSON` struct, `safeSetValue()` helper, `setAttendeesOnEvent()`, wired into create/update/batch-create |
| `lib/schemas.js` | `attendees` array property on calendar tool and batch_create items |
| `lib/tool-args.js` | `--attendees` flag with `JSON.stringify` in create and update builders |

## Test plan

- [x] `swift build -c release` succeeds
- [x] `calendar-cli create --help` / `update --help` show `--attendees` flag
- [x] JS schema imports without errors, no `oneOf`/`anyOf` in calendar tool
- [x] `buildCalendarCreateArgs()` / `buildCalendarUpdateArgs()` stringify attendees correctly
- [x] `safeSetValue()` rejects invalid KVC keys (`commonName`, `name`) without crashing
- [x] End-to-end: event created with attendee via OpenClaw agent, attendee visible in Calendar.app
- [x] Google Calendar sends invitation email to attendee via CalDAV

🤖 Generated with [Claude Code](https://claude.com/claude-code)