### PR TITLE
feat: add mail attachment support (receive, save, send, reply)

### DIFF
--- a/evals/fixtures/mail/get-with-attachments.json
+++ b/evals/fixtures/mail/get-with-attachments.json
@@ -1,0 +1,43 @@
+{
+  "success": true,
+  "message": {
+    "messageId": "msg-att@example.com",
+    "subject": "Q1 Report with Attachments",
+    "sender": "colleague@example.com",
+    "dateReceived": "2026-03-15T14:30:00-07:00",
+    "dateSent": "2026-03-15T14:29:45-07:00",
+    "isRead": true,
+    "isFlagged": false,
+    "isJunk": false,
+    "replyTo": "",
+    "mailbox": "INBOX",
+    "account": "Google",
+    "content": "Hi, please find the Q1 report and supporting data attached.",
+    "to": [{ "name": "Joe", "address": "joe@example.com" }],
+    "cc": [],
+    "attachments": [
+      {
+        "index": 0,
+        "name": "q1-report.pdf",
+        "fileSize": 245760,
+        "downloaded": true,
+        "mimeType": "application/pdf"
+      },
+      {
+        "index": 1,
+        "name": "data.xlsx",
+        "fileSize": 51200,
+        "downloaded": true,
+        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      },
+      {
+        "index": 2,
+        "name": "notes.md",
+        "fileSize": 1024,
+        "downloaded": true,
+        "mimeType": "text/markdown"
+      }
+    ],
+    "attachmentCount": 3
+  }
+}

--- a/evals/scenarios/safety.yaml
+++ b/evals/scenarios/safety.yaml
@@ -70,7 +70,7 @@ id_required_actions:
     error_pattern: "ID is required"
 
   - tool: mail
-    actions: [get, update, move, delete, reply, auth_check]
+    actions: [get, update, move, delete, reply, save_attachment, auth_check]
     error_pattern: "ID is required"
 
 # Actions that delegate to buildArgs without ID validation (schema-enforced only):

--- a/evals/tests/safety.test.js
+++ b/evals/tests/safety.test.js
@@ -137,7 +137,7 @@ describe("Category 4: Safety Properties", () => {
       const covered = new Set([
         "accounts", "mailboxes", "messages", "get", "search",
         "update", "move", "delete", "batch_update", "batch_delete",
-        "send", "reply", "auth_check", "schema",
+        "send", "reply", "save_attachment", "auth_check", "schema",
       ]);
       for (const action of actions) {
         expect(covered.has(action)).toBe(true);
@@ -177,6 +177,7 @@ describe("Category 4: Safety Properties", () => {
       expect(isMutation("mail", "batch_delete")).toBe(true);
       expect(isMutation("mail", "send")).toBe(true);
       expect(isMutation("mail", "reply")).toBe(true);
+      expect(isMutation("mail", "save_attachment")).toBe(true);
       expect(isMutation("mail", "accounts")).toBe(false);
       expect(isMutation("mail", "messages")).toBe(false);
     });

--- a/evals/tests/tool-call-correctness.test.js
+++ b/evals/tests/tool-call-correctness.test.js
@@ -286,6 +286,122 @@ describe("Category 1: Tool Call Correctness", () => {
       await expect(handleMail({ action: "search" }, mockCLI))
         .rejects.toThrow("query");
     });
+
+    it("mail save_attachment throws without id", async () => {
+      const mockCLI = createMockCLI({});
+      await expect(handleMail({ action: "save_attachment" }, mockCLI))
+        .rejects.toThrow("Message ID is required");
+    });
+  });
+
+  describe("save_attachment argument construction", () => {
+    it("passes --index when index is provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:save-attachment": { success: true, saved: [] } });
+      await handleMail({ action: "save_attachment", id: "msg_1", index: 2 }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(callArgs).toContain("save-attachment");
+      expect(argsPairPresent(callArgs, "--id", "msg_1")).toBe(true);
+      expect(argsPairPresent(callArgs, "--index", "2")).toBe(true);
+    });
+
+    it("passes --dest-dir when destDir is provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:save-attachment": { success: true, saved: [] } });
+      await handleMail({ action: "save_attachment", id: "msg_1", destDir: "/tmp/test" }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(argsPairPresent(callArgs, "--dest-dir", "/tmp/test")).toBe(true);
+    });
+
+    it("omits --index when index is not provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:save-attachment": { success: true, saved: [] } });
+      await handleMail({ action: "save_attachment", id: "msg_1" }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(callArgs).not.toContain("--index");
+    });
+  });
+
+  describe("send/reply attachment argument construction", () => {
+    it("send passes --attachment for single file path", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:send": { success: true } });
+      await handleMail({
+        action: "send", to: ["a@b.com"], subject: "test", body: "hi",
+        attachment: "/dev/null",
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(argsPairPresent(callArgs, "--attachment", "/dev/null")).toBe(true);
+    });
+
+    it("send passes multiple --attachment flags for array", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:send": { success: true } });
+      await handleMail({
+        action: "send", to: ["a@b.com"], subject: "test", body: "hi",
+        attachment: ["/dev/null", "/dev/zero"],
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      const attValues = callArgs
+        .map((arg, i) => arg === "--attachment" ? callArgs[i + 1] : null)
+        .filter(Boolean);
+      expect(attValues).toContain("/dev/null");
+      expect(attValues).toContain("/dev/zero");
+      expect(attValues).toHaveLength(2);
+    });
+
+    it("send omits --attachment when not provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:send": { success: true } });
+      await handleMail({
+        action: "send", to: ["a@b.com"], subject: "test", body: "hi",
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(callArgs).not.toContain("--attachment");
+    });
+
+    it("send throws for nonexistent attachment path", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:send": { success: true } });
+      await expect(handleMail({
+        action: "send", to: ["a@b.com"], subject: "test", body: "hi",
+        attachment: "/tmp/does-not-exist-abc123.txt",
+      }, mockCLI)).rejects.toThrow("Attachment file not found");
+    });
+
+    it("reply passes --attachment when provided", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:reply": { success: true } });
+      await handleMail({
+        action: "reply", id: "msg_1", body: "thanks",
+        attachment: "/dev/null",
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      expect(argsPairPresent(callArgs, "--attachment", "/dev/null")).toBe(true);
+    });
+
+    it("reply passes multiple --attachment flags for array", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:reply": { success: true } });
+      await handleMail({
+        action: "reply", id: "msg_1", body: "thanks",
+        attachment: ["/dev/null", "/dev/zero"],
+      }, mockCLI);
+
+      const callArgs = mockCLI.mock.calls[0][1];
+      const attValues = callArgs
+        .map((arg, i) => arg === "--attachment" ? callArgs[i + 1] : null)
+        .filter(Boolean);
+      expect(attValues).toContain("/dev/null");
+      expect(attValues).toContain("/dev/zero");
+      expect(attValues).toHaveLength(2);
+    });
+
+    it("reply throws for nonexistent attachment path", async () => {
+      const mockCLI = createMockCLI({ "mail-cli:reply": { success: true } });
+      await expect(handleMail({
+        action: "reply", id: "msg_1", body: "thanks",
+        attachment: "/tmp/does-not-exist-abc123.txt",
+      }, mockCLI)).rejects.toThrow("Attachment file not found");
+    });
   });
 
   describe("batch operation validation", () => {

--- a/lib/dry-run.js
+++ b/lib/dry-run.js
@@ -27,6 +27,7 @@ const MUTATION_ACTIONS = {
     "batch_delete",
     "send",
     "reply",
+    "save_attachment",
   ]),
 };
 
