### PR TITLE
feat: add mail attachment receive support (metadata, save-to-disk)

### DIFF
--- a/evals/fixtures/mail/get-with-attachments.json
+++ b/evals/fixtures/mail/get-with-attachments.json
@@ -1,0 +1,43 @@
+{
+  "success": true,
+  "message": {
+    "messageId": "msg-att@example.com",
+    "subject": "Q1 Report with Attachments",
+    "sender": "colleague@example.com",
+    "dateReceived": "2026-03-15T14:30:00-07:00",
+    "dateSent": "2026-03-15T14:29:45-07:00",
+    "isRead": true,
+    "isFlagged": false,
+    "isJunk": false,
+    "replyTo": "",
+    "mailbox": "INBOX",
+    "account": "Google",
+    "content": "Hi, please find the Q1 report and supporting data attached.",
+    "to": [{ "name": "Joe", "address": "joe@example.com" }],
+    "cc": [],
+    "attachments": [
+      {
+        "index": 0,
+        "name": "q1-report.pdf",
+        "fileSize": 245760,
+        "downloaded": true,
+        "mimeType": "application/pdf"
+      },
+      {
+        "index": 1,
+        "name": "data.xlsx",
+        "fileSize": 51200,
+        "downloaded": true,
+        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      },
+      {
+        "index": 2,
+        "name": "notes.md",
+        "fileSize": 1024,
+        "downloaded": true,
+        "mimeType": "text/markdown"
+      }
+    ],
+    "attachmentCount": 3
+  }
+}

--- a/evals/scenarios/safety.yaml
+++ b/evals/scenarios/safety.yaml
@@ -70,7 +70,7 @@ id_required_actions:
     error_pattern: "ID is required"
 
   - tool: mail
-    actions: [get, update, move, delete, reply, auth_check]
+    actions: [get, update, move, delete, reply, save_attachment, auth_check]
     error_pattern: "ID is required"
 
 # Actions that delegate to buildArgs without ID validation (schema-enforced only):

--- a/evals/tests/safety.test.js
+++ b/evals/tests/safety.test.js
@@ -137,7 +137,7 @@ describe("Category 4: Safety Properties", () => {
       const covered = new Set([
         "accounts", "mailboxes", "messages", "get", "search",
         "update", "move", "delete", "batch_update", "batch_delete",
-        "send", "reply", "auth_check", "schema",
+        "send", "reply", "save_attachment", "auth_check", "schema",
       ]);
       for (const action of actions) {
         expect(covered.has(action)).toBe(true);
@@ -177,6 +177,7 @@ describe("Category 4: Safety Properties", () => {
       expect(isMutation("mail", "batch_delete")).toBe(true);
       expect(isMutation("mail", "send")).toBe(true);
       expect(isMutation("mail", "reply")).toBe(true);
+      expect(isMutation("mail", "save_attachment")).toBe(true);
       expect(isMutation("mail", "accounts")).toBe(false);
       expect(isMutation("mail", "messages")).toBe(false);
     });

--- a/evals/tests/tool-call-correctness.test.js
+++ b/evals/tests/tool-call-correctness.test.js
@@ -286,6 +286,40 @@ describe("Category 1: Tool Call Correctness", () => {
       await expect(handleMail({ action: "search" }, mockCLI))
         .rejects.toThrow("query");
     });
+
+    it("mail save_attachment throws without id", async () => {
+      const mockCLI = createMockCLI({});
+      await expect(handleMail({ action: "save_attachment" }, mockCLI))
+        .rejects.toThrow("Message ID is required");
+    });
+  });
+
+  describe("save_attachment argument construction", () => {
+    it("passes --index when index is provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:save-attachment": { success: true, saved: [] } });
+      await handleMail({ action: "save_attachment", id: "msg_1", index: 2 }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(callArgs).toContain("save-attachment");
+      expect(argsPairPresent(callArgs, "--id", "msg_1")).toBe(true);
+      expect(argsPairPresent(callArgs, "--index", "2")).toBe(true);
+    });
+
+    it("passes --dest-dir when destDir is provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:save-attachment": { success: true, saved: [] } });
+      await handleMail({ action: "save_attachment", id: "msg_1", destDir: "/tmp/test" }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(argsPairPresent(callArgs, "--dest-dir", "/tmp/test")).toBe(true);
+    });
+
+    it("omits --index when index is not provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:save-attachment": { success: true, saved: [] } });
+      await handleMail({ action: "save_attachment", id: "msg_1" }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(callArgs).not.toContain("--index");
+    });
   });
 
   describe("batch operation validation", () => {

--- a/lib/dry-run.js
+++ b/lib/dry-run.js
@@ -27,6 +27,7 @@ const MUTATION_ACTIONS = {
     "batch_delete",
     "send",
     "reply",
+    "save_attachment",
   ]),
 };
 
