### PR TITLE
feat: configurable calendar date output format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Each Swift CLI is a standalone binary that reads from macOS frameworks, validate
 - The MCP server does NOT do any config filtering — it passes `--profile` to CLIs when set.
 - **OpenClaw plugin** (`openclaw/`): Registers tools that spawn CLIs directly (no MCP). Supports per-call `configDir`/`profile` parameters for multi-agent workspace isolation. See [`docs/multi-agent-setup.md`](docs/multi-agent-setup.md).
 - **Direct CLI usage:** `APPLE_PIM_CONFIG_DIR` overrides the config root directory; `APPLE_PIM_PROFILE` selects a profile.
+- **Date format:** `APPLE_PIM_DATE_FORMAT` selects calendar date output format. Presets: `utc` (default, `2026-03-20T14:00:00Z`), `local` (`2026-03-20T07:00:00-07:00`), `day-utc` (`Friday, 2026-03-20T14:00:00Z`), `day-local` (`Friday, 2026-03-20T07:00:00-07:00`). CalendarCLI only.
 
 ## Testing Notes
 

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -96,6 +96,36 @@ func outputJSON(_ value: Any) {
     }
 }
 
+/// Format a date as ISO 8601 using the preset selected by APPLE_PIM_DATE_FORMAT.
+///
+/// Presets: utc (default), local, day-utc, day-local.
+func formatDate(_ date: Date) -> String {
+    let preset = (ProcessInfo.processInfo.environment["APPLE_PIM_DATE_FORMAT"] ?? "utc").lowercased()
+
+    let useLocal = preset == "local" || preset == "day-local"
+    let useDay = preset == "day-utc" || preset == "day-local"
+
+    let iso: String
+    if useLocal {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd'T'HH:mm:ssxxxxx"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        iso = fmt.string(from: date)
+    } else {
+        iso = ISO8601DateFormatter().string(from: date)
+    }
+
+    if useDay {
+        let dayFmt = DateFormatter()
+        dayFmt.dateFormat = "EEEE"
+        dayFmt.locale = Locale(identifier: "en_US_POSIX")
+        dayFmt.timeZone = useLocal ? TimeZone.current : TimeZone(identifier: "UTC")!
+        return "\(dayFmt.string(from: date)), \(iso)"
+    }
+
+    return iso
+}
+
 func parseDate(_ string: String) -> Date? {
     // Handle relative dates first
     let lowercased = string.lowercased()
@@ -186,8 +216,8 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
     var dict: [String: Any] = [
         "id": event.eventIdentifier ?? "",
         "title": event.title ?? "",
-        "startDate": ISO8601DateFormatter().string(from: event.startDate),
-        "endDate": ISO8601DateFormatter().string(from: event.endDate),
+        "startDate": formatDate(event.startDate),
+        "endDate": formatDate(event.endDate),
         "isAllDay": event.isAllDay,
         "calendar": event.calendar?.title ?? "",
         "calendarId": event.calendar?.calendarIdentifier ?? ""
@@ -222,7 +252,7 @@ func ruleToDict(_ rule: EKRecurrenceRule) -> [String: Any] {
     ]
     if let end = rule.recurrenceEnd {
         if let endDate = end.endDate {
-            dict["endDate"] = ISO8601DateFormatter().string(from: endDate)
+            dict["endDate"] = formatDate(endDate)
         } else {
             dict["occurrenceCount"] = end.occurrenceCount
         }
@@ -291,9 +321,8 @@ func participantRoleString(_ role: EKParticipantRole) -> String {
 /// Build a verification dict comparing requested inputs against stored event values.
 /// Gives calling agents an immediate signal if date parsing produced wrong times.
 func buildVerification(event: EKEvent, requestedStart: String, requestedEnd: String?, requestedCalendar: String?) -> [String: Any] {
-    let isoFmt = ISO8601DateFormatter()
-    let storedStart = isoFmt.string(from: event.startDate)
-    let storedEnd = isoFmt.string(from: event.endDate)
+    let storedStart = formatDate(event.startDate)
+    let storedEnd = formatDate(event.endDate)
 
     // Re-parse the requested strings to compare as Date values (tolerating 1s for rounding)
     let startMatch: Bool
@@ -569,8 +598,8 @@ struct ListEvents: AsyncParsableCommand {
             "events": Array(events),
             "count": events.count,
             "dateRange": [
-                "from": ISO8601DateFormatter().string(from: startDate),
-                "to": ISO8601DateFormatter().string(from: endDate)
+                "from": formatDate(startDate),
+                "to": formatDate(endDate)
             ]
         ])
     }

--- a/swift/Tests/CalendarCLITests/DateParsingTests.swift
+++ b/swift/Tests/CalendarCLITests/DateParsingTests.swift
@@ -104,4 +104,63 @@ final class DateParsingTests: XCTestCase {
         XCTAssertEqual(result, "2026-03-16T04:00:00Z",
             "9 PM PDT should be 4 AM UTC next day")
     }
+
+    // MARK: - formatDate presets (APPLE_PIM_DATE_FORMAT)
+
+    private func clearDateEnv() {
+        unsetenv("APPLE_PIM_DATE_FORMAT")
+    }
+
+    func testFormatDateDefaultUTC() {
+        clearDateEnv()
+        let date = ISO8601DateFormatter().date(from: "2026-03-20T14:00:00Z")!
+        XCTAssertEqual(formatDate(date), "2026-03-20T14:00:00Z")
+    }
+
+    func testFormatDateLocal() {
+        clearDateEnv()
+        setenv("APPLE_PIM_DATE_FORMAT", "local", 1)
+        defer { clearDateEnv() }
+
+        let date = ISO8601DateFormatter().date(from: "2026-03-20T14:00:00Z")!
+        let result = formatDate(date)
+        // Must contain T separator, must NOT end with Z, must have offset like +/-HH:MM
+        XCTAssertTrue(result.contains("T"), "Local format should contain T separator")
+        XCTAssertFalse(result.hasSuffix("Z"), "Local format should not end with Z")
+        XCTAssertTrue(result.contains("+") || result.contains("-"),
+            "Local format should include timezone offset")
+    }
+
+    func testFormatDateDayUTC() {
+        clearDateEnv()
+        setenv("APPLE_PIM_DATE_FORMAT", "day-utc", 1)
+        defer { clearDateEnv() }
+
+        let date = ISO8601DateFormatter().date(from: "2026-03-20T14:00:00Z")!
+        XCTAssertEqual(formatDate(date), "Friday, 2026-03-20T14:00:00Z")
+    }
+
+    func testFormatDateDayLocal() {
+        clearDateEnv()
+        setenv("APPLE_PIM_DATE_FORMAT", "day-local", 1)
+        defer { clearDateEnv() }
+
+        let date = ISO8601DateFormatter().date(from: "2026-03-20T14:00:00Z")!
+        let result = formatDate(date)
+        XCTAssertTrue(result.hasPrefix("Friday,"), "day-local should start with day name")
+        XCTAssertFalse(result.hasSuffix("Z"), "day-local should not end with Z")
+        XCTAssertTrue(result.contains("+") || result.contains("-"),
+            "day-local should include timezone offset")
+    }
+
+    func testFormatDateUnknownPreset() {
+        clearDateEnv()
+        setenv("APPLE_PIM_DATE_FORMAT", "bogus", 1)
+        defer { clearDateEnv() }
+
+        let date = ISO8601DateFormatter().date(from: "2026-03-20T14:00:00Z")!
+        XCTAssertEqual(formatDate(date), "2026-03-20T14:00:00Z",
+            "Unknown preset should fall back to UTC")
+    }
+
 }


### PR DESCRIPTION
Adds `APPLE_PIM_DATE_FORMAT` env var to control how CalendarCLI formats dates in JSON output. Four presets:

| Preset | Example |
|--------|---------|
| `utc` (default) | `2026-03-20T14:00:00Z` |
| `local` | `2026-03-20T07:00:00-07:00` |
| `day-utc` | `Friday, 2026-03-20T14:00:00Z` |
| `day-local` | `Friday, 2026-03-20T07:00:00-07:00` |

**Why:** LLM agents waste tokens computing day-of-week from raw ISO dates when reasoning about scheduling. The `day-*` presets surface this directly. The `local` presets show the user's actual timezone instead of forcing UTC mental math.

**Implementation:** Single `formatDate(_:)` helper replaces all 7 `ISO8601DateFormatter().string()` output calls in CalendarCLI. Day name timezone always matches the ISO portion (UTC for `day-utc`, local for `day-local`) to avoid midnight-boundary mismatches. Unknown preset values fall back to `utc`. No env var = current behavior unchanged.

**Scope:** CalendarCLI only. No JS handler changes needed (dates pass through as strings). No MCP/OpenClaw plumbing needed (env var inherited by subprocess automatically). ReminderCLI uses a different date codepath (`DateComponents`-based) and is out of scope.

| File | Change |
|------|--------|
| `swift/Sources/CalendarCLI/CalendarCLI.swift` | Add `formatDate()` helper, replace 7 output call sites |
| `swift/Tests/CalendarCLITests/DateParsingTests.swift` | 5 new tests (all presets + unknown fallback) |
| `CLAUDE.md` | Document `APPLE_PIM_DATE_FORMAT` in Configuration section |

180 agent eval tests passing.