@@ -91,10 +92,16 @@ function describeMutation(tool, action, params) {
       return `Would mark reminder ${params.id || "?"} as ${params.undo ? "incomplete" : "complete"}`;
     case "move":
       return `Would move message ${params.id || "?"} to mailbox "${params.toMailbox || "?"}"`;
-    case "send":
-      return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"`;
-    case "reply":
-      return `Would reply to message ${params.id || "?"}`;
+    case "send": {
+      const sendAttCount = params.attachment ? (Array.isArray(params.attachment) ? params.attachment.length : 1) : 0;
+      return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"${sendAttCount ? ` (${sendAttCount} attachment${sendAttCount > 1 ? "s" : ""})` : ""}`;
+    }
+    case "reply": {
+      const replyAttCount = params.attachment ? (Array.isArray(params.attachment) ? params.attachment.length : 1) : 0;
+      return `Would reply to message ${params.id || "?"}${replyAttCount ? ` (${replyAttCount} attachment${replyAttCount > 1 ? "s" : ""})` : ""}`;
+    }
+    case "save_attachment":
+      return `Would save ${params.index !== undefined ? `attachment #${params.index}` : "all attachments"} from message ${params.id || "?"} to ${params.destDir || "temp directory"}`;
     default:
       return `Would perform ${action} on ${tool}`;
   }

--- a/lib/handlers/mail.js
+++ b/lib/handlers/mail.js
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { formatMailGetResult } from "../mail-format.js";
 
 export async function handleMail(args, runCLI) {
@@ -113,6 +115,16 @@ export async function handleMail(args, runCLI) {
         for (const addr of bccList) sendArgs.push("--bcc", addr);
       }
       if (args.from) sendArgs.push("--from", args.from);
+      if (args.attachment) {
+        const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+        for (const filePath of attachments) {
+          const expanded = filePath.startsWith("~/") ? homedir() + filePath.slice(1) : filePath;
+          if (!existsSync(expanded)) {
+            throw new Error(`Attachment file not found: ${expanded}`);
+          }
+          sendArgs.push("--attachment", expanded);
+        }
+      }
       return await runCLI("mail-cli", sendArgs);
     }
 
