### PR TITLE
fix(openclaw): provide static names for factory-registered tools

### DIFF
--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -160,7 +160,9 @@ export default definePluginEntry({
 
       if (!openclawName || !handler) continue;
 
-      // Register as factory for per-workspace context resolution
+      // Register as factory for per-workspace context resolution.
+      // Pass the stable tool name explicitly so `openclaw plugins inspect`
+      // can render names for factory-registered tools instead of `(anonymous)`.
       api.registerTool((ctx) => {
         const workspaceDir = ctx.workspaceDir;
 
@@ -207,7 +209,7 @@ export default definePluginEntry({
             }
           },
         };
-      });
+      }, { name: openclawName });
     }
   },
 });


### PR DESCRIPTION
Pass the stable tool name as registerTool() metadata so `openclaw plugins inspect` can display tool names instead of anonymous entries while preserving workspace-aware factory registration.

Before:

```
% openclaw plugins inspect apple-pim-cli

🦞 OpenClaw 2026.4.5 (3e72c03) — Give me a workspace and I'll give you fewer tabs, fewer toggles, and more oxygen.

Apple PIM
id: apple-pim-cli
macOS Calendar, Reminders, Contacts, and Mail via native Swift CLIs

Status: loaded
Format: openclaw
Source: ~/src/github.com--omarshahine--Apple-PIM-Agent-Plugin/openclaw/src/index.ts
Origin: config
Version: 3.4.2
Shape: non-capability
Capability mode: none
Legacy before_agent_start: no

Tools:
(anonymous)
(anonymous)
(anonymous)
(anonymous)
(anonymous)

Install:
Source: path
Source path: ~/src/github.com--omarshahine--Apple-PIM-Agent-Plugin/openclaw
Install path: ~/src/github.com--omarshahine--Apple-PIM-Agent-Plugin/openclaw
Recorded version: 3.4.1
Installed at: 2026-04-10T16:23:05.609Z
```

After:

```
% openclaw plugins inspect apple-pim-cli

🦞 OpenClaw 2026.4.5 (3e72c03) — I can grep it, git blame it, and gently roast it—pick your coping mechanism.

Apple PIM
id: apple-pim-cli
macOS Calendar, Reminders, Contacts, and Mail via native Swift CLIs

Status: loaded
Format: openclaw
Source: ~/src/github.com--omarshahine--Apple-PIM-Agent-Plugin/openclaw/src/index.ts
Origin: config
Version: 3.4.2
Shape: non-capability
Capability mode: none
Legacy before_agent_start: no

Tools:
apple_pim_calendar
apple_pim_reminder
apple_pim_contact
apple_pim_mail
apple_pim_system

Install:
Source: path
Source path: ~/src/github.com--omarshahine--Apple-PIM-Agent-Plugin/openclaw
Install path: ~/src/github.com--omarshahine--Apple-PIM-Agent-Plugin/openclaw
Recorded version: 3.4.1
Installed at: 2026-04-10T16:23:05.609Z
```