### PR TITLE
feat: add attachment support for send and reply

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,65 @@
+# Code Review: Apple-PIM Mail Attachment PRs
+
+We're about to submit two PRs to upstream (omarshahine/Apple-PIM-Agent-Plugin). Both branches are based on `origin/main` (commit `9d5ba49`). Fork remote is `juan-deere-4000/Apple-PIM-Agent-Plugin`.
+
+Please review both branches for correctness, edge cases, and anything that would embarrass us in a public PR.
+
+## Branches
+
+### 1. `feat/mail-attachment-receive` (commit `083da0e`)
+
+Adds attachment metadata to `messages` and `get` actions, plus a new `save_attachment` action.
+
+**Files changed:**
+- `swift/Sources/MailCLI/MailCLI.swift` — bulk of the work: `SaveAttachment` command struct, `inferMimeJXA()` helper, attachment metadata in `ListMessages` and `GetMessage` JXA, filename sanitization, dedup logic
+- `lib/handlers/mail.js` — `save_attachment` case with ID validation, arg construction
+- `lib/schemas.js` — `save_attachment` added to action enum, `index` and `destDir` properties added, description updated
+- `lib/dry-run.js` — `save_attachment` added to mutation set and describe
+- `evals/scenarios/safety.yaml` — `save_attachment` in id_required_actions
+- `evals/tests/safety.test.js` — coverage set updated, isMutation assertion added
+- `evals/tests/tool-call-correctness.test.js` — save_attachment validation and arg construction tests
+- `evals/fixtures/mail/get-with-attachments.json` — new fixture
+- `mcp-server/dist/server.js` — rebuilt bundle
+
+### 2. `feat/mail-attachment-send` (commit `df8fb96`)
+
+Adds `--attachment` (repeatable) to `send` and `reply` actions.
+
+**Files changed:**
+- `swift/Sources/MailCLI/MailCLI.swift` — `--attachment` option on `SendMessage` and `ReplyMessage`, file existence validation, AppleScript attachment block injection
+- `lib/handlers/mail.js` — attachment validation (existsSync + tilde expansion) and `--attachment` flag construction for both send and reply
+- `lib/schemas.js` — `attachment` property added as `{ type: "array", items: { type: "string" } }` (NOT `oneOf` — OpenClaw gateway silently drops `oneOf` params), description updated
+- `lib/dry-run.js` — send/reply descriptions include attachment count
+- `evals/tests/tool-call-correctness.test.js` — 6 new tests covering single/multi/missing attachments for send and reply
+- `mcp-server/dist/server.js` — rebuilt bundle
+
+## What to look for
+
+1. **Swift correctness** — AppleScript/JXA injection risks from unsanitized input, proper escaping, error handling paths
+2. **JS handler correctness** — arg construction, edge cases (empty arrays, single string vs array normalization), error messages
+3. **Schema correctness** — property types, descriptions, enum completeness
+4. **Eval coverage** — are we missing any important test cases?
+5. **Consistency between the two branches** — they don't depend on each other but they touch some of the same files. Any conflicts or inconsistencies?
+6. **MCP server bundle** — the rebuilt `mcp-server/dist/server.js` includes upstream dependency diffs from esbuild rebuild (mailparser, ajv changes). These are NOT part of our changes but will show in the diff. This is expected and matches what upstream would get from a clean `npm run build`.
+
+## How to review
+
+```bash
+cd ~/projects/apple-pim
+
+# PR 1
+git diff origin/main..feat/mail-attachment-receive -- swift/ lib/ evals/
+
+# PR 2
+git diff origin/main..feat/mail-attachment-send -- swift/ lib/ evals/
+
+# Run evals on either branch
+git checkout feat/mail-attachment-receive  # or feat/mail-attachment-send
+cd evals && npm test
+```
+
+## Context
+
+- Upstream repo: https://github.com/omarshahine/Apple-PIM-Agent-Plugin
+- Fork: https://github.com/juan-deere-4000/Apple-PIM-Agent-Plugin
+- Both features were developed and tested locally. Send attachments were verified end-to-end (4 test cases: single, multiple, nonexistent, none). Receive attachments were verified with real emails containing PDF and markdown attachments.

--- a/evals/tests/tool-call-correctness.test.js
+++ b/evals/tests/tool-call-correctness.test.js
@@ -288,6 +288,88 @@ describe("Category 1: Tool Call Correctness", () => {
     });
   });
 
