### PR TITLE
fix: date-only --to values resolve to end-of-day

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Each Swift CLI is a standalone binary that reads from macOS frameworks, validate
 - Full EventKit/Contacts/Mail integration paths can require local TCC permissions and Mail.app running.
 - **Agent evals** (`evals/`) test the tool layer from the agent's perspective: argument correctness, response interpretation, multi-turn workflows, and safety properties. All evals run against mock CLI fixtures (zero TCC, no real data). Run with `npm run eval` from repo root.
 - To add new eval cases, edit the YAML files in `evals/scenarios/` and add fixture JSON in `evals/fixtures/` as needed. No test code changes required for new cases in existing categories.
+- **Calendar reasoning evals** (`tests/calendar-reasoning.test.js`) are model-in-the-loop: they call `claude -p` with fixtures and grade responses with an LLM judge. They require `ANTHROPIC_API_KEY` in the environment. A full run of 8 scenarios costs ~$2.31 and takes ~8 minutes. These are non-deterministic and may flake on edge-case reasoning.
 
 ## CI And PR Workflow
 

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -77374,7 +77374,7 @@ var agentDXProperties = {
   fields: {
     type: "array",
     items: { type: "string" },
-    description: `Limit returned fields to these keys (e.g., ["id", "title", "start"]). Reduces token usage. The 'id' field is always included.`
+    description: `Limit returned fields to these keys (e.g., ["id", "title", "start"]). Reduces token usage. The 'id' field is always included. Requesting 'start'/'startDate' auto-includes 'localStart'; requesting 'end'/'endDate' auto-includes 'localEnd'.`
   },
   dryRun: {
     type: "boolean",
@@ -77788,6 +77788,10 @@ function pickFields(obj, fields) {
     return obj;
   const fieldSet = new Set(fields);
   fieldSet.add("id");
+  if (fieldSet.has("start") || fieldSet.has("startDate"))
+    fieldSet.add("localStart");
+  if (fieldSet.has("end") || fieldSet.has("endDate"))
+    fieldSet.add("localEnd");
   const picked = {};
   for (const key of Object.keys(obj)) {
     if (fieldSet.has(key)) {
@@ -77803,6 +77807,12 @@ function applyFieldSelection(result, fields) {
   if (!result || typeof result !== "object") {
     return result;
   }
+  const fieldSet = new Set(fields);
+  fieldSet.add("id");
+  if (fieldSet.has("start") || fieldSet.has("startDate"))
+    fieldSet.add("localStart");
+  if (fieldSet.has("end") || fieldSet.has("endDate"))
+    fieldSet.add("localEnd");
   const filtered = {};
   for (const [key, value] of Object.entries(result)) {
     if (WRAPPER_KEYS.has(key) && Array.isArray(value)) {
@@ -77810,7 +77820,7 @@ function applyFieldSelection(result, fields) {
     } else if (WRAPPER_KEYS.has(key)) {
       filtered[key] = value;
     } else {
-      if (fields.includes(key) || key === "id") {
+      if (fieldSet.has(key)) {
         filtered[key] = value;
       }
     }

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -96,23 +96,18 @@ func outputJSON(_ value: Any) {
     }
 }
 
+private let dateOnlyISO = try! NSRegularExpression(pattern: #"^\d{4}-\d{2}-\d{2}$"#)
+private let dateOnlyUS  = try! NSRegularExpression(pattern: #"^\d{2}/\d{2}/\d{4}$"#)
+
 /// Returns true if the string represents a date without an explicit time component.
 /// Used to decide whether an end-date should be pushed to end-of-day (23:59:59).
 func isDateOnly(_ string: String) -> Bool {
     let trimmed = string.trimmingCharacters(in: .whitespaces)
     let lowercased = trimmed.lowercased()
-    // Relative day names are date-only
     if ["today", "tomorrow", "yesterday"].contains(lowercased) { return true }
-    // yyyy-MM-dd or MM/dd/yyyy without any time portion
-    let dateOnlyPatterns = [
-        #"^\d{4}-\d{2}-\d{2}$"#,
-        #"^\d{2}/\d{2}/\d{4}$"#,
-    ]
-    return dateOnlyPatterns.contains { pattern in
-        (try? NSRegularExpression(pattern: pattern))?.firstMatch(
-            in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed)
-        ) != nil
-    }
+    let range = NSRange(trimmed.startIndex..., in: trimmed)
+    return dateOnlyISO.firstMatch(in: trimmed, range: range) != nil
+        || dateOnlyUS.firstMatch(in: trimmed, range: range) != nil
 }
 
 /// Adjusts a date to end-of-day (23:59:59) when the original string had no time component.

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -96,6 +96,36 @@ func outputJSON(_ value: Any) {
     }
 }
 
+/// Returns true if the string represents a date without an explicit time component.
+/// Used to decide whether an end-date should be pushed to end-of-day (23:59:59).
+func isDateOnly(_ string: String) -> Bool {
+    let trimmed = string.trimmingCharacters(in: .whitespaces)
+    let lowercased = trimmed.lowercased()
+    // Relative day names are date-only
+    if ["today", "tomorrow", "yesterday"].contains(lowercased) { return true }
+    // yyyy-MM-dd or MM/dd/yyyy without any time portion
+    let dateOnlyPatterns = [
+        #"^\d{4}-\d{2}-\d{2}$"#,
+        #"^\d{2}/\d{2}/\d{4}$"#,
+    ]
+    return dateOnlyPatterns.contains { pattern in
+        (try? NSRegularExpression(pattern: pattern))?.firstMatch(
+            in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed)
+        ) != nil
+    }
+}
+
+/// Adjusts a date to end-of-day (23:59:59) when the original string had no time component.
+/// This ensures `--from today --to today` spans the full day instead of a zero-width range.
+func adjustToEndOfDay(_ date: Date, originalString: String) -> Date {
+    guard isDateOnly(originalString) else { return date }
+    var components = Calendar.current.dateComponents([.year, .month, .day], from: date)
+    components.hour = 23
+    components.minute = 59
+    components.second = 59
+    return Calendar.current.date(from: components) ?? date
+}
+
 func parseDate(_ string: String) -> Date? {
     // Handle relative dates first
     let lowercased = string.lowercased()
@@ -554,7 +584,7 @@ struct ListEvents: AsyncParsableCommand {
             guard let parsed = parseDate(toStr) else {
                 throw CLIError.invalidInput("Invalid end date: \(toStr)")
             }
-            endDate = parsed
+            endDate = adjustToEndOfDay(parsed, originalString: toStr)
         } else {
             endDate = Calendar.current.date(byAdding: .day, value: 7, to: startDate) ?? startDate
         }
@@ -644,7 +674,12 @@ struct SearchEvents: AsyncParsableCommand {
         let config = pimOptions.loadConfig()
 
         let startDate = from.flatMap { parseDate($0) } ?? Calendar.current.date(byAdding: .day, value: -30, to: Date())!
-        let endDate = to.flatMap { parseDate($0) } ?? Calendar.current.date(byAdding: .year, value: 1, to: Date())!
+        let endDate: Date
+        if let toStr = to, let parsed = parseDate(toStr) {
+            endDate = adjustToEndOfDay(parsed, originalString: toStr)
+        } else {
+            endDate = Calendar.current.date(byAdding: .year, value: 1, to: Date())!
+        }
 
         // Resolve calendars: explicit filter > all allowed calendars
         var calendars: [EKCalendar]?

--- a/swift/Tests/CalendarCLITests/DateParsingTests.swift
+++ b/swift/Tests/CalendarCLITests/DateParsingTests.swift
@@ -91,6 +91,57 @@ final class DateParsingTests: XCTestCase {
         XCTAssertNotNil(date)
     }
 
+    // MARK: - isDateOnly detection
+
+    func testIsDateOnlyRelativeNames() {
+        XCTAssertTrue(isDateOnly("today"))
+        XCTAssertTrue(isDateOnly("Tomorrow"))
+        XCTAssertTrue(isDateOnly("yesterday"))
+    }
+
+    func testIsDateOnlyISODate() {
+        XCTAssertTrue(isDateOnly("2026-03-15"))
+        XCTAssertTrue(isDateOnly("2026-12-01"))
+    }
+
+    func testIsDateOnlyUSDate() {
+        XCTAssertTrue(isDateOnly("03/15/2026"))
+    }
+
+    func testIsDateOnlyFalseForDateTimes() {
+        XCTAssertFalse(isDateOnly("2026-03-15T13:30:00"))
+        XCTAssertFalse(isDateOnly("2026-03-15T13:30:00-07:00"))
+        XCTAssertFalse(isDateOnly("2026-03-15 13:30"))
+        XCTAssertFalse(isDateOnly("03/15/2026 13:30"))
+        XCTAssertFalse(isDateOnly("next week"))
+    }
+
+    // MARK: - adjustToEndOfDay
+
+    func testAdjustToEndOfDayForDateOnlyString() {
+        let date = parseDate("2026-03-15")!
+        let adjusted = adjustToEndOfDay(date, originalString: "2026-03-15")
+        let comps = Calendar.current.dateComponents([.hour, .minute, .second], from: adjusted)
+        XCTAssertEqual(comps.hour, 23)
+        XCTAssertEqual(comps.minute, 59)
+        XCTAssertEqual(comps.second, 59)
+    }
+
+    func testAdjustToEndOfDayForToday() {
+        let date = parseDate("today")!
+        let adjusted = adjustToEndOfDay(date, originalString: "today")
+        let comps = Calendar.current.dateComponents([.hour, .minute, .second], from: adjusted)
+        XCTAssertEqual(comps.hour, 23)
+        XCTAssertEqual(comps.minute, 59)
+        XCTAssertEqual(comps.second, 59)
+    }
+
+    func testAdjustToEndOfDayNoOpForDateTime() {
+        let date = parseDate("2026-03-15T13:30:00")!
+        let adjusted = adjustToEndOfDay(date, originalString: "2026-03-15T13:30:00")
+        XCTAssertEqual(date, adjusted, "Should not adjust when time is explicit")
+    }
+
     // MARK: - Precision: offset dates should NOT lose time component
 
     func testOffsetDatePreservesExactTime() {


### PR DESCRIPTION
## Summary

- **Fixes empty results when querying `--from today --to today`** — both dates were resolving to midnight (00:00:00), creating a zero-width range. Now date-only `--to` values are adjusted to 23:59:59.
- Adds `isDateOnly()` and `adjustToEndOfDay()` helpers to CalendarCLI, applied in both `ListEvents` and `SearchEvents` commands.
- Adds 7 unit tests covering the new helpers.
- Rebuilds `mcp-server/dist/server.js` to include local time field auto-inclusion from a3bf3e6.

Addresses user feedback from #38 (cc @matthieugomez).

## Test plan

- [x] All 76 XCTest + 53 Swift Testing tests pass (`swift test`)
- [x] All 41 MCP server tests pass (`npm test` in mcp-server/)
- [x] 125 deterministic agent evals pass
- [ ] Manual verification: `calendar-cli events --from today --to today` returns today's events

🤖 Generated with [Claude Code](https://claude.com/claude-code)