@@ -95,6 +96,8 @@ function describeMutation(tool, action, params) {
       return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"`;
     case "reply":
       return `Would reply to message ${params.id || "?"}`;
+    case "save_attachment":
+      return `Would save ${params.index !== undefined ? `attachment #${params.index}` : "all attachments"} from message ${params.id || "?"} to ${params.destDir || "temp directory"}`;
     default:
       return `Would perform ${action} on ${tool}`;
   }

--- a/lib/handlers/mail.js
+++ b/lib/handlers/mail.js
@@ -125,6 +125,16 @@ export async function handleMail(args, runCLI) {
       return await runCLI("mail-cli", replyArgs);
     }
 
+    case "save_attachment": {
+      if (!args.id) throw new Error("Message ID is required for save_attachment");
+      const saveArgs = ["save-attachment", "--id", args.id];
+      if (args.index !== undefined) saveArgs.push("--index", String(args.index));
+      if (args.destDir) saveArgs.push("--dest-dir", args.destDir);
+      if (args.mailbox) saveArgs.push("--mailbox", args.mailbox);
+      if (args.account) saveArgs.push("--account", args.account);
+      return await runCLI("mail-cli", saveArgs);
+    }
+
     case "auth_check": {
       if (!args.id) throw new Error("Message ID is required for auth_check");
       const authArgs = ["auth-check", "--id", args.id];

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -332,7 +332,7 @@ export const tools = [
   {
     name: "mail",
     description:
-      "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list), get (full message by ID), search, update (flags), move, delete, batch_update, batch_delete, send, reply, auth_check, schema (show input schema).",
+      "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list with attachmentCount), get (full message by ID with attachment metadata), search, update (flags), move, delete, batch_update, batch_delete, send, reply, save_attachment (save message attachments to disk), auth_check, schema (show input schema).",
     inputSchema: {
       type: "object",
       properties: {
@@ -341,13 +341,13 @@ export const tools = [
           enum: [
             "accounts", "mailboxes", "messages", "get", "search",
             "update", "move", "delete", "batch_update", "batch_delete",
-            "send", "reply", "auth_check",
+            "send", "reply", "save_attachment", "auth_check",
             "schema",
           ],
           description: "Operation to perform",
         },
         ...agentDXProperties,
-        id: { type: "string", description: "RFC 2822 message ID (get/update/move/delete/reply/auth_check)" },
+        id: { type: "string", description: "RFC 2822 message ID (get/update/move/delete/reply/save_attachment/auth_check)" },
         ids: { type: "array", items: { type: "string" }, description: "Message IDs (batch_update/batch_delete)" },
         account: { type: "string", description: "Account name" },
         mailbox: { type: "string", description: "Mailbox name" },
@@ -379,6 +379,8 @@ export const tools = [
         cc: { type: "array", items: { type: "string" }, description: "CC addresses (send)" },
         bcc: { type: "array", items: { type: "string" }, description: "BCC addresses (send)" },
         from: { type: "string", description: "Sender email address for account selection (send)" },
+        index: { type: "integer", minimum: 0, description: "Zero-based attachment index (save_attachment). Omit to save all attachments." },
+        destDir: { type: "string", description: "Directory to save attachments into (save_attachment). Defaults to system temp." },
         trustedSenders: { type: "string", description: "Path to trusted-senders.json (auth_check)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only — ignored by MCP server)" },
         profile: { type: "string", description: "Override PIM profile name (OpenClaw only — MCP server uses APPLE_PIM_PROFILE env)" },

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -4745,6 +4745,7 @@ var require_pattern = __commonJS({
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
+    var util_1 = require_util();
     var codegen_1 = require_codegen();
     var error2 = {
       message: ({ schemaCode }) => (0, codegen_1.str)`must match pattern "${schemaCode}"`,
@@ -4757,10 +4758,18 @@ var require_pattern = __commonJS({
       $data: true,
       error: error2,
       code(cxt) {
-        const { data, $data, schema, schemaCode, it } = cxt;
+        const { gen, data, $data, schema, schemaCode, it } = cxt;
         const u = it.opts.unicodeRegExp ? "u" : "";
-        const regExp = $data ? (0, codegen_1._)`(new RegExp(${schemaCode}, ${u}))` : (0, code_1.usePattern)(cxt, schema);
-        cxt.fail$data((0, codegen_1._)`!${regExp}.test(${data})`);
+        if ($data) {
+          const { regExp } = it.opts.code;
+          const regExpCode = regExp.code === "new RegExp" ? (0, codegen_1._)`new RegExp` : (0, util_1.useFunc)(gen, regExp);
+          const valid = gen.let("valid");
+          gen.try(() => gen.assign(valid, (0, codegen_1._)`${regExpCode}(${schemaCode}, ${u}).test(${data})`), () => gen.assign(valid, false));
+          cxt.fail$data((0, codegen_1._)`!${valid}`);
+        } else {
+          const regExp = (0, code_1.usePattern)(cxt, schema);
+          cxt.fail$data((0, codegen_1._)`!${regExp}.test(${data})`);
+        }
       }
     };
     exports.default = def;
@@ -31739,6 +31748,14 @@ var require_addressparser = __commonJS({
           parsedAddresses = parsedAddresses.concat(address2);
         }
       });
+      for (let i = parsedAddresses.length - 2; i >= 0; i--) {
+        let current = parsedAddresses[i];
+        let next = parsedAddresses[i + 1];
+        if (current.address === "" && current.name && !current.group && next.address && next.name && !next.group) {
+          next.name = current.name + ", " + next.name;
+          parsedAddresses.splice(i, 1);
+        }
+      }
       if (options.flatten) {
         let addresses2 = [];
         let walkAddressList = (list) => {
@@ -44921,7 +44938,7 @@ var require_mail_parser = __commonJS({
                 value = this.libmime.decodeWords(value);
               } catch (E) {
               }
-              value = value.split(/\s+/).map(this.ensureMessageIDFormat);
+              value = value.split(/\s+/).map(this.ensureMessageIDFormat).filter((val) => val);
               break;
             case "message-id":
             case "in-reply-to":
@@ -45078,21 +45095,39 @@ var require_mail_parser = __commonJS({
           let address = addresses[i];
           address.name = (address.name || "").toString().trim();
           if (!address.address && /^(=\?([^?]+)\?[Bb]\?[^?]*\?=)(\s*=\?([^?]+)\?[Bb]\?[^?]*\?=)*$/.test(address.name) && !processedAddress.has(address)) {
-            let parsed = addressparser(this.libmime.decodeWords(address.name));
-            if (parsed.length) {
-              parsed.forEach((entry) => {
-                processedAddress.add(entry);
-                addresses.push(entry);
-              });
+            let decoded = this.libmime.decodeWords(address.name);
+            if (/<[^<>]+@[^<>]+>/.test(decoded)) {
+              let parsed = addressparser(decoded);
+              if (parsed.length) {
+                parsed.forEach((entry) => {
+                  processedAddress.add(entry);
+                  addresses.push(entry);
+                });
+              }
+              addresses.splice(i, 1);
+              i--;
+              continue;
+            } else {
+              address.name = decoded;
+              continue;
             }
-            addresses.splice(i, 1);
-            i--;
-            continue;
           }
           if (address.name) {
             try {
               address.name = this.libmime.decodeWords(address.name);
             } catch (E) {
+            }
+          }
+          if (address.address && /[=]\?[^?]+\?[BbQq]\?[^?]*\?[=]/.test(address.address)) {
+            try {
+              let decodedAddr = this.libmime.decodeWords(address.address);
+              if (/^[^\s@]+@[^\s@]+$/.test(decodedAddr) && !/[=]\?/.test(decodedAddr)) {
+                address.address = decodedAddr;
+              } else {
+                address.address = "";
+              }
+            } catch (E) {
+              address.address = "";
             }
           }
           if (/@xn--/.test(address.address)) {
@@ -68779,7 +68814,7 @@ var Doc = class {
 var version = {
   major: 4,
   minor: 3,
-  patch: 5
+  patch: 6
 };
 
 // node_modules/zod/v4/core/schemas.js
@@ -70070,7 +70105,7 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
         if (keyResult instanceof Promise) {
           throw new Error("Async schemas not supported in object keys currently");
         }
-        const checkNumericKey = typeof key === "string" && number.test(key) && keyResult.issues.length && keyResult.issues.some((iss) => iss.code === "invalid_type" && iss.expected === "number");
+        const checkNumericKey = typeof key === "string" && number.test(key) && keyResult.issues.length;
         if (checkNumericKey) {
           const retryResult = def.keyType._zod.run({ value: Number(key), issues: [] }, ctx);
           if (retryResult instanceof Promise) {
@@ -71915,7 +71950,7 @@ function finalize(ctx, schema) {
           }
         }
       }
-      if (refSchema.$ref) {
+      if (refSchema.$ref && refSeen.def) {
         for (const key in schema2) {
           if (key === "$ref" || key === "allOf")
             continue;
@@ -75714,6 +75749,9 @@ var Protocol = class {
    * The Protocol object assumes ownership of the Transport, replacing any callbacks that have already been set, and expects that it is the only user of the Transport instance going forward.
    */
   async connect(transport2) {
+    if (this._transport) {
+      throw new Error("Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.");
+    }
     this._transport = transport2;
     const _onclose = this.transport?.onclose;
     this._transport.onclose = () => {
@@ -75746,6 +75784,10 @@ var Protocol = class {
     this._progressHandlers.clear();
     this._taskProgressTokens.clear();
     this._pendingDebouncedNotifications.clear();
+    for (const controller of this._requestHandlerAbortControllers.values()) {
+      controller.abort();
+    }
+    this._requestHandlerAbortControllers.clear();
     const error2 = McpError.fromError(ErrorCode.ConnectionClosed, "Connection closed");
     this._transport = void 0;
     this.onclose?.();
@@ -75796,6 +75838,8 @@ var Protocol = class {
       sessionId: capturedTransport?.sessionId,
       _meta: request.params?._meta,
       sendNotification: async (notification) => {
+        if (abortController.signal.aborted)
+          return;
         const notificationOptions = { relatedRequestId: request.id };
         if (relatedTaskId) {
           notificationOptions.relatedTask = { taskId: relatedTaskId };
@@ -75803,6 +75847,9 @@ var Protocol = class {
         await this.notification(notification, notificationOptions);
       },
       sendRequest: async (r, resultSchema, options) => {
+        if (abortController.signal.aborted) {
+          throw new McpError(ErrorCode.ConnectionClosed, "Request was cancelled");
+        }
         const requestOptions = { ...options, relatedRequestId: request.id };
         if (relatedTaskId && !requestOptions.relatedTask) {
           requestOptions.relatedTask = { taskId: relatedTaskId };
@@ -76562,6 +76609,147 @@ var ExperimentalServerTasks = class {
    */
   requestStream(request, resultSchema, options) {
     return this._server.requestStream(request, resultSchema, options);
+  }
+  /**
+   * Sends a sampling request and returns an AsyncGenerator that yields response messages.
+   * The generator is guaranteed to end with either a 'result' or 'error' message.
+   *
+   * For task-augmented requests, yields 'taskCreated' and 'taskStatus' messages
+   * before the final result.
+   *
+   * @example
+   * ```typescript
+   * const stream = server.experimental.tasks.createMessageStream({
+   *     messages: [{ role: 'user', content: { type: 'text', text: 'Hello' } }],
+   *     maxTokens: 100
+   * }, {
+   *     onprogress: (progress) => {
+   *         // Handle streaming tokens via progress notifications
+   *         console.log('Progress:', progress.message);
+   *     }
+   * });
+   *
+   * for await (const message of stream) {
+   *     switch (message.type) {
+   *         case 'taskCreated':
+   *             console.log('Task created:', message.task.taskId);
+   *             break;
+   *         case 'taskStatus':
+   *             console.log('Task status:', message.task.status);
+   *             break;
+   *         case 'result':
+   *             console.log('Final result:', message.result);
+   *             break;
+   *         case 'error':
+   *             console.error('Error:', message.error);
+   *             break;
+   *     }
+   * }
+   * ```
+   *
+   * @param params - The sampling request parameters
+   * @param options - Optional request options (timeout, signal, task creation params, onprogress, etc.)
+   * @returns AsyncGenerator that yields ResponseMessage objects
+   *
+   * @experimental
+   */
+  createMessageStream(params, options) {
+    const clientCapabilities = this._server.getClientCapabilities();
+    if ((params.tools || params.toolChoice) && !clientCapabilities?.sampling?.tools) {
+      throw new Error("Client does not support sampling tools capability.");
+    }
+    if (params.messages.length > 0) {
+      const lastMessage = params.messages[params.messages.length - 1];
+      const lastContent = Array.isArray(lastMessage.content) ? lastMessage.content : [lastMessage.content];
+      const hasToolResults = lastContent.some((c) => c.type === "tool_result");
+      const previousMessage = params.messages.length > 1 ? params.messages[params.messages.length - 2] : void 0;
+      const previousContent = previousMessage ? Array.isArray(previousMessage.content) ? previousMessage.content : [previousMessage.content] : [];
+      const hasPreviousToolUse = previousContent.some((c) => c.type === "tool_use");
+      if (hasToolResults) {
+        if (lastContent.some((c) => c.type !== "tool_result")) {
+          throw new Error("The last message must contain only tool_result content if any is present");
+        }
+        if (!hasPreviousToolUse) {
+          throw new Error("tool_result blocks are not matching any tool_use from the previous message");
+        }
+      }
+      if (hasPreviousToolUse) {
+        const toolUseIds = new Set(previousContent.filter((c) => c.type === "tool_use").map((c) => c.id));
+        const toolResultIds = new Set(lastContent.filter((c) => c.type === "tool_result").map((c) => c.toolUseId));
+        if (toolUseIds.size !== toolResultIds.size || ![...toolUseIds].every((id) => toolResultIds.has(id))) {
+          throw new Error("ids of tool_result blocks and tool_use blocks from previous message do not match");
+        }
+      }
+    }
+    return this.requestStream({
+      method: "sampling/createMessage",
+      params
+    }, CreateMessageResultSchema, options);
+  }
+  /**
+   * Sends an elicitation request and returns an AsyncGenerator that yields response messages.
+   * The generator is guaranteed to end with either a 'result' or 'error' message.
+   *
+   * For task-augmented requests (especially URL-based elicitation), yields 'taskCreated'
+   * and 'taskStatus' messages before the final result.
+   *
+   * @example
+   * ```typescript
+   * const stream = server.experimental.tasks.elicitInputStream({
+   *     mode: 'url',
+   *     message: 'Please authenticate',
+   *     elicitationId: 'auth-123',
+   *     url: 'https://example.com/auth'
+   * }, {
+   *     task: { ttl: 300000 } // Task-augmented for long-running auth flow
+   * });
+   *
+   * for await (const message of stream) {
+   *     switch (message.type) {
+   *         case 'taskCreated':
+   *             console.log('Task created:', message.task.taskId);
+   *             break;
+   *         case 'taskStatus':
+   *             console.log('Task status:', message.task.status);
+   *             break;
+   *         case 'result':
+   *             console.log('User action:', message.result.action);
+   *             break;
+   *         case 'error':
+   *             console.error('Error:', message.error);
+   *             break;
+   *     }
+   * }
+   * ```
+   *
+   * @param params - The elicitation request parameters
+   * @param options - Optional request options (timeout, signal, task creation params, etc.)
+   * @returns AsyncGenerator that yields ResponseMessage objects
+   *
+   * @experimental
+   */
+  elicitInputStream(params, options) {
+    const clientCapabilities = this._server.getClientCapabilities();
+    const mode = params.mode ?? "form";
+    switch (mode) {
+      case "url": {
+        if (!clientCapabilities?.elicitation?.url) {
+          throw new Error("Client does not support url elicitation.");
+        }
+        break;
+      }
+      case "form": {
+        if (!clientCapabilities?.elicitation?.form) {
+          throw new Error("Client does not support form elicitation.");
+        }
+        break;
+      }
+    }
+    const normalizedParams = mode === "form" && params.mode === void 0 ? { ...params, mode: "form" } : params;
+    return this.requestStream({
+      method: "elicitation/create",
+      params: normalizedParams
+    }, ElicitResultSchema, options);
   }
   /**
    * Gets the current status of a task.
@@ -77675,7 +77863,7 @@ var tools = [
   },
   {
     name: "mail",
-    description: "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list), get (full message by ID), search, update (flags), move, delete, batch_update, batch_delete, send, reply, auth_check, schema (show input schema).",
+    description: "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list with attachmentCount), get (full message by ID with attachment metadata), search, update (flags), move, delete, batch_update, batch_delete, send, reply, save_attachment (save message attachments to disk), auth_check, schema (show input schema).",
     inputSchema: {
       type: "object",
       properties: {
@@ -77694,13 +77882,14 @@ var tools = [
             "batch_delete",
             "send",
             "reply",
+            "save_attachment",
             "auth_check",
             "schema"
           ],
           description: "Operation to perform"
         },
         ...agentDXProperties,
-        id: { type: "string", description: "RFC 2822 message ID (get/update/move/delete/reply/auth_check)" },
+        id: { type: "string", description: "RFC 2822 message ID (get/update/move/delete/reply/save_attachment/auth_check)" },
         ids: { type: "array", items: { type: "string" }, description: "Message IDs (batch_update/batch_delete)" },
         account: { type: "string", description: "Account name" },
         mailbox: { type: "string", description: "Mailbox name" },
@@ -77732,6 +77921,8 @@ var tools = [
         cc: { type: "array", items: { type: "string" }, description: "CC addresses (send)" },
         bcc: { type: "array", items: { type: "string" }, description: "BCC addresses (send)" },
         from: { type: "string", description: "Sender email address for account selection (send)" },
+        index: { type: "integer", minimum: 0, description: "Zero-based attachment index (save_attachment). Omit to save all attachments." },
+        destDir: { type: "string", description: "Directory to save attachments into (save_attachment). Defaults to system temp." },
         trustedSenders: { type: "string", description: "Path to trusted-senders.json (auth_check)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only \u2014 ignored by MCP server)" },
         profile: { type: "string", description: "Override PIM profile name (OpenClaw only \u2014 MCP server uses APPLE_PIM_PROFILE env)" }
@@ -77838,7 +78029,8 @@ var MUTATION_ACTIONS = {
     "batch_update",
     "batch_delete",
     "send",
-    "reply"
+    "reply",
+    "save_attachment"
   ])
 };
 function isMutation(toolName, action) {
@@ -77890,6 +78082,8 @@ function describeMutation(tool, action, params) {
       return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"`;
     case "reply":
       return `Would reply to message ${params.id || "?"}`;
+    case "save_attachment":
+      return `Would save ${params.index !== void 0 ? `attachment #${params.index}` : "all attachments"} from message ${params.id || "?"} to ${params.destDir || "temp directory"}`;
     default:
       return `Would perform ${action} on ${tool}`;
   }
@@ -78530,6 +78724,20 @@ async function handleMail(args, runCLI2) {
       if (args.account)
         replyArgs.push("--account", args.account);
       return await runCLI2("mail-cli", replyArgs);
+    }
+    case "save_attachment": {
+      if (!args.id)
+        throw new Error("Message ID is required for save_attachment");
+      const saveArgs = ["save-attachment", "--id", args.id];
+      if (args.index !== void 0)
+        saveArgs.push("--index", String(args.index));
+      if (args.destDir)
+        saveArgs.push("--dest-dir", args.destDir);
+      if (args.mailbox)
+        saveArgs.push("--mailbox", args.mailbox);
+      if (args.account)
+        saveArgs.push("--account", args.account);
+      return await runCLI2("mail-cli", saveArgs);
     }
     case "auth_check": {
       if (!args.id)

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -22,6 +22,7 @@ struct MailCLI: AsyncParsableCommand {
             BatchDeleteMessages.self,
             SendMessage.self,
             ReplyMessage.self,
+            SaveAttachment.self,
             AuthCheck.self,
             ConfigCommand.self,
         ]
@@ -190,6 +191,33 @@ func runAppleScript(_ script: String) throws -> String {
     }
 
     return String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+}
+
+/// Returns a JXA function that infers MIME type from a mail attachment.
+/// Tries the native `att.mimeType()` first; falls back to file-extension lookup.
+func inferMimeJXA() -> String {
+    return """
+    function inferMime(att) {
+        try { var m = att.mimeType(); if (m) return m; } catch(e) {}
+        var name = att.name() || '';
+        var dot = name.lastIndexOf('.');
+        if (dot < 0) return 'application/octet-stream';
+        var ext = name.slice(dot + 1).toLowerCase();
+        var map = {
+            md:'text/markdown', txt:'text/plain', pdf:'application/pdf',
+            jpg:'image/jpeg', jpeg:'image/jpeg', png:'image/png', gif:'image/gif',
+            doc:'application/msword',
+            docx:'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            xls:'application/vnd.ms-excel',
+            xlsx:'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            pptx:'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            csv:'text/csv', html:'text/html', htm:'text/html',
+            json:'application/json', xml:'application/xml', rtf:'application/rtf',
+            zip:'application/zip', gz:'application/gzip'
+        };
+        return map[ext] || 'application/octet-stream';
+    }
+    """
 }
 
 func ensureMailRunning() throws {
@@ -571,6 +599,8 @@ struct ListMessages: AsyncParsableCommand {
                         if (filterType === 'unread' && isRead) continue;
                         if (filterType === 'flagged' && !isFlagged) continue;
                         const dr = m.dateReceived();
+                        var attCount = 0;
+                        try { attCount = m.mailAttachments.length; } catch(e2) {}
                         results.push({
                             messageId: m.messageId(),
                             sender: m.sender(),
@@ -578,7 +608,8 @@ struct ListMessages: AsyncParsableCommand {
                             dateReceived: dr ? dr.toISOString() : null,
                             isRead: isRead,
                             isFlagged: isFlagged,
-                            isJunk: m.junkMailStatus()
+                            isJunk: m.junkMailStatus(),
+                            attachmentCount: attCount
                         });
                     } catch(e) { /* skip messages that fail to read */ }
                 }
@@ -642,6 +673,8 @@ struct GetMessage: AsyncParsableCommand {
         let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
 
         let script = """
+        \(inferMimeJXA())
+
         \(findHelper)
 
         const msg = findMessage();
@@ -684,6 +717,26 @@ struct GetMessage: AsyncParsableCommand {
             try {
                 result.allHeaders = msg.allHeaders();
             } catch(e) {}
+
+            // Collect attachment metadata
+            var attachments = [];
+            try {
+                var attCount = msg.mailAttachments.length;
+                for (var i = 0; i < attCount; i++) {
+                    try {
+                        var att = msg.mailAttachments[i];
+                        attachments.push({
+                            index: i,
+                            name: att.name(),
+                            fileSize: att.fileSize(),
+                            downloaded: att.downloaded(),
+                            mimeType: inferMime(att)
+                        });
+                    } catch(e) {}
+                }
+            } catch(e) {}
+            result.attachments = attachments;
+            result.attachmentCount = attachments.length;
 
             JSON.stringify(result);
         }
@@ -1391,6 +1444,275 @@ struct ReplyMessage: AsyncParsableCommand {
             "inReplyTo": id,
             "originalSubject": dict["subject"] ?? ""
         ])
+    }
+}
+
+// MARK: - Save Attachment
+
+struct SaveAttachment: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "save-attachment",
+        abstract: "Save one or all attachments from a message to a local directory"
+    )
+
+    @OptionGroup var pimOptions: PIMOptions
+
+    @Option(name: .long, help: "RFC 2822 message ID")
+    var id: String
+
+    @Option(name: .long, help: "Zero-based attachment index (saves all if omitted)")
+    var index: Int?
+
+    @Option(name: .long, help: "Directory to save into (default: system temp)")
+    var destDir: String?
+
+    @Option(name: .long, help: "Mailbox name hint (speeds up lookup)")
+    var mailbox: String?
+
+    @Option(name: .long, help: "Account name hint (speeds up lookup)")
+    var account: String?
+
+    func run() async throws {
+        try ensureMailRunning()
+        let config = pimOptions.loadConfig()
+        try checkMailEnabled(config: config)
+
+        // Phase 1: Get attachment metadata via JXA
+        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+
+        let metadataScript = """
+        \(inferMimeJXA())
+
+        \(findHelper)
+
+        const msg = findMessage();
+        if (!msg) {
+            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
+        } else {
+            var attachments = [];
+            try {
+                var attCount = msg.mailAttachments.length;
+                for (var i = 0; i < attCount; i++) {
+                    try {
+                        var att = msg.mailAttachments[i];
+                        attachments.push({
+                            index: i,
+                            name: att.name(),
+                            fileSize: att.fileSize(),
+                            downloaded: att.downloaded(),
+                            mimeType: inferMime(att)
+                        });
+                    } catch(e) {}
+                }
+            } catch(e) {}
+            JSON.stringify({attachments: attachments});
+        }
+        """
+
+        let metadataRaw = try runJXA(metadataScript)
+
+        guard let metadataDict = metadataRaw as? [String: Any] else {
+            throw CLIError.jxaError("Unexpected output from attachment metadata lookup")
+        }
+
+        if let error = metadataDict["error"] as? String {
+            throw CLIError.notFound(error)
+        }
+
+        let attachments = metadataDict["attachments"] as? [[String: Any]] ?? []
+
+        guard !attachments.isEmpty else {
+            throw CLIError.invalidInput("Message has no attachments")
+        }
+
+        // Determine which attachments to save
+        let targetAttachments: [[String: Any]]
+        if let idx = index {
+            guard idx >= 0 && idx < attachments.count else {
+                throw CLIError.invalidInput("Attachment index \(idx) out of range (message has \(attachments.count) attachment\(attachments.count == 1 ? "" : "s"))")
+            }
+            targetAttachments = [attachments[idx]]
+        } else {
+            targetAttachments = attachments
+        }
+
+        // Check all target attachments are downloaded
+        for att in targetAttachments {
+            let downloaded = att["downloaded"] as? Bool ?? false
+            if !downloaded {
+                let name = att["name"] as? String ?? "unknown"
+                throw CLIError.invalidInput("Attachment \"\(name)\" has not been downloaded from the server yet")
+            }
+        }
+
+        // Phase 2: Create destination directory and compute safe filenames
+        let destDirURL: URL
+        if let destDirPath = destDir {
+            destDirURL = URL(fileURLWithPath: NSString(string: destDirPath).expandingTildeInPath)
+        } else {
+            destDirURL = FileManager.default.temporaryDirectory.appendingPathComponent("apple-pim-attachments")
+        }
+
+        try FileManager.default.createDirectory(at: destDirURL, withIntermediateDirectories: true)
+
+        // Build save targets with deduplicated filenames.
+        // Track allocated paths within this batch so two attachments with the
+        // same sanitized name don't collide before any files hit disk.
+        var saveTargets = [(index: Int, destPath: String, name: String, fileSize: Int, mimeType: String)]()
+        var allocatedPaths = Set<String>()
+
+        for att in targetAttachments {
+            let attIndex = att["index"] as? Int ?? 0
+            let rawName = att["name"] as? String ?? ""
+            let fileSize = att["fileSize"] as? Int ?? 0
+            let mimeType = att["mimeType"] as? String ?? "application/octet-stream"
+
+            let safeName = sanitizeFilename(rawName, fallback: "attachment_\(attIndex)")
+            var destPath = deduplicatePath(destDirURL.appendingPathComponent(safeName).path)
+            // Also deduplicate against paths already planned in this batch
+            while allocatedPaths.contains(destPath) {
+                destPath = deduplicatePath(destPath + "_\(attIndex)")
+            }
+            allocatedPaths.insert(destPath)
+            saveTargets.append((index: attIndex, destPath: destPath, name: safeName, fileSize: fileSize, mimeType: mimeType))
+        }
+
+        // Phase 3: Save attachments via JXA.
+        // Note: This is a separate JXA call from Phase 1 (metadata fetch), which
+        // introduces a TOCTOU window — Mail could move or re-index the message
+        // between calls. We accept this trade-off because: (a) it keeps the
+        // metadata-only path lightweight for agents that just need attachment info,
+        // and (b) combining both phases into one JXA script would require passing
+        // pre-computed paths into the metadata script, complicating the flow.
+        // The error message "not found on second lookup" is specific enough to
+        // diagnose if this ever triggers in practice.
+        let findHelper2 = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+
+        var saveStatements = ""
+        for (i, target) in saveTargets.enumerated() {
+            let escapedPath = escapeForJXA(target.destPath)
+            saveStatements += """
+            try {
+                var att\(i) = msg.mailAttachments[\(target.index)];
+                Mail.save(att\(i), {in: Path('\(escapedPath)')});
+                saved.push({index: \(target.index), path: '\(escapedPath)', success: true});
+            } catch(e) {
+                errors.push({index: \(target.index), error: e.message || String(e)});
+            }
+
+            """
+        }
+
+        let saveScript = """
+        \(findHelper2)
+
+        const Mail = Application("Mail");
+        const msg = findMessage();
+        if (!msg) {
+            JSON.stringify({error: "Message not found on second lookup"});
+        } else {
+            var saved = [];
+            var errors = [];
+            \(saveStatements)
+            JSON.stringify({saved: saved, errors: errors});
+        }
+        """
+
+        let saveRaw = try runJXA(saveScript)
+
+        guard let saveDict = saveRaw as? [String: Any] else {
+            throw CLIError.jxaError("Unexpected output from attachment save")
+        }
+
+        if let error = saveDict["error"] as? String {
+            throw CLIError.jxaError(error)
+        }
+
+        let savedResults = saveDict["saved"] as? [[String: Any]] ?? []
+        let saveErrors = saveDict["errors"] as? [[String: Any]] ?? []
+
+        // Build final response with full metadata
+        var savedOutput = [[String: Any]]()
+        for result in savedResults {
+            guard let resultIndex = result["index"] as? Int,
+                  let path = result["path"] as? String else { continue }
+            if let target = saveTargets.first(where: { $0.index == resultIndex }) {
+                savedOutput.append([
+                    "index": resultIndex,
+                    "name": target.name,
+                    "path": path,
+                    "fileSize": target.fileSize,
+                    "mimeType": target.mimeType
+                ])
+            }
+        }
+
+        if !saveErrors.isEmpty {
+            outputJSON([
+                "success": false,
+                "saved": savedOutput,
+                "errors": saveErrors
+            ])
+        } else {
+            outputJSON([
+                "success": true,
+                "saved": savedOutput
+            ])
+        }
+    }
+
+    /// Sanitize a filename: strip path separators, null bytes, and leading dots.
+    private func sanitizeFilename(_ name: String, fallback: String) -> String {
+        var sanitized = name
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespaces)
+
+        while sanitized.hasPrefix(".") {
+            sanitized = String(sanitized.dropFirst())
+        }
+
+        if sanitized.isEmpty {
+            return fallback
+        }
+
+        return sanitized
+    }
+
+    /// Deduplicate a file path by appending _1, _2, etc. before the extension.
+    private func deduplicatePath(_ path: String) -> String {
+        guard FileManager.default.fileExists(atPath: path) else {
+            return path
+        }
+
+        let url = URL(fileURLWithPath: path)
+        let directory = url.deletingLastPathComponent().path
+        let ext = url.pathExtension
+        let stem: String
+        if ext.isEmpty {
+            stem = url.lastPathComponent
+        } else {
+            stem = String(url.lastPathComponent.dropLast(ext.count + 1))
+        }
+
+        for i in 1...99 {
+            let candidate: String
+            if ext.isEmpty {
+                candidate = "\(directory)/\(stem)_\(i)"
+            } else {
+                candidate = "\(directory)/\(stem)_\(i).\(ext)"
+            }
+            if !FileManager.default.fileExists(atPath: candidate) {
+                return candidate
+            }
+        }
+
+        let ts = Int(Date().timeIntervalSince1970)
+        if ext.isEmpty {
+            return "\(directory)/\(stem)_\(ts)"
+        } else {
+            return "\(directory)/\(stem)_\(ts).\(ext)"
+        }
     }
 }
 


### PR DESCRIPTION
This adds three things:

1. **`messages` now includes `attachmentCount`** — so agents can see which messages have attachments without fetching the full body.

2. **`get` returns attachment metadata** — `index`, `name`, `fileSize`, `downloaded` flag, `mimeType`. MIME inference uses JXA native `mimeType()` with extension-based fallback for common types.

3. **New `save_attachment` action** — saves one or all attachments to a local directory. Accepts `id` (required), `index` (optional — saves all if omitted), `destDir` (optional, defaults to system temp). Validates bounds and download status, sanitizes filenames, deduplicates on collision. Uses JXA `Mail.save()` because AppleScript `save` throws -10000.

Updated schema, handler, dry-run, evals (safety + tool-call-correctness), and MCP server bundle. Added a test fixture for attachment-bearing message data.

> **Note:** The `mcp-server/dist/server.js` diff includes upstream dependency changes from a clean esbuild rebuild (mailparser, ajv). These are not part of this feature — upstream can rebuild the bundle independently.