@@ -122,7 +134,27 @@ export async function handleMail(args, runCLI) {
       const replyArgs = ["reply", "--id", args.id, "--body", args.body];
       if (args.mailbox) replyArgs.push("--mailbox", args.mailbox);
       if (args.account) replyArgs.push("--account", args.account);
+      if (args.attachment) {
+        const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+        for (const filePath of attachments) {
+          const expanded = filePath.startsWith("~/") ? homedir() + filePath.slice(1) : filePath;
+          if (!existsSync(expanded)) {
+            throw new Error(`Attachment file not found: ${expanded}`);
+          }
+          replyArgs.push("--attachment", expanded);
+        }
+      }
       return await runCLI("mail-cli", replyArgs);
+    }
+
+    case "save_attachment": {
+      if (!args.id) throw new Error("Message ID is required for save_attachment");
+      const saveArgs = ["save-attachment", "--id", args.id];
+      if (args.index !== undefined) saveArgs.push("--index", String(args.index));
+      if (args.destDir) saveArgs.push("--dest-dir", args.destDir);
+      if (args.mailbox) saveArgs.push("--mailbox", args.mailbox);
+      if (args.account) saveArgs.push("--account", args.account);
+      return await runCLI("mail-cli", saveArgs);
     }
 
     case "auth_check": {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -332,7 +332,7 @@ export const tools = [
   {
     name: "mail",
     description:
-      "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list), get (full message by ID), search, update (flags), move, delete, batch_update, batch_delete, send, reply, auth_check, schema (show input schema).",
+      "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list with attachmentCount), get (full message by ID with attachment metadata), search, update (flags), move, delete, batch_update, batch_delete, send (with optional attachments), reply (with optional attachments), save_attachment (save message attachments to disk), auth_check, schema (show input schema).",
     inputSchema: {
       type: "object",
       properties: {
@@ -341,13 +341,13 @@ export const tools = [
           enum: [
             "accounts", "mailboxes", "messages", "get", "search",
             "update", "move", "delete", "batch_update", "batch_delete",
-            "send", "reply", "auth_check",
+            "send", "reply", "save_attachment", "auth_check",
             "schema",
           ],
           description: "Operation to perform",
         },
         ...agentDXProperties,
-        id: { type: "string", description: "RFC 2822 message ID (get/update/move/delete/reply/auth_check)" },
+        id: { type: "string", description: "RFC 2822 message ID (get/update/move/delete/reply/save_attachment/auth_check)" },
         ids: { type: "array", items: { type: "string" }, description: "Message IDs (batch_update/batch_delete)" },
         account: { type: "string", description: "Account name" },
         mailbox: { type: "string", description: "Mailbox name" },
@@ -379,6 +379,9 @@ export const tools = [
         cc: { type: "array", items: { type: "string" }, description: "CC addresses (send)" },
         bcc: { type: "array", items: { type: "string" }, description: "BCC addresses (send)" },
         from: { type: "string", description: "Sender email address for account selection (send)" },
+        attachment: { type: "array", items: { type: "string" }, description: "Absolute or ~-prefixed file paths to attach (send/reply). Files must exist on disk." },
+        index: { type: "integer", minimum: 0, description: "Zero-based attachment index (save_attachment). Omit to save all attachments." },
+        destDir: { type: "string", description: "Directory to save attachments into (save_attachment). Must be within home directory or system temp. Defaults to system temp. Use dryRun: true to preview." },
         trustedSenders: { type: "string", description: "Path to trusted-senders.json (auth_check)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only — ignored by MCP server)" },
         profile: { type: "string", description: "Override PIM profile name (OpenClaw only — MCP server uses APPLE_PIM_PROFILE env)" },

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -77675,7 +77675,7 @@ var tools = [
   },
   {
     name: "mail",
-    description: "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list), get (full message by ID), search, update (flags), move, delete, batch_update, batch_delete, send, reply, auth_check, schema (show input schema).",
+    description: "Manage Mail.app messages. Requires Mail.app to be running. Actions: accounts, mailboxes, messages (list with attachmentCount), get (full message by ID with attachment metadata), search, update (flags), move, delete, batch_update, batch_delete, send (with optional attachments), reply (with optional attachments), save_attachment (save message attachments to disk), auth_check, schema (show input schema).",
     inputSchema: {
       type: "object",
       properties: {
@@ -77694,13 +77694,14 @@ var tools = [
             "batch_delete",
             "send",
             "reply",
+            "save_attachment",
             "auth_check",
             "schema"
           ],
           description: "Operation to perform"
         },
         ...agentDXProperties,
-        id: { type: "string", description: "RFC 2822 message ID (get/update/move/delete/reply/auth_check)" },
+        id: { type: "string", description: "RFC 2822 message ID (get/update/move/delete/reply/save_attachment/auth_check)" },
         ids: { type: "array", items: { type: "string" }, description: "Message IDs (batch_update/batch_delete)" },
         account: { type: "string", description: "Account name" },
         mailbox: { type: "string", description: "Mailbox name" },
@@ -77732,6 +77733,9 @@ var tools = [
         cc: { type: "array", items: { type: "string" }, description: "CC addresses (send)" },
         bcc: { type: "array", items: { type: "string" }, description: "BCC addresses (send)" },
         from: { type: "string", description: "Sender email address for account selection (send)" },
+        attachment: { type: "array", items: { type: "string" }, description: "Absolute or ~-prefixed file paths to attach (send/reply). Files must exist on disk." },
+        index: { type: "integer", minimum: 0, description: "Zero-based attachment index (save_attachment). Omit to save all attachments." },
+        destDir: { type: "string", description: "Directory to save attachments into (save_attachment). Must be within home directory or system temp. Defaults to system temp. Use dryRun: true to preview." },
         trustedSenders: { type: "string", description: "Path to trusted-senders.json (auth_check)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only \u2014 ignored by MCP server)" },
         profile: { type: "string", description: "Override PIM profile name (OpenClaw only \u2014 MCP server uses APPLE_PIM_PROFILE env)" }
@@ -77848,7 +77852,8 @@ var MUTATION_ACTIONS = {
     "batch_update",
     "batch_delete",
     "send",
-    "reply"
+    "reply",
+    "save_attachment"
   ])
 };
 function isMutation(toolName, action) {
@@ -77896,10 +77901,16 @@ function describeMutation(tool, action, params) {
       return `Would mark reminder ${params.id || "?"} as ${params.undo ? "incomplete" : "complete"}`;
     case "move":
       return `Would move message ${params.id || "?"} to mailbox "${params.toMailbox || "?"}"`;
-    case "send":
-      return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"`;
-    case "reply":
-      return `Would reply to message ${params.id || "?"}`;
+    case "send": {
+      const sendAttCount = params.attachment ? Array.isArray(params.attachment) ? params.attachment.length : 1 : 0;
+      return `Would send email to ${formatRecipients(params.to)} with subject "${params.subject || ""}"${sendAttCount ? ` (${sendAttCount} attachment${sendAttCount > 1 ? "s" : ""})` : ""}`;
+    }
+    case "reply": {
+      const replyAttCount = params.attachment ? Array.isArray(params.attachment) ? params.attachment.length : 1 : 0;
+      return `Would reply to message ${params.id || "?"}${replyAttCount ? ` (${replyAttCount} attachment${replyAttCount > 1 ? "s" : ""})` : ""}`;
+    }
+    case "save_attachment":
+      return `Would save ${params.index !== void 0 ? `attachment #${params.index}` : "all attachments"} from message ${params.id || "?"} to ${params.destDir || "temp directory"}`;
     default:
       return `Would perform ${action} on ${tool}`;
   }
@@ -78329,6 +78340,10 @@ async function handleContact(args, runCLI2) {
   }
 }
 
+// ../lib/handlers/mail.js
+import { existsSync as existsSync2 } from "node:fs";
+import { homedir as homedir2 } from "node:os";
+
 // ../lib/mail-format.js
 var import_mailparser = __toESM(require_mailparser(), 1);
 var import_turndown = __toESM(require_turndown_cjs(), 1);
@@ -78527,6 +78542,16 @@ async function handleMail(args, runCLI2) {
       }
       if (args.from)
         sendArgs.push("--from", args.from);
+      if (args.attachment) {
+        const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+        for (const filePath of attachments) {
+          const expanded = filePath.startsWith("~/") ? homedir2() + filePath.slice(1) : filePath;
+          if (!existsSync2(expanded)) {
+            throw new Error(`Attachment file not found: ${expanded}`);
+          }
+          sendArgs.push("--attachment", expanded);
+        }
+      }
       return await runCLI2("mail-cli", sendArgs);
     }
     case "reply": {
@@ -78539,7 +78564,31 @@ async function handleMail(args, runCLI2) {
         replyArgs.push("--mailbox", args.mailbox);
       if (args.account)
         replyArgs.push("--account", args.account);
+      if (args.attachment) {
+        const attachments = Array.isArray(args.attachment) ? args.attachment : [args.attachment];
+        for (const filePath of attachments) {
+          const expanded = filePath.startsWith("~/") ? homedir2() + filePath.slice(1) : filePath;
+          if (!existsSync2(expanded)) {
+            throw new Error(`Attachment file not found: ${expanded}`);
+          }
+          replyArgs.push("--attachment", expanded);
+        }
+      }
       return await runCLI2("mail-cli", replyArgs);
+    }
+    case "save_attachment": {
+      if (!args.id)
+        throw new Error("Message ID is required for save_attachment");
+      const saveArgs = ["save-attachment", "--id", args.id];
+      if (args.index !== void 0)
+        saveArgs.push("--index", String(args.index));
+      if (args.destDir)
+        saveArgs.push("--dest-dir", args.destDir);
+      if (args.mailbox)
+        saveArgs.push("--mailbox", args.mailbox);
+      if (args.account)
+        saveArgs.push("--account", args.account);
+      return await runCLI2("mail-cli", saveArgs);
     }
     case "auth_check": {
       if (!args.id)

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -222,11 +222,15 @@ func inferMimeJXA() -> String {
 
 /// Validate that a destination directory is within the user's home or system temp.
 /// Prevents agents from writing attachments to arbitrary filesystem locations.
+/// Call after createDirectory so resolvingSymlinksInPath works on the real path.
 func validateDestDir(_ url: URL) throws {
-    let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
-    let tmp = FileManager.default.temporaryDirectory.standardizedFileURL.path
-    let resolved = url.standardizedFileURL.path
-    guard resolved.hasPrefix(home) || resolved.hasPrefix(tmp) else {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+        .resolvingSymlinksInPath().standardizedFileURL.path
+    let tmp = FileManager.default.temporaryDirectory
+        .resolvingSymlinksInPath().standardizedFileURL.path
+    let resolved = url.resolvingSymlinksInPath().standardizedFileURL.path
+    guard resolved == home || resolved.hasPrefix(home + "/") ||
+          resolved == tmp  || resolved.hasPrefix(tmp  + "/") else {
         throw CLIError.invalidInput("destDir must be within your home directory or system temp directory, got: \(resolved)")
     }
 }
@@ -1610,12 +1614,15 @@ struct SaveAttachment: AsyncParsableCommand {
             destDirURL = FileManager.default.temporaryDirectory.appendingPathComponent("apple-pim-attachments")
         }
 
-        // Security: restrict writes to home directory or system temp
-        try validateDestDir(destDirURL)
-
         try FileManager.default.createDirectory(at: destDirURL, withIntermediateDirectories: true)
 
-        // Build save targets with deduplicated filenames
+        // Security: restrict writes to home directory or system temp.
+        // Called after createDirectory so resolvingSymlinksInPath works on the real path.
+        try validateDestDir(destDirURL)
+
+        // Build save targets with deduplicated filenames.
+        // allocatedPaths tracks planned writes so batch saves with duplicate
+        // names get unique suffixes without malformed double-numbering.
         var saveTargets = [(index: Int, destPath: String, name: String, fileSize: Int, mimeType: String)]()
         var allocatedPaths = Set<String>()
 
@@ -1626,10 +1633,7 @@ struct SaveAttachment: AsyncParsableCommand {
             let mimeType = att["mimeType"] as? String ?? "application/octet-stream"
 
             let safeName = sanitizeFilename(rawName, fallback: "attachment_\(attIndex)")
-            var destPath = deduplicatePath(destDirURL.appendingPathComponent(safeName).path)
-            while allocatedPaths.contains(destPath) {
-                destPath = deduplicatePath(destPath + "_\(attIndex)")
-            }
+            let destPath = deduplicatePath(destDirURL.appendingPathComponent(safeName).path, avoiding: allocatedPaths)
             allocatedPaths.insert(destPath)
             saveTargets.append((index: attIndex, destPath: destPath, name: safeName, fileSize: fileSize, mimeType: mimeType))
         }
@@ -1733,10 +1737,15 @@ struct SaveAttachment: AsyncParsableCommand {
         return sanitized
     }
 
-    private func deduplicatePath(_ path: String) -> String {
-        guard FileManager.default.fileExists(atPath: path) else {
-            return path
+    /// Find a unique path by appending _1, _2, etc. before the extension.
+    /// Checks both disk and the `avoiding` set so batch saves with duplicate
+    /// names get clean suffixes (report_1.pdf, report_2.pdf) not garbled ones.
+    private func deduplicatePath(_ path: String, avoiding: Set<String> = []) -> String {
+        func isTaken(_ p: String) -> Bool {
+            avoiding.contains(p) || FileManager.default.fileExists(atPath: p)
         }
+
+        guard isTaken(path) else { return path }
 
         let url = URL(fileURLWithPath: path)
         let directory = url.deletingLastPathComponent().path
@@ -1755,7 +1764,7 @@ struct SaveAttachment: AsyncParsableCommand {
             } else {
                 candidate = "\(directory)/\(stem)_\(i).\(ext)"
             }
-            if !FileManager.default.fileExists(atPath: candidate) {
+            if !isTaken(candidate) {
                 return candidate
             }
         }

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -22,6 +22,7 @@ struct MailCLI: AsyncParsableCommand {
             BatchDeleteMessages.self,
             SendMessage.self,
             ReplyMessage.self,
+            SaveAttachment.self,
             AuthCheck.self,
             ConfigCommand.self,
         ]
@@ -190,6 +191,44 @@ func runAppleScript(_ script: String) throws -> String {
     }
 
     return String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+}
+
+/// Returns a JXA function that infers MIME type from a mail attachment.
+/// Tries the native `att.mimeType()` first; falls back to file-extension lookup.
+func inferMimeJXA() -> String {
+    return """
+    function inferMime(att) {
+        try { var m = att.mimeType(); if (m) return m; } catch(e) {}
+        var name = att.name() || '';
+        var dot = name.lastIndexOf('.');
+        if (dot < 0) return 'application/octet-stream';
+        var ext = name.slice(dot + 1).toLowerCase();
+        var map = {
+            md:'text/markdown', txt:'text/plain', pdf:'application/pdf',
+            jpg:'image/jpeg', jpeg:'image/jpeg', png:'image/png', gif:'image/gif',
+            doc:'application/msword',
+            docx:'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            xls:'application/vnd.ms-excel',
+            xlsx:'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            pptx:'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            csv:'text/csv', html:'text/html', htm:'text/html',
+            json:'application/json', xml:'application/xml', rtf:'application/rtf',
+            zip:'application/zip', gz:'application/gzip'
+        };
+        return map[ext] || 'application/octet-stream';
+    }
+    """
+}
+
+/// Validate that a destination directory is within the user's home or system temp.
+/// Prevents agents from writing attachments to arbitrary filesystem locations.
+func validateDestDir(_ url: URL) throws {
+    let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+    let tmp = FileManager.default.temporaryDirectory.standardizedFileURL.path
+    let resolved = url.standardizedFileURL.path
+    guard resolved.hasPrefix(home) || resolved.hasPrefix(tmp) else {
+        throw CLIError.invalidInput("destDir must be within your home directory or system temp directory, got: \(resolved)")
+    }
 }
 
 func ensureMailRunning() throws {
@@ -571,6 +610,8 @@ struct ListMessages: AsyncParsableCommand {
                         if (filterType === 'unread' && isRead) continue;
                         if (filterType === 'flagged' && !isFlagged) continue;
                         const dr = m.dateReceived();
+                        var attCount = 0;
+                        try { attCount = m.mailAttachments.length; } catch(e2) {}
                         results.push({
                             messageId: m.messageId(),
                             sender: m.sender(),
@@ -578,7 +619,8 @@ struct ListMessages: AsyncParsableCommand {
                             dateReceived: dr ? dr.toISOString() : null,
                             isRead: isRead,
                             isFlagged: isFlagged,
-                            isJunk: m.junkMailStatus()
+                            isJunk: m.junkMailStatus(),
+                            attachmentCount: attCount
                         });
                     } catch(e) { /* skip messages that fail to read */ }
                 }
@@ -642,6 +684,8 @@ struct GetMessage: AsyncParsableCommand {
         let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
 
         let script = """
+        \(inferMimeJXA())
+
         \(findHelper)
 
         const msg = findMessage();
@@ -684,6 +728,26 @@ struct GetMessage: AsyncParsableCommand {
             try {
                 result.allHeaders = msg.allHeaders();
             } catch(e) {}
+
+            // Collect attachment metadata
+            var attachments = [];
+            try {
+                var attCount = msg.mailAttachments.length;
+                for (var i = 0; i < attCount; i++) {
+                    try {
+                        var att = msg.mailAttachments[i];
+                        attachments.push({
+                            index: i,
+                            name: att.name(),
+                            fileSize: att.fileSize(),
+                            downloaded: att.downloaded(),
+                            mimeType: inferMime(att)
+                        });
+                    } catch(e) {}
+                }
+            } catch(e) {}
+            result.attachments = attachments;
+            result.attachmentCount = attachments.length;
 
             JSON.stringify(result);
         }
@@ -1254,6 +1318,9 @@ struct SendMessage: AsyncParsableCommand {
     @Option(name: .long, help: "Sender email address (selects account)")
     var from: String?
 
+    @Option(name: .long, help: "File path to attach (repeatable)")
+    var attachment: [String] = []
+
     func run() async throws {
         try ensureMailRunning()
         let config = pimOptions.loadConfig()
@@ -1261,6 +1328,16 @@ struct SendMessage: AsyncParsableCommand {
 
         guard !to.isEmpty else {
             throw CLIError.invalidInput("At least one --to recipient is required")
+        }
+
+        // Validate attachment files exist before building the script
+        var attachmentLines = ""
+        for filePath in attachment {
+            let expandedPath = (filePath as NSString).expandingTildeInPath
+            guard FileManager.default.fileExists(atPath: expandedPath) else {
+                throw CLIError.invalidInput("Attachment file not found: \(expandedPath)")
+            }
+            attachmentLines += "\n        make new attachment with properties {file name:\"\(escapeForAppleScript(expandedPath))\"} at after the last paragraph"
         }
 
         // Write body to temp file to avoid AppleScript escaping issues
@@ -1283,25 +1360,35 @@ struct SendMessage: AsyncParsableCommand {
         let escapedSubject = escapeForAppleScript(subject)
         let senderProp = from.map { ", sender:\"\(escapeForAppleScript($0))\"" } ?? ""
 
+        let attachmentBlock = attachmentLines.isEmpty ? "" : """
+
+            tell newMessage\(attachmentLines)
+            end tell
+        """
+
         let script = """
         set bodyText to read POSIX file "\(bodyFile.path)" as «class utf8»
         tell application "Mail"
             set newMessage to make new outgoing message with properties {subject:"\(escapedSubject)", visible:false\(senderProp)}
             tell newMessage\(recipientLines)
             end tell
-            set content of newMessage to bodyText
+            set content of newMessage to bodyText\(attachmentBlock)
             send newMessage
         end tell
         """
 
         _ = try runAppleScript(script)
 
-        outputJSON([
+        var result: [String: Any] = [
             "success": true,
             "message": "Email sent successfully",
             "to": to,
             "subject": subject
-        ])
+        ]
+        if !attachment.isEmpty {
+            result["attachments"] = attachment.map { ($0 as NSString).expandingTildeInPath }
+        }
+        outputJSON(result)
     }
 }
 
@@ -1325,10 +1412,23 @@ struct ReplyMessage: AsyncParsableCommand {
     @Option(name: .long, help: "Account name hint (speeds up lookup)")
     var account: String?
 
+    @Option(name: .long, help: "File path to attach (repeatable)")
+    var attachment: [String] = []
+
     func run() async throws {
         try ensureMailRunning()
         let config = pimOptions.loadConfig()
         try checkMailEnabled(config: config)
+
+        // Validate attachment files exist before building the script
+        var attachmentLines = ""
+        for filePath in attachment {
+            let expandedPath = (filePath as NSString).expandingTildeInPath
+            guard FileManager.default.fileExists(atPath: expandedPath) else {
+                throw CLIError.invalidInput("Attachment file not found: \(expandedPath)")
+            }
+            attachmentLines += "\n        make new attachment with properties {file name:\"\(escapeForAppleScript(expandedPath))\"} at after the last paragraph"
+        }
 
         // Step 1: Use JXA to find the message by RFC 2822 messageId and get its numeric Apple Mail ID
         let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
@@ -1373,24 +1473,299 @@ struct ReplyMessage: AsyncParsableCommand {
         let escapedAccount = escapeForAppleScript(accountName)
         let escapedMailbox = escapeForAppleScript(mailboxName)
 
+        let attachmentBlock = attachmentLines.isEmpty ? "" : """
+
+            tell replyMsg\(attachmentLines)
+            end tell
+        """
+
         let replyScript = """
         set replyBody to read POSIX file "\(bodyFile.path)" as «class utf8»
         tell application "Mail"
             set origMsg to first message of mailbox "\(escapedMailbox)" of account "\(escapedAccount)" whose id is \(appleMailId)
             set replyMsg to reply origMsg with opening window
-            set content of replyMsg to replyBody & return & return & content of replyMsg
+            set content of replyMsg to replyBody & return & return & content of replyMsg\(attachmentBlock)
             send replyMsg
         end tell
         """
 
         _ = try runAppleScript(replyScript)
 
-        outputJSON([
+        var result: [String: Any] = [
             "success": true,
             "message": "Reply sent successfully",
             "inReplyTo": id,
             "originalSubject": dict["subject"] ?? ""
-        ])
+        ]
+        if !attachment.isEmpty {
+            result["attachments"] = attachment.map { ($0 as NSString).expandingTildeInPath }
+        }
+        outputJSON(result)
+    }
+}
+
+// MARK: - Save Attachment
+
+struct SaveAttachment: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "save-attachment",
+        abstract: "Save one or all attachments from a message to a local directory"
+    )
+
+    @OptionGroup var pimOptions: PIMOptions
+
+    @Option(name: .long, help: "RFC 2822 message ID")
+    var id: String
+
+    @Option(name: .long, help: "Zero-based attachment index (saves all if omitted)")
+    var index: Int?
+
+    @Option(name: .long, help: "Directory to save into (default: system temp)")
+    var destDir: String?
+
+    @Option(name: .long, help: "Mailbox name hint (speeds up lookup)")
+    var mailbox: String?
+
+    @Option(name: .long, help: "Account name hint (speeds up lookup)")
+    var account: String?
+
+    func run() async throws {
+        try ensureMailRunning()
+        let config = pimOptions.loadConfig()
+        try checkMailEnabled(config: config)
+
+        // Phase 1: Get attachment metadata via JXA
+        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+
+        let metadataScript = """
+        \(inferMimeJXA())
+
+        \(findHelper)
+
+        const msg = findMessage();
+        if (!msg) {
+            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
+        } else {
+            var attachments = [];
+            try {
+                var attCount = msg.mailAttachments.length;
+                for (var i = 0; i < attCount; i++) {
+                    try {
+                        var att = msg.mailAttachments[i];
+                        attachments.push({
+                            index: i,
+                            name: att.name(),
+                            fileSize: att.fileSize(),
+                            downloaded: att.downloaded(),
+                            mimeType: inferMime(att)
+                        });
+                    } catch(e) {}
+                }
+            } catch(e) {}
+            JSON.stringify({attachments: attachments});
+        }
+        """
+
+        let metadataRaw = try runJXA(metadataScript)
+
+        guard let metadataDict = metadataRaw as? [String: Any] else {
+            throw CLIError.jxaError("Unexpected output from attachment metadata lookup")
+        }
+
+        if let error = metadataDict["error"] as? String {
+            throw CLIError.notFound(error)
+        }
+
+        let attachments = metadataDict["attachments"] as? [[String: Any]] ?? []
+
+        guard !attachments.isEmpty else {
+            throw CLIError.invalidInput("Message has no attachments")
+        }
+
+        // Determine which attachments to save
+        let targetAttachments: [[String: Any]]
+        if let idx = index {
+            guard idx >= 0 && idx < attachments.count else {
+                throw CLIError.invalidInput("Attachment index \(idx) out of range (message has \(attachments.count) attachment\(attachments.count == 1 ? "" : "s"))")
+            }
+            targetAttachments = [attachments[idx]]
+        } else {
+            targetAttachments = attachments
+        }
+
+        // Check all target attachments are downloaded
+        for att in targetAttachments {
+            let downloaded = att["downloaded"] as? Bool ?? false
+            if !downloaded {
+                let name = att["name"] as? String ?? "unknown"
+                throw CLIError.invalidInput("Attachment \"\(name)\" has not been downloaded from the server yet")
+            }
+        }
+
+        // Phase 2: Create destination directory and compute safe filenames
+        let destDirURL: URL
+        if let destDirPath = destDir {
+            destDirURL = URL(fileURLWithPath: NSString(string: destDirPath).expandingTildeInPath)
+        } else {
+            destDirURL = FileManager.default.temporaryDirectory.appendingPathComponent("apple-pim-attachments")
+        }
+
+        // Security: restrict writes to home directory or system temp
+        try validateDestDir(destDirURL)
+
+        try FileManager.default.createDirectory(at: destDirURL, withIntermediateDirectories: true)
+
+        // Build save targets with deduplicated filenames
+        var saveTargets = [(index: Int, destPath: String, name: String, fileSize: Int, mimeType: String)]()
+        var allocatedPaths = Set<String>()
+
+        for att in targetAttachments {
+            let attIndex = att["index"] as? Int ?? 0
+            let rawName = att["name"] as? String ?? ""
+            let fileSize = att["fileSize"] as? Int ?? 0
+            let mimeType = att["mimeType"] as? String ?? "application/octet-stream"
+
+            let safeName = sanitizeFilename(rawName, fallback: "attachment_\(attIndex)")
+            var destPath = deduplicatePath(destDirURL.appendingPathComponent(safeName).path)
+            while allocatedPaths.contains(destPath) {
+                destPath = deduplicatePath(destPath + "_\(attIndex)")
+            }
+            allocatedPaths.insert(destPath)
+            saveTargets.append((index: attIndex, destPath: destPath, name: safeName, fileSize: fileSize, mimeType: mimeType))
+        }
+
+        // Phase 3: Save attachments via JXA
+        let findHelper2 = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+
+        var saveStatements = ""
+        for (i, target) in saveTargets.enumerated() {
+            let escapedPath = escapeForJXA(target.destPath)
+            saveStatements += """
+            try {
+                var att\(i) = msg.mailAttachments[\(target.index)];
+                Mail.save(att\(i), {in: Path('\(escapedPath)')});
+                saved.push({index: \(target.index), path: '\(escapedPath)', success: true});
+            } catch(e) {
+                errors.push({index: \(target.index), error: e.message || String(e)});
+            }
+
+            """
+        }
+
+        let saveScript = """
+        \(findHelper2)
+
+        const Mail = Application("Mail");
+        const msg = findMessage();
+        if (!msg) {
+            JSON.stringify({error: "Message not found on second lookup"});
+        } else {
+            var saved = [];
+            var errors = [];
+            \(saveStatements)
+            JSON.stringify({saved: saved, errors: errors});
+        }
+        """
+
+        let saveRaw = try runJXA(saveScript)
+
+        guard let saveDict = saveRaw as? [String: Any] else {
+            throw CLIError.jxaError("Unexpected output from attachment save")
+        }
+
+        if let error = saveDict["error"] as? String {
+            throw CLIError.jxaError(error)
+        }
+
+        let savedResults = saveDict["saved"] as? [[String: Any]] ?? []
+        let saveErrors = saveDict["errors"] as? [[String: Any]] ?? []
+
+        // Build final response with full metadata and post-save size verification
+        var savedOutput = [[String: Any]]()
+        for result in savedResults {
+            guard let resultIndex = result["index"] as? Int,
+                  let path = result["path"] as? String else { continue }
+            if let target = saveTargets.first(where: { $0.index == resultIndex }) {
+                var entry: [String: Any] = [
+                    "index": resultIndex,
+                    "name": target.name,
+                    "path": path,
+                    "fileSize": target.fileSize,
+                    "mimeType": target.mimeType
+                ]
+                // Verify saved file size matches expected (catches deferred/stub downloads)
+                let actualSize = (try? FileManager.default.attributesOfItem(atPath: path)[.size] as? Int) ?? 0
+                if actualSize == 0 && target.fileSize > 0 {
+                    entry["warning"] = "Saved file is empty (attachment may not have been fully downloaded)"
+                }
+                savedOutput.append(entry)
+            }
+        }
+
+        if !saveErrors.isEmpty {
+            outputJSON([
+                "success": false,
+                "saved": savedOutput,
+                "errors": saveErrors
+            ])
+        } else {
+            outputJSON([
+                "success": true,
+                "saved": savedOutput
+            ])
+        }
+    }
+
+    private func sanitizeFilename(_ name: String, fallback: String) -> String {
+        var sanitized = name
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespaces)
+
+        while sanitized.hasPrefix(".") {
+            sanitized = String(sanitized.dropFirst())
+        }
+
+        if sanitized.isEmpty {
+            return fallback
+        }
+
+        return sanitized
+    }
+
+    private func deduplicatePath(_ path: String) -> String {
+        guard FileManager.default.fileExists(atPath: path) else {
+            return path
+        }
+
+        let url = URL(fileURLWithPath: path)
+        let directory = url.deletingLastPathComponent().path
+        let ext = url.pathExtension
+        let stem: String
+        if ext.isEmpty {
+            stem = url.lastPathComponent
+        } else {
+            stem = String(url.lastPathComponent.dropLast(ext.count + 1))
+        }
+
+        for i in 1...99 {
+            let candidate: String
+            if ext.isEmpty {
+                candidate = "\(directory)/\(stem)_\(i)"
+            } else {
+                candidate = "\(directory)/\(stem)_\(i).\(ext)"
+            }
+            if !FileManager.default.fileExists(atPath: candidate) {
+                return candidate
+            }
+        }
+
+        let ts = Int(Date().timeIntervalSince1970)
+        if ext.isEmpty {
+            return "\(directory)/\(stem)_\(ts)"
+        } else {
+            return "\(directory)/\(stem)_\(ts).\(ext)"
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds comprehensive attachment support to MailCLI, consolidating and improving the work from #44 and #45 by @juan-deere-4000.

- **`messages`** action now includes `attachmentCount` per message
- **`get`** action returns full attachment metadata (name, size, MIME type, download status)
- **New `save_attachment`** action saves one or all attachments to disk with configurable destination
- **`send`** and **`reply`** accept `--attachment` flag (repeatable) for outbound file attachments

### Security improvements over original PRs
- `destDir` validated to user's home directory or system temp only (prevents arbitrary filesystem writes)
- Post-save file size verification warns on empty/stub downloads from iCloud/Exchange deferred attachments
- JS handler uses `~/` prefix expansion (not bare `~`) to avoid directory false-positive on `existsSync`
- Error messages show expanded paths for debugging

### Changes
| File | What |
|------|------|
| `swift/Sources/MailCLI/MailCLI.swift` | `SaveAttachment` command, `inferMimeJXA()`, `validateDestDir()`, attachment metadata in list/get, `--attachment` on send/reply |
| `lib/handlers/mail.js` | `save_attachment` handler, attachment arg threading for send/reply with file validation |
| `lib/schemas.js` | New `save_attachment` action, `attachment`/`index`/`destDir` properties |
| `lib/dry-run.js` | Dry-run descriptions for save_attachment and attachment counts on send/reply |
| `evals/` | New fixture, safety coverage, 11 new tool-call-correctness tests |
| `mcp-server/dist/server.js` | Rebuilt bundle |

## Test plan
- [x] `swift build -c release` succeeds
- [x] All 41 MCP server tests pass
- [x] All 137 deterministic eval tests pass (8 calendar-reasoning model-in-the-loop tests excluded, require API key)
- [ ] End-to-end: `save_attachment` with valid destDir within home directory
- [ ] End-to-end: `save_attachment` rejects destDir outside home/temp
- [ ] End-to-end: `send` with `--attachment` attaches file in Mail.app

Based on work by @juan-deere-4000 (PRs #44 and #45). Thank you for the contribution!

Closes #44
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)