+  describe("send/reply attachment argument construction", () => {
+    it("send passes --attachment for single file path", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:send": { success: true } });
+      await handleMail({
+        action: "send", to: ["a@b.com"], subject: "test", body: "hi",
+        attachment: "/dev/null",
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(argsPairPresent(callArgs, "--attachment", "/dev/null")).toBe(true);
+    });
+
+    it("send passes multiple --attachment flags for array", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:send": { success: true } });
+      await handleMail({
+        action: "send", to: ["a@b.com"], subject: "test", body: "hi",
+        attachment: ["/dev/null", "/dev/zero"],
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      const attValues = callArgs
+        .map((arg, i) => arg === "--attachment" ? callArgs[i + 1] : null)
+        .filter(Boolean);
+      expect(attValues).toContain("/dev/null");
+      expect(attValues).toContain("/dev/zero");
+      expect(attValues).toHaveLength(2);
+    });
+
+    it("send omits --attachment when not provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:send": { success: true } });
+      await handleMail({
+        action: "send", to: ["a@b.com"], subject: "test", body: "hi",
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(callArgs).not.toContain("--attachment");
+    });
+
+    it("send throws for nonexistent attachment path", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:send": { success: true } });
+      await expect(handleMail({
+        action: "send", to: ["a@b.com"], subject: "test", body: "hi",
+        attachment: "/tmp/does-not-exist-abc123.txt",
+      }, mockCLI)).rejects.toThrow("Attachment file not found: /tmp/does-not-exist-abc123.txt");
+    });
+
+    it("reply passes --attachment when provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:reply": { success: true } });
+      await handleMail({
+        action: "reply", id: "msg_1", body: "thanks",
+        attachment: "/dev/null",
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(argsPairPresent(callArgs, "--attachment", "/dev/null")).toBe(true);
+    });
+
+    it("reply passes multiple --attachment flags for array", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:reply": { success: true } });
+      await handleMail({
+        action: "reply", id: "msg_1", body: "thanks",
+        attachment: ["/dev/null", "/dev/zero"],
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      const attValues = callArgs
+        .map((arg, i) => arg === "--attachment" ? callArgs[i + 1] : null)
+        .filter(Boolean);
+      expect(attValues).toContain("/dev/null");
+      expect(attValues).toContain("/dev/zero");
+      expect(attValues).toHaveLength(2);
+    });
+
+    it("reply throws for nonexistent attachment path", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:reply": { success: true } });
+      await expect(handleMail({
+        action: "reply", id: "msg_1", body: "thanks",
+        attachment: "/tmp/does-not-exist-abc123.txt",
+      }, mockCLI)).rejects.toThrow("Attachment file not found: /tmp/does-not-exist-abc123.txt");
+    });
+  });
+
   describe("batch operation validation", () => {
     it("calendar batch_create throws with empty events", async () => {
       const mockCLI = createMockCLI({});

--- a/lib/dry-run.js
+++ b/lib/dry-run.js
@@ -91,10 +91,14 @@ function describeMutation(tool, action, params) {
       return `Would mark reminder ${params.id || "?"} as ${params.undo ? "incomplete" : "complete"}`;
     case "move":
       return `Would move message ${params.id || "?"} to mailbox "${params.toMailbox || "?"}"`;
-    case "send":
-      return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"`;
-    case "reply":
-      return `Would reply to message ${params.id || "?"}`;
+    case "send": {
+      const attCount = params.attachment ? (Array.isArray(params.attachment) ? params.attachment.length : 1) : 0;
+      return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"${attCount ? ` (${attCount} attachment${attCount > 1 ? "s" : ""})` : ""}`;
+    }
+    case "reply": {
+      const attCount = params.attachment ? (Array.isArray(params.attachment) ? params.attachment.length : 1) : 0;
+      return `Would reply to message ${params.id || "?"}${attCount ? ` (${attCount} attachment${attCount > 1 ? "s" : ""})` : ""}`;
+    }
     default:
       return `Would perform ${action} on ${tool}`;
   }

--- a/lib/handlers/mail.js
+++ b/lib/handlers/mail.js
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { formatMailGetResult } from "../mail-format.js";
 
 export async function handleMail(args, runCLI) {
@@ -113,6 +115,16 @@ export async function handleMail(args, runCLI) {
         for (const addr of bccList) sendArgs.push("--bcc", addr);
       }
       if (args.from) sendArgs.push("--from", args.from);
+      if (args.attachment) {
+        const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+        for (const filePath of attachments) {
+          const expanded = filePath.replace(/^~/, homedir());
+          if (!existsSync(expanded)) {
+            throw new Error(`Attachment file not found: ${filePath}`);
+          }
+          sendArgs.push("--attachment", expanded);
+        }
+      }
       return await runCLI("mail-cli", sendArgs);
     }
 
@@ -122,6 +134,16 @@ export async function handleMail(args, runCLI) {
       const replyArgs = ["reply", "--id", args.id, "--body", args.body];
       if (args.mailbox) replyArgs.push("--mailbox", args.mailbox);
       if (args.account) replyArgs.push("--account", args.account);
+      if (args.attachment) {
+        const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+        for (const filePath of attachments) {
+          const expanded = filePath.replace(/^~/, homedir());
+          if (!existsSync(expanded)) {
+            throw new Error(`Attachment file not found: ${filePath}`);
+          }
+          replyArgs.push("--attachment", expanded);
+        }
+      }
       return await runCLI("mail-cli", replyArgs);
     }
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -332,7 +332,7 @@ export const tools = [
   {
     name: "mail",
     description:
-      "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list), get (full message by ID), search, update (flags), move, delete, batch_update, batch_delete, send, reply, auth_check, schema (show input schema).",
+      "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list), get (full message by ID), search, update (flags), move, delete, batch_update, batch_delete, send (with optional attachments), reply (with optional attachments), auth_check, schema (show input schema).",
     inputSchema: {
       type: "object",
       properties: {
@@ -379,6 +379,11 @@ export const tools = [
         cc: { type: "array", items: { type: "string" }, description: "CC addresses (send)" },
         bcc: { type: "array", items: { type: "string" }, description: "BCC addresses (send)" },
         from: { type: "string", description: "Sender email address for account selection (send)" },
+        attachment: {
+          type: "array",
+          items: { type: "string" },
+          description: "File path(s) to attach (send/reply).",
+        },
         trustedSenders: { type: "string", description: "Path to trusted-senders.json (auth_check)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only — ignored by MCP server)" },
         profile: { type: "string", description: "Override PIM profile name (OpenClaw only — MCP server uses APPLE_PIM_PROFILE env)" },

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -4745,6 +4745,7 @@ var require_pattern = __commonJS({
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
+    var util_1 = require_util();
     var codegen_1 = require_codegen();
     var error2 = {
       message: ({ schemaCode }) => (0, codegen_1.str)`must match pattern "${schemaCode}"`,
@@ -4757,10 +4758,18 @@ var require_pattern = __commonJS({
       $data: true,
       error: error2,
       code(cxt) {
-        const { data, $data, schema, schemaCode, it } = cxt;
+        const { gen, data, $data, schema, schemaCode, it } = cxt;
         const u = it.opts.unicodeRegExp ? "u" : "";
-        const regExp = $data ? (0, codegen_1._)`(new RegExp(${schemaCode}, ${u}))` : (0, code_1.usePattern)(cxt, schema);
-        cxt.fail$data((0, codegen_1._)`!${regExp}.test(${data})`);
+        if ($data) {
+          const { regExp } = it.opts.code;
+          const regExpCode = regExp.code === "new RegExp" ? (0, codegen_1._)`new RegExp` : (0, util_1.useFunc)(gen, regExp);
+          const valid = gen.let("valid");
+          gen.try(() => gen.assign(valid, (0, codegen_1._)`${regExpCode}(${schemaCode}, ${u}).test(${data})`), () => gen.assign(valid, false));
+          cxt.fail$data((0, codegen_1._)`!${valid}`);
+        } else {
+          const regExp = (0, code_1.usePattern)(cxt, schema);
+          cxt.fail$data((0, codegen_1._)`!${regExp}.test(${data})`);
+        }
       }
     };
     exports.default = def;
@@ -31739,6 +31748,14 @@ var require_addressparser = __commonJS({
           parsedAddresses = parsedAddresses.concat(address2);
         }
       });
+      for (let i = parsedAddresses.length - 2; i >= 0; i--) {
+        let current = parsedAddresses[i];
+        let next = parsedAddresses[i + 1];
+        if (current.address === "" && current.name && !current.group && next.address && next.name && !next.group) {
+          next.name = current.name + ", " + next.name;
+          parsedAddresses.splice(i, 1);
+        }
+      }
       if (options.flatten) {
         let addresses2 = [];
         let walkAddressList = (list) => {
@@ -44921,7 +44938,7 @@ var require_mail_parser = __commonJS({
                 value = this.libmime.decodeWords(value);
               } catch (E) {
               }
-              value = value.split(/\s+/).map(this.ensureMessageIDFormat);
+              value = value.split(/\s+/).map(this.ensureMessageIDFormat).filter((val) => val);
               break;
             case "message-id":
             case "in-reply-to":
@@ -45078,21 +45095,39 @@ var require_mail_parser = __commonJS({
           let address = addresses[i];
           address.name = (address.name || "").toString().trim();
           if (!address.address && /^(=\?([^?]+)\?[Bb]\?[^?]*\?=)(\s*=\?([^?]+)\?[Bb]\?[^?]*\?=)*$/.test(address.name) && !processedAddress.has(address)) {
-            let parsed = addressparser(this.libmime.decodeWords(address.name));
-            if (parsed.length) {
-              parsed.forEach((entry) => {
-                processedAddress.add(entry);
-                addresses.push(entry);
-              });
+            let decoded = this.libmime.decodeWords(address.name);
+            if (/<[^<>]+@[^<>]+>/.test(decoded)) {
+              let parsed = addressparser(decoded);
+              if (parsed.length) {
+                parsed.forEach((entry) => {
+                  processedAddress.add(entry);
+                  addresses.push(entry);
+                });
+              }
+              addresses.splice(i, 1);
+              i--;
+              continue;
+            } else {
+              address.name = decoded;
+              continue;
             }
-            addresses.splice(i, 1);
-            i--;
-            continue;
           }
           if (address.name) {
             try {
               address.name = this.libmime.decodeWords(address.name);
             } catch (E) {
+            }
+          }
+          if (address.address && /[=]\?[^?]+\?[BbQq]\?[^?]*\?[=]/.test(address.address)) {
+            try {
+              let decodedAddr = this.libmime.decodeWords(address.address);
+              if (/^[^\s@]+@[^\s@]+$/.test(decodedAddr) && !/[=]\?/.test(decodedAddr)) {
+                address.address = decodedAddr;
+              } else {
+                address.address = "";
+              }
+            } catch (E) {
+              address.address = "";
             }
           }
           if (/@xn--/.test(address.address)) {
@@ -68779,7 +68814,7 @@ var Doc = class {
 var version = {
   major: 4,
   minor: 3,
-  patch: 5
+  patch: 6
 };
 
 // node_modules/zod/v4/core/schemas.js
@@ -70070,7 +70105,7 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
         if (keyResult instanceof Promise) {
           throw new Error("Async schemas not supported in object keys currently");
         }
-        const checkNumericKey = typeof key === "string" && number.test(key) && keyResult.issues.length && keyResult.issues.some((iss) => iss.code === "invalid_type" && iss.expected === "number");
+        const checkNumericKey = typeof key === "string" && number.test(key) && keyResult.issues.length;
         if (checkNumericKey) {
           const retryResult = def.keyType._zod.run({ value: Number(key), issues: [] }, ctx);
           if (retryResult instanceof Promise) {
@@ -71915,7 +71950,7 @@ function finalize(ctx, schema) {
           }
         }
       }
-      if (refSchema.$ref) {
+      if (refSchema.$ref && refSeen.def) {
         for (const key in schema2) {
           if (key === "$ref" || key === "allOf")
             continue;
@@ -75714,6 +75749,9 @@ var Protocol = class {
    * The Protocol object assumes ownership of the Transport, replacing any callbacks that have already been set, and expects that it is the only user of the Transport instance going forward.
    */
   async connect(transport2) {
+    if (this._transport) {
+      throw new Error("Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.");
+    }
     this._transport = transport2;
     const _onclose = this.transport?.onclose;
     this._transport.onclose = () => {
@@ -75746,6 +75784,10 @@ var Protocol = class {
     this._progressHandlers.clear();
     this._taskProgressTokens.clear();
     this._pendingDebouncedNotifications.clear();
+    for (const controller of this._requestHandlerAbortControllers.values()) {
+      controller.abort();
+    }
+    this._requestHandlerAbortControllers.clear();
     const error2 = McpError.fromError(ErrorCode.ConnectionClosed, "Connection closed");
     this._transport = void 0;
     this.onclose?.();
@@ -75796,6 +75838,8 @@ var Protocol = class {
       sessionId: capturedTransport?.sessionId,
       _meta: request.params?._meta,
       sendNotification: async (notification) => {
+        if (abortController.signal.aborted)
+          return;
         const notificationOptions = { relatedRequestId: request.id };
         if (relatedTaskId) {
           notificationOptions.relatedTask = { taskId: relatedTaskId };
@@ -75803,6 +75847,9 @@ var Protocol = class {
         await this.notification(notification, notificationOptions);
       },
       sendRequest: async (r, resultSchema, options) => {
+        if (abortController.signal.aborted) {
+          throw new McpError(ErrorCode.ConnectionClosed, "Request was cancelled");
+        }
         const requestOptions = { ...options, relatedRequestId: request.id };
         if (relatedTaskId && !requestOptions.relatedTask) {
           requestOptions.relatedTask = { taskId: relatedTaskId };
@@ -76562,6 +76609,147 @@ var ExperimentalServerTasks = class {
    */
   requestStream(request, resultSchema, options) {
     return this._server.requestStream(request, resultSchema, options);
+  }
+  /**
+   * Sends a sampling request and returns an AsyncGenerator that yields response messages.
+   * The generator is guaranteed to end with either a 'result' or 'error' message.
+   *
+   * For task-augmented requests, yields 'taskCreated' and 'taskStatus' messages
+   * before the final result.
+   *
+   * @example
+   * ```typescript
+   * const stream = server.experimental.tasks.createMessageStream({
+   *     messages: [{ role: 'user', content: { type: 'text', text: 'Hello' } }],
+   *     maxTokens: 100
+   * }, {
+   *     onprogress: (progress) => {
+   *         // Handle streaming tokens via progress notifications
+   *         console.log('Progress:', progress.message);
+   *     }
+   * });
+   *
+   * for await (const message of stream) {
+   *     switch (message.type) {
+   *         case 'taskCreated':
+   *             console.log('Task created:', message.task.taskId);
+   *             break;
+   *         case 'taskStatus':
+   *             console.log('Task status:', message.task.status);
+   *             break;
+   *         case 'result':
+   *             console.log('Final result:', message.result);
+   *             break;
+   *         case 'error':
+   *             console.error('Error:', message.error);
+   *             break;
+   *     }
+   * }
+   * ```
+   *
+   * @param params - The sampling request parameters
+   * @param options - Optional request options (timeout, signal, task creation params, onprogress, etc.)
+   * @returns AsyncGenerator that yields ResponseMessage objects
+   *
+   * @experimental
+   */
+  createMessageStream(params, options) {
+    const clientCapabilities = this._server.getClientCapabilities();
+    if ((params.tools || params.toolChoice) && !clientCapabilities?.sampling?.tools) {
+      throw new Error("Client does not support sampling tools capability.");
+    }
+    if (params.messages.length > 0) {
+      const lastMessage = params.messages[params.messages.length - 1];
+      const lastContent = Array.isArray(lastMessage.content) ? lastMessage.content : [lastMessage.content];
+      const hasToolResults = lastContent.some((c) => c.type === "tool_result");
+      const previousMessage = params.messages.length > 1 ? params.messages[params.messages.length - 2] : void 0;
+      const previousContent = previousMessage ? Array.isArray(previousMessage.content) ? previousMessage.content : [previousMessage.content] : [];
+      const hasPreviousToolUse = previousContent.some((c) => c.type === "tool_use");
+      if (hasToolResults) {
+        if (lastContent.some((c) => c.type !== "tool_result")) {
+          throw new Error("The last message must contain only tool_result content if any is present");
+        }
+        if (!hasPreviousToolUse) {
+          throw new Error("tool_result blocks are not matching any tool_use from the previous message");
+        }
+      }
+      if (hasPreviousToolUse) {
+        const toolUseIds = new Set(previousContent.filter((c) => c.type === "tool_use").map((c) => c.id));
+        const toolResultIds = new Set(lastContent.filter((c) => c.type === "tool_result").map((c) => c.toolUseId));
+        if (toolUseIds.size !== toolResultIds.size || ![...toolUseIds].every((id) => toolResultIds.has(id))) {
+          throw new Error("ids of tool_result blocks and tool_use blocks from previous message do not match");
+        }
+      }
+    }
+    return this.requestStream({
+      method: "sampling/createMessage",
+      params
+    }, CreateMessageResultSchema, options);
+  }
+  /**
+   * Sends an elicitation request and returns an AsyncGenerator that yields response messages.
+   * The generator is guaranteed to end with either a 'result' or 'error' message.
+   *
+   * For task-augmented requests (especially URL-based elicitation), yields 'taskCreated'
+   * and 'taskStatus' messages before the final result.
+   *
+   * @example
+   * ```typescript
+   * const stream = server.experimental.tasks.elicitInputStream({
+   *     mode: 'url',
+   *     message: 'Please authenticate',
+   *     elicitationId: 'auth-123',
+   *     url: 'https://example.com/auth'
+   * }, {
+   *     task: { ttl: 300000 } // Task-augmented for long-running auth flow
+   * });
+   *
+   * for await (const message of stream) {
+   *     switch (message.type) {
+   *         case 'taskCreated':
+   *             console.log('Task created:', message.task.taskId);
+   *             break;
+   *         case 'taskStatus':
+   *             console.log('Task status:', message.task.status);
+   *             break;
+   *         case 'result':
+   *             console.log('User action:', message.result.action);
+   *             break;
+   *         case 'error':
+   *             console.error('Error:', message.error);
+   *             break;
+   *     }
+   * }
+   * ```
+   *
+   * @param params - The elicitation request parameters
+   * @param options - Optional request options (timeout, signal, task creation params, etc.)
+   * @returns AsyncGenerator that yields ResponseMessage objects
+   *
+   * @experimental
+   */
+  elicitInputStream(params, options) {
+    const clientCapabilities = this._server.getClientCapabilities();
+    const mode = params.mode ?? "form";
+    switch (mode) {
+      case "url": {
+        if (!clientCapabilities?.elicitation?.url) {
+          throw new Error("Client does not support url elicitation.");
+        }
+        break;
+      }
+      case "form": {
+        if (!clientCapabilities?.elicitation?.form) {
+          throw new Error("Client does not support form elicitation.");
+        }
+        break;
+      }
+    }
+    const normalizedParams = mode === "form" && params.mode === void 0 ? { ...params, mode: "form" } : params;
+    return this.requestStream({
+      method: "elicitation/create",
+      params: normalizedParams
+    }, ElicitResultSchema, options);
   }
   /**
    * Gets the current status of a task.
@@ -77675,7 +77863,7 @@ var tools = [
   },
   {
     name: "mail",
-    description: "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list), get (full message by ID), search, update (flags), move, delete, batch_update, batch_delete, send, reply, auth_check, schema (show input schema).",
+    description: "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list), get (full message by ID), search, update (flags), move, delete, batch_update, batch_delete, send (with optional attachments), reply (with optional attachments), auth_check, schema (show input schema).",
     inputSchema: {
       type: "object",
       properties: {
@@ -77732,6 +77920,11 @@ var tools = [
         cc: { type: "array", items: { type: "string" }, description: "CC addresses (send)" },
         bcc: { type: "array", items: { type: "string" }, description: "BCC addresses (send)" },
         from: { type: "string", description: "Sender email address for account selection (send)" },
+        attachment: {
+          type: "array",
+          items: { type: "string" },
+          description: "File path(s) to attach (send/reply)."
+        },
         trustedSenders: { type: "string", description: "Path to trusted-senders.json (auth_check)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only \u2014 ignored by MCP server)" },
         profile: { type: "string", description: "Override PIM profile name (OpenClaw only \u2014 MCP server uses APPLE_PIM_PROFILE env)" }
@@ -77886,10 +78079,14 @@ function describeMutation(tool, action, params) {
       return `Would mark reminder ${params.id || "?"} as ${params.undo ? "incomplete" : "complete"}`;
     case "move":
       return `Would move message ${params.id || "?"} to mailbox "${params.toMailbox || "?"}"`;
-    case "send":
-      return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"`;
-    case "reply":
-      return `Would reply to message ${params.id || "?"}`;
+    case "send": {
+      const attCount = params.attachment ? Array.isArray(params.attachment) ? params.attachment.length : 1 : 0;
+      return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"${attCount ? ` (${attCount} attachment${attCount > 1 ? "s" : ""})` : ""}`;
+    }
+    case "reply": {
+      const attCount = params.attachment ? Array.isArray(params.attachment) ? params.attachment.length : 1 : 0;
+      return `Would reply to message ${params.id || "?"}${attCount ? ` (${attCount} attachment${attCount > 1 ? "s" : ""})` : ""}`;
+    }
     default:
       return `Would perform ${action} on ${tool}`;
   }
@@ -78319,6 +78516,10 @@ async function handleContact(args, runCLI2) {
   }
 }
 
+// ../lib/handlers/mail.js
+import { existsSync as existsSync2 } from "node:fs";
+import { homedir as homedir2 } from "node:os";
+
 // ../lib/mail-format.js
 var import_mailparser = __toESM(require_mailparser(), 1);
 var import_turndown = __toESM(require_turndown_cjs(), 1);
@@ -78517,6 +78718,16 @@ async function handleMail(args, runCLI2) {
       }
       if (args.from)
         sendArgs.push("--from", args.from);
+      if (args.attachment) {
+        const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+        for (const filePath of attachments) {
+          const expanded = filePath.replace(/^~/, homedir2());
+          if (!existsSync2(expanded)) {
+            throw new Error(`Attachment file not found: ${filePath}`);
+          }
+          sendArgs.push("--attachment", expanded);
+        }
+      }
       return await runCLI2("mail-cli", sendArgs);
     }
     case "reply": {
@@ -78529,6 +78740,16 @@ async function handleMail(args, runCLI2) {
         replyArgs.push("--mailbox", args.mailbox);
       if (args.account)
         replyArgs.push("--account", args.account);
+      if (args.attachment) {
+        const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+        for (const filePath of attachments) {
+          const expanded = filePath.replace(/^~/, homedir2());
+          if (!existsSync2(expanded)) {
+            throw new Error(`Attachment file not found: ${filePath}`);
+          }
+          replyArgs.push("--attachment", expanded);
+        }
+      }
       return await runCLI2("mail-cli", replyArgs);
     }
     case "auth_check": {

--- a/specs/done/fix-send-attachment-bugs.md
+++ b/specs/done/fix-send-attachment-bugs.md
@@ -1,0 +1,97 @@
+# Fix Send-with-Attachment Bugs
+
+## Problem
+
+Sending emails with attachments through the OpenClaw plugin silently fails. The email sends but no attachments are included. The CLI works correctly when called directly.
+
+Two root causes:
+
+### Bug 1: `oneOf` schema type dropped by OpenClaw gateway
+
+The `attachment` property in `lib/schemas.js` uses a `oneOf` union type:
+
+```javascript
+attachment: {
+  oneOf: [
+    { type: "string" },
+    { type: "array", items: { type: "string" } },
+  ],
+  description: "File path(s) to attach (send/reply). Accepts a single path or array of paths.",
+},
+```
+
+The OpenClaw gateway does not support `oneOf` in tool parameter schemas. It silently drops the property during tool registration. The parameter never reaches the handler, so `args.attachment` is always `undefined` and the attachment block in the handler never fires.
+
+Evidence: the gateway's exposed tool definition for `apple_pim_mail` does not include `attachment` in its parameter list. All five test emails sent through the plugin had `attachmentCount: 0`. A direct CLI call with `--attachment` produced `attachmentCount: 1`.
+
+### Bug 2: Handler does not validate file existence
+
+The JS handler in `lib/handlers/mail.js` passes file paths straight through to the CLI without checking if they exist:
+
+```javascript
+if (args.attachment) {
+  const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+  for (const filePath of attachments) sendArgs.push("--attachment", filePath);
+}
+```
+
+The Swift CLI does validate with `FileManager.default.fileExists(atPath:)` and throws `CLIError.invalidInput`. So bad paths will error at the CLI layer. But the handler should validate too for a clean error message at the JS layer, before spawning a process.
+
+This applies to both the `send` and `reply` cases (lines ~116-119 and ~129-132).
+
+## Fix
+
+### schemas.js (line ~382)
+
+Replace the `oneOf` union with a plain array type:
+
+```javascript
+attachment: {
+  type: "array",
+  items: { type: "string" },
+  description: "File path(s) to attach (send/reply).",
+},
+```
+
+The handler already normalizes with `Array.isArray(args.attachment) ? args.attachment : [args.attachment]`, so it handles both forms. But since the gateway only passes what the schema declares, just use `array`. Agents will always pass an array.
+
+### handlers/mail.js — send case (line ~116)
+
+Add file existence validation before building CLI args:
+
+```javascript
+if (args.attachment) {
+  const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+  for (const filePath of attachments) {
+    const expanded = filePath.replace(/^~/, require("os").homedir());
+    if (!require("fs").existsSync(expanded)) {
+      throw new Error(`Attachment file not found: ${filePath}`);
+    }
+    sendArgs.push("--attachment", filePath);
+  }
+}
+```
+
+### handlers/mail.js — reply case (line ~129)
+
+Same validation pattern as send.
+
+### MCP server
+
+The MCP server (`mcp-server/dist/server.js`) uses the same `lib/schemas.js` and `lib/handlers/mail.js`. The `oneOf` schema works fine in MCP (the MCP protocol supports `oneOf`), so this is OpenClaw-specific. But changing to `array` is fine for MCP too since Claude/agents will just pass arrays. No MCP-specific changes needed.
+
+## Verification
+
+After fixing, test through the OpenClaw plugin (not direct CLI):
+
+1. Send with single attachment: `attachment: ["/tmp/test.txt"]`
+2. Send with multiple attachments: `attachment: ["/tmp/a.txt", "/tmp/b.txt"]`
+3. Send with nonexistent file: `attachment: ["/tmp/does-not-exist.txt"]` — should error before sending
+4. Reply with attachment: same pattern
+5. Send without attachment: regression check, should work as before
+6. Verify received emails have `attachmentCount > 0` and `attachments` array populated
+
+## Files to Change
+
+- `lib/schemas.js` — line ~382, replace `oneOf` with `type: "array"`
+- `lib/handlers/mail.js` — lines ~116 and ~129, add file existence checks

--- a/specs/mail-attachments.md
+++ b/specs/mail-attachments.md
@@ -1,0 +1,171 @@
+# Mail Attachments Spec
+
+## Problem
+
+The `mail` tool (via `mail-cli`) can list and read email messages but has no way to access attachments. When a message has attachments, the agent sees the body text but cannot list, inspect, or extract the attached files. This blocks workflows where Joe emails files to Juan (research reports, documents, etc.) and expects Juan to file or process them.
+
+## Prior Art: What the Mail.app Scripting Dictionary Exposes
+
+From `/System/Applications/Mail.app/Contents/Resources/Mail.sdef`, the `mail attachment` class:
+
+```
+name        text     (r/o)  — filename
+MIME type   text     (r/o)  — e.g. "text/plain" (unreliable, fails on some messages)
+file size   integer  (r/o)  — approximate bytes
+downloaded  boolean  (r/o)  — whether the attachment has been fetched from server
+id          text     (r/o)  — unique identifier within the message
+```
+
+Responds to `save` command: `save attachment in <file path>`.
+
+### Verified Working (JXA)
+
+```javascript
+const att = msg.mailAttachments[0];
+att.name()        // "report.md"
+att.downloaded()  // true
+att.fileSize()    // 62548
+att.id()          // "2"
+Mail.save(att, {in: Path("/tmp/report.md")});  // saves the file
+```
+
+### Known Issues
+
+- `att.mimeType()` throws `AppleEvent handler failed` (-10000) for many messages. Not reliably accessible. Treat it as optional/best-effort. Fall back to inferring from file extension.
+- `msg.mailAttachments()` (calling as function on the collection) throws in JXA. Use `msg.mailAttachments[i]` (indexing) instead.
+
+## Design
+
+### Two new actions on the existing `mail` tool
+
+No new CLI subcommands. Extend the existing `get` action and add one new action.
+
+#### 1. Extend `get` action: include attachment metadata
+
+When getting a message, always include an `attachments` array in the response:
+
+```json
+{
+  "message": {
+    "messageId": "...",
+    "subject": "...",
+    "attachments": [
+      {
+        "index": 0,
+        "name": "report.md",
+        "fileSize": 62548,
+        "downloaded": true,
+        "mimeType": "text/markdown"
+      }
+    ]
+  }
+}
+```
+
+- `index`: zero-based position in the attachment list (used as the stable reference for save)
+- `mimeType`: best-effort. Try `att.mimeType()` in a try/catch. If it fails, infer from extension using a hardcoded map (`.md` -> `text/markdown`, `.pdf` -> `application/pdf`, `.jpg`/`.jpeg` -> `image/jpeg`, `.png` -> `image/png`, `.doc`/`.docx` -> `application/msword`, `.xls`/`.xlsx` -> `application/vnd.ms-excel`, `.csv` -> `text/csv`, `.txt` -> `text/plain`, `.zip` -> `application/zip`, `.html` -> `text/html`). Default: `application/octet-stream`.
+- `downloaded`: if false, the attachment hasn't been fetched from the server yet. Save will fail.
+
+Also include `attachmentCount` at the message level for quick checks without needing to inspect the array.
+
+#### 2. New action: `save-attachment`
+
+Saves one or all attachments from a message to a local directory.
+
+**Parameters:**
+- `id` (required): RFC 2822 message ID
+- `index` (optional): zero-based attachment index. If omitted, saves all attachments.
+- `destDir` (optional): directory path to save into. Default: `~/.openclaw/workspace/mail-attachments/`. Created if it doesn't exist.
+- `mailbox` (optional): hint for faster message lookup
+- `account` (optional): hint for faster message lookup
+
+**Behavior:**
+1. Find the message by ID (reuse existing `findMessageJXA`).
+2. Get the attachment(s) at the specified index (or all if no index).
+3. Check `downloaded` status. If not downloaded, return an error.
+4. Save to `{destDir}/{sanitized_filename}`. If a file with that name exists, append a counter: `report.md` -> `report_1.md`.
+5. Return the saved file path(s) so the agent can read them.
+
+**Output:**
+```json
+{
+  "success": true,
+  "saved": [
+    {
+      "index": 0,
+      "name": "report.md",
+      "path": "/Users/joe/.openclaw/workspace/mail-attachments/report.md",
+      "fileSize": 62548,
+      "mimeType": "text/markdown"
+    }
+  ]
+}
+```
+
+**Error cases:**
+- Message not found: standard `notFound` error
+- Attachment index out of range: error with available count
+- Attachment not downloaded: error with `downloaded: false`
+- Save failed (permissions, disk): error with OS message
+
+### Changes needed in the `messages` (list) action
+
+Add `attachmentCount` to each message in list results (cheap: just `msg.mailAttachments.length` in JXA). This lets the agent know which messages have attachments without fetching each one.
+
+## Implementation Scope
+
+### Swift CLI (`swift/Sources/MailCLI/MailCLI.swift`)
+
+1. **Modify `GetMessage`**: add attachment metadata collection to the existing JXA script. After the current `JSON.stringify(result)` block, iterate `msg.mailAttachments` and build the array. Add `attachmentCount` field.
+
+2. **Modify `ListMessages`**: add `attachmentCount` to each message object in the JXA loop. One extra line: `attachmentCount: m.mailAttachments.length`.
+
+3. **New subcommand `SaveAttachment`**: new `ParsableCommand` struct.
+   - Options: `--id` (message ID), `--index` (optional int), `--dest-dir` (optional string, default `~/.openclaw/workspace/mail-attachments/`), `--mailbox`, `--account`
+   - JXA: reuse `findMessageJXA`, then `Mail.save(att, {in: Path(destPath)})` for each target attachment
+   - Filename sanitization: strip path separators, null bytes. Keep the original name otherwise.
+   - Dedup: if file exists, append `_1`, `_2`, etc. before the extension.
+
+4. **MIME type helper** (shared): try/catch wrapper around `att.mimeType()` with extension-based fallback map.
+
+5. **Register `SaveAttachment`** in the `MailCLI` subcommands array.
+
+### JS handler (`lib/handlers/mail.js`)
+
+Add `save_attachment` case to the switch:
+
+```javascript
+case "save_attachment": {
+  if (!args.id) throw new Error("Message ID required");
+  const saveArgs = ["save-attachment", "--id", args.id];
+  if (args.index !== undefined) saveArgs.push("--index", String(args.index));
+  if (args.destDir) saveArgs.push("--dest-dir", args.destDir);
+  if (args.mailbox) saveArgs.push("--mailbox", args.mailbox);
+  if (args.account) saveArgs.push("--account", args.account);
+  return await runCLI("mail-cli", saveArgs);
+}
+```
+
+### Schema (`lib/schemas.js`)
+
+Add `save-attachment` to the mail tool's action enum. Add `index` (integer, optional) and `destDir` (string, optional) to the mail input schema.
+
+### OpenClaw plugin (`openclaw/src/index.ts`)
+
+No changes needed. The plugin delegates to the handler, which delegates to the CLI. The new action flows through automatically.
+
+## What NOT to build
+
+- No inline attachment content in `get` responses (binary data doesn't belong in JSON tool output).
+- No attachment upload/compose (sending attachments is a separate feature).
+- No streaming/partial download for large attachments.
+- No attachment preview/thumbnail generation.
+
+## Testing
+
+1. Send an email with a text attachment (.md, .txt) -> verify `get` shows attachment metadata, `save-attachment` extracts it
+2. Send an email with a binary attachment (.pdf, .png) -> same verification
+3. Send an email with multiple attachments -> verify `save-attachment` without `--index` saves all, with `--index` saves one
+4. Message with no attachments -> verify `attachments: []` in get, `save-attachment` returns clean error
+5. Filename collision -> verify dedup counter works
+6. MIME type fallback -> verify extension-based inference when `mimeType()` throws

--- a/specs/send-attachments.md
+++ b/specs/send-attachments.md
@@ -1,0 +1,172 @@
+# Send Attachments Spec
+
+Add attachment support to the `send` and `reply` subcommands in mail-cli.
+
+## Verified AppleScript Pattern
+
+Tested and confirmed working on macOS 15 / Mail.app:
+
+```applescript
+tell application "Mail"
+    set newMessage to make new outgoing message with properties {subject:"test", visible:false}
+    tell newMessage
+        make new to recipient at end of to recipients with properties {address:"recipient@example.com"}
+    end tell
+    set content of newMessage to "body text"
+    tell newMessage
+        make new attachment with properties {file name:"/path/to/file.pdf"} at after the last paragraph
+        make new attachment with properties {file name:"/path/to/other.txt"} at after the last paragraph
+    end tell
+    send newMessage
+end tell
+```
+
+Key ordering: set `content` BEFORE adding attachments (attachments go `at after the last paragraph`). Multiple attachments work by repeating the `make new attachment` line.
+
+## Changes
+
+### 1. Swift CLI: `SendMessage` struct (MailCLI.swift ~line 1284)
+
+Add a new option:
+
+```swift
+@Option(name: .long, help: "File path to attach (repeatable)")
+var attachment: [String] = []
+```
+
+In the `run()` method, after the existing `set content of newMessage to bodyText` line, add attachment lines to the AppleScript:
+
+```swift
+var attachmentLines = ""
+for filePath in attachment {
+    // Validate file exists before building the script
+    let expandedPath = (filePath as NSString).expandingTildeInPath
+    guard FileManager.default.fileExists(atPath: expandedPath) else {
+        throw CLIError.invalidInput("Attachment file not found: \(filePath)")
+    }
+    attachmentLines += "\n        make new attachment with properties {file name:\"\(escapeForAppleScript(expandedPath))\"} at after the last paragraph"
+}
+```
+
+The AppleScript template becomes:
+
+```applescript
+set bodyText to read POSIX file "{bodyFile.path}" as «class utf8»
+tell application "Mail"
+    set newMessage to make new outgoing message with properties {subject:"{escapedSubject}", visible:false{senderProp}}
+    tell newMessage{recipientLines}
+    end tell
+    set content of newMessage to bodyText
+    tell newMessage{attachmentLines}
+    end tell
+    send newMessage
+end tell
+```
+
+Note: the `tell newMessage{attachmentLines}\nend tell` block should only be emitted when `attachmentLines` is non-empty. When there are no attachments, the script stays identical to today.
+
+Update the success output to include attachment info:
+
+```swift
+var result: [String: Any] = [
+    "success": true,
+    "message": "Email sent successfully",
+    "to": to,
+    "subject": subject
+]
+if !attachment.isEmpty {
+    result["attachments"] = attachment.map { ($0 as NSString).expandingTildeInPath }
+}
+outputJSON(result)
+```
+
+### 2. Swift CLI: `ReplyMessage` struct (MailCLI.swift ~line 1364)
+
+Same pattern. Add:
+
+```swift
+@Option(name: .long, help: "File path to attach (repeatable)")
+var attachment: [String] = []
+```
+
+In the `run()` method, after `set content of replyMsg to replyBody & return & return & content of replyMsg`, add the attachment block before `send replyMsg`:
+
+```swift
+var attachmentLines = ""
+for filePath in attachment {
+    let expandedPath = (filePath as NSString).expandingTildeInPath
+    guard FileManager.default.fileExists(atPath: expandedPath) else {
+        throw CLIError.invalidInput("Attachment file not found: \(filePath)")
+    }
+    attachmentLines += "\n        make new attachment with properties {file name:\"\(escapeForAppleScript(expandedPath))\"} at after the last paragraph"
+}
+```
+
+Insert the `tell replyMsg{attachmentLines}\nend tell` block (if non-empty) between the content assignment and the `send replyMsg` line.
+
+### 3. JS Handler: `lib/handlers/mail.js`
+
+In the `send` case (~line 120), after the existing `bcc` handling:
+
+```javascript
+if (args.attachment) {
+  const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+  for (const filePath of attachments) sendArgs.push("--attachment", filePath);
+}
+```
+
+In the `reply` case (~line 138), add the same block after the existing `account` handling:
+
+```javascript
+if (args.attachment) {
+  const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+  for (const filePath of attachments) replyArgs.push("--attachment", filePath);
+}
+```
+
+### 4. Schema: `lib/schemas.js`
+
+Add to the mail tool's properties (after the existing `bcc` property):
+
+```javascript
+attachment: {
+  oneOf: [
+    { type: "string" },
+    { type: "array", items: { type: "string" } }
+  ],
+  description: "File path(s) to attach (send/reply). Accepts a single path or array of paths."
+},
+```
+
+Update the mail tool description to mention attachment support:
+
+```javascript
+"Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list with attachmentCount), get (full message by ID with attachment metadata), search, update (flags), move, delete, batch_update, batch_delete, send (with optional attachments), reply (with optional attachments), save_attachment (save message attachments to disk), auth_check, schema (show input schema)."
+```
+
+### 5. OpenClaw plugin: No changes needed
+
+The plugin delegates to the handler which delegates to the CLI. The new parameter flows through automatically.
+
+## Error Cases
+
+- File not found: validated in Swift before building the AppleScript. Throws `CLIError.invalidInput("Attachment file not found: /path/to/file")`.
+- File not readable (permissions): Mail.app will throw an AppleScript error. The existing error handling will surface it.
+- Empty attachment array: no-op, script is identical to today.
+
+## What NOT to Build
+
+- No inline/base64 attachment content (always file paths on disk).
+- No URL-based attachments (must be local files).
+- No attachment size limits (Mail.app handles that).
+- No HTML body support (separate feature).
+
+## Testing
+
+1. `send` with single `--attachment /path/to/file.txt` — verify email arrives with attachment
+2. `send` with multiple `--attachment` flags — verify all attachments present
+3. `send` with nonexistent file path — verify clean error before sending
+4. `send` without `--attachment` — verify no regression, identical behavior to today
+5. `reply` with `--attachment` — verify attachment on reply
+6. Agent call with `attachment: "/path/to/file"` (string) — verify handler normalizes
+7. Agent call with `attachment: ["/path/to/a", "/path/to/b"]` (array) — verify handler passes multiple flags

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -1254,6 +1254,9 @@ struct SendMessage: AsyncParsableCommand {
     @Option(name: .long, help: "Sender email address (selects account)")
     var from: String?
 
+    @Option(name: .long, help: "File path to attach (repeatable)")
+    var attachment: [String] = []
+
     func run() async throws {
         try ensureMailRunning()
         let config = pimOptions.loadConfig()
@@ -1261,6 +1264,16 @@ struct SendMessage: AsyncParsableCommand {
 
         guard !to.isEmpty else {
             throw CLIError.invalidInput("At least one --to recipient is required")
+        }
+
+        // Validate attachment files exist before building the script
+        var attachmentLines = ""
+        for filePath in attachment {
+            let expandedPath = (filePath as NSString).expandingTildeInPath
+            guard FileManager.default.fileExists(atPath: expandedPath) else {
+                throw CLIError.invalidInput("Attachment file not found: \(filePath)")
+            }
+            attachmentLines += "\n        make new attachment with properties {file name:\"\(escapeForAppleScript(expandedPath))\"} at after the last paragraph"
         }
 
         // Write body to temp file to avoid AppleScript escaping issues
@@ -1283,25 +1296,35 @@ struct SendMessage: AsyncParsableCommand {
         let escapedSubject = escapeForAppleScript(subject)
         let senderProp = from.map { ", sender:\"\(escapeForAppleScript($0))\"" } ?? ""
 
+        let attachmentBlock = attachmentLines.isEmpty ? "" : """
+
+            tell newMessage\(attachmentLines)
+            end tell
+        """
+
         let script = """
         set bodyText to read POSIX file "\(bodyFile.path)" as «class utf8»
         tell application "Mail"
             set newMessage to make new outgoing message with properties {subject:"\(escapedSubject)", visible:false\(senderProp)}
             tell newMessage\(recipientLines)
             end tell
-            set content of newMessage to bodyText
+            set content of newMessage to bodyText\(attachmentBlock)
             send newMessage
         end tell
         """
 
         _ = try runAppleScript(script)
 
-        outputJSON([
+        var result: [String: Any] = [
             "success": true,
             "message": "Email sent successfully",
             "to": to,
             "subject": subject
-        ])
+        ]
+        if !attachment.isEmpty {
+            result["attachments"] = attachment.map { ($0 as NSString).expandingTildeInPath }
+        }
+        outputJSON(result)
     }
 }
 
@@ -1325,10 +1348,23 @@ struct ReplyMessage: AsyncParsableCommand {
     @Option(name: .long, help: "Account name hint (speeds up lookup)")
     var account: String?
 
+    @Option(name: .long, help: "File path to attach (repeatable)")
+    var attachment: [String] = []
+
     func run() async throws {
         try ensureMailRunning()
         let config = pimOptions.loadConfig()
         try checkMailEnabled(config: config)
+
+        // Validate attachment files exist before building the script
+        var attachmentLines = ""
+        for filePath in attachment {
+            let expandedPath = (filePath as NSString).expandingTildeInPath
+            guard FileManager.default.fileExists(atPath: expandedPath) else {
+                throw CLIError.invalidInput("Attachment file not found: \(filePath)")
+            }
+            attachmentLines += "\n        make new attachment with properties {file name:\"\(escapeForAppleScript(expandedPath))\"} at after the last paragraph"
+        }
 
         // Step 1: Use JXA to find the message by RFC 2822 messageId and get its numeric Apple Mail ID
         let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
@@ -1373,24 +1409,34 @@ struct ReplyMessage: AsyncParsableCommand {
         let escapedAccount = escapeForAppleScript(accountName)
         let escapedMailbox = escapeForAppleScript(mailboxName)
 
+        let attachmentBlock = attachmentLines.isEmpty ? "" : """
+
+            tell replyMsg\(attachmentLines)
+            end tell
+        """
+
         let replyScript = """
         set replyBody to read POSIX file "\(bodyFile.path)" as «class utf8»
         tell application "Mail"
             set origMsg to first message of mailbox "\(escapedMailbox)" of account "\(escapedAccount)" whose id is \(appleMailId)
             set replyMsg to reply origMsg with opening window
-            set content of replyMsg to replyBody & return & return & content of replyMsg
+            set content of replyMsg to replyBody & return & return & content of replyMsg\(attachmentBlock)
             send replyMsg
         end tell
         """
 
         _ = try runAppleScript(replyScript)
 
-        outputJSON([
+        var result: [String: Any] = [
             "success": true,
             "message": "Reply sent successfully",
             "inReplyTo": id,
             "originalSubject": dict["subject"] ?? ""
-        ])
+        ]
+        if !attachment.isEmpty {
+            result["attachments"] = attachment.map { ($0 as NSString).expandingTildeInPath }
+        }
+        outputJSON(result)
     }
 }
 


### PR DESCRIPTION
Adds `--attachment` (repeatable) to both `send` and `reply` actions.

**Background:** The original schema used `oneOf` for the attachment parameter. The OpenClaw gateway silently drops `oneOf` types during tool registration, so `args.attachment` was always undefined. Changed to plain `{ type: "array", items: { type: "string" } }` and it works.

**Swift CLI:** Both `SendMessage` and `ReplyMessage` accept repeatable `--attachment` flags. File existence is validated before building the AppleScript. Attachments are injected via `make new attachment with properties {file name:...}` after setting message content.

**JS handler:** Also validates file existence with tilde expansion before passing to CLI — provides clear error messages at the agent layer instead of cryptic AppleScript failures.

Dry-run descriptions now include attachment count. Response includes expanded paths on success. Evals cover single/multiple/missing attachment paths for both send and reply.

> **Note:** The `mcp-server/dist/server.js` diff includes upstream dependency changes from a clean esbuild rebuild (mailparser, ajv). These are not part of this feature — upstream can rebuild the bundle independently.
>
> This PR has minor merge conflicts with #44 (attachment receive) in `lib/schemas.js`, `lib/dry-run.js`, and `evals/tests/tool-call-correctness.test.js` — both touch adjacent lines. Each PR is self-contained; conflicts are straightforward to resolve when both are merged.