### PR TITLE
feat: add attendee write support for calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Native macOS integration for Calendar, Reminders, Contacts, and Mail using Event
 
 ## Features
 
-- **Calendar Management**: List calendars, create/read/update/delete events, search by date/title
+- **Calendar Management**: List calendars, create/read/update/delete events, search by date/title, attendee support (add/replace attendees via CalDAV invitation emails)
 - **Reminder Management**: List reminder lists, create/complete/update/delete reminders, search
 - **Contact Management**: List groups, create/read/update/delete contacts, search by name/email/phone, birthday support (with or without year)
-- **Mail Integration**: List accounts/mailboxes, read/search/send/reply/move/delete messages, update flags, verify sender authentication (via Apple Mail.app + JXA/AppleScript)
+- **Mail Integration**: List accounts/mailboxes, read/search/send/reply/move/delete messages, update flags, attachment support (metadata, save-to-disk, send/reply with attachments), verify sender authentication (via Apple Mail.app + JXA/AppleScript)
 - **Recurrence Rules**: Create recurring events and reminders (daily, weekly, monthly, yearly)
 - **Batch Operations**: Create multiple events or reminders in a single efficient transaction
 - **Per-Domain Control**: Enable or disable entire domains (calendars, reminders, contacts, mail) independently
@@ -334,8 +334,11 @@ reminder-cli items --list "Personal" --filter overdue
 contacts-cli search "John"
 mail-cli messages --mailbox INBOX --limit 10
 mail-cli send --to "user@example.com" --subject "Hello" --body "Message"
+mail-cli send --to "user@example.com" --subject "Report" --body "See attached" --attachment ~/report.pdf
 mail-cli reply --id "<message-id>" --body "Thanks!"
+mail-cli save-attachment --id "<message-id>" --dest-dir ~/Downloads
 mail-cli auth-check --id "<message-id>"
+calendar-cli create --title "Meeting" --start "tomorrow 2pm" --attendees '[{"email":"a@example.com"}]'
 ```
 
 ## Tools Reference
@@ -347,7 +350,7 @@ mail-cli auth-check --id "<message-id>"
 | `calendar` / `apple_pim_calendar` | `list`, `events`, `get`, `search`, `create`, `update`, `delete`, `batch_create` | Calendar events via EventKit |
 | `reminder` / `apple_pim_reminder` | `lists`, `items`, `get`, `search`, `create`, `complete`, `update`, `delete`, `batch_create`, `batch_complete`, `batch_delete` | Reminders via EventKit |
 | `contact` / `apple_pim_contact` | `groups`, `list`, `search`, `get`, `create`, `update`, `delete` | Contacts framework |
-| `mail` / `apple_pim_mail` | `accounts`, `mailboxes`, `messages`, `get`, `search`, `send`, `reply`, `update`, `move`, `delete`, `batch_update`, `batch_delete`, `auth_check` | Mail.app via JXA/AppleScript |
+| `mail` / `apple_pim_mail` | `accounts`, `mailboxes`, `messages`, `get`, `search`, `send`, `reply`, `save_attachment`, `update`, `move`, `delete`, `batch_update`, `batch_delete`, `auth_check` | Mail.app via JXA/AppleScript |
 | `apple-pim` / `apple_pim_system` | `status`, `authorize`, `config_show`, `config_init` | Authorization & configuration |
 
 ### Recurrence Rules
@@ -422,7 +425,7 @@ apple-pim/
 │   ├── openclaw.plugin.json  # Plugin manifest + config schema
 │   ├── lib -> ../lib         # Symlink to shared code
 │   └── skills/apple-pim/     # OpenClaw skill knowledge
-├── evals/                    # Agent eval framework (125 tests)
+├── evals/                    # Agent eval framework (137 tests)
 │   ├── helpers/              # Mock CLI, scenario runner, grading
 │   ├── fixtures/             # Canned CLI JSON responses
 │   ├── scenarios/            # YAML eval case definitions
@@ -521,7 +524,7 @@ calendar-cli config show --profile travel
 The eval framework tests how well the tool layer serves AI agents. All tests run against mock CLI fixtures with zero TCC permissions and no real macOS data.
 
 ```bash
-# Run all 125 eval tests
+# Run all eval tests
 npm run eval
 
 # Watch mode during development

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -70,6 +70,19 @@ export const tools = [
         allDay: { type: "boolean", description: "All-day event" },
         alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before event" },
         url: { type: "string", description: "URL" },
+        attendees: {
+          type: "array",
+          description: "Event attendees (create/update). Replaces all existing attendees on update.",
+          items: {
+            type: "object",
+            properties: {
+              email: { type: "string", description: "Email address (required)" },
+              name: { type: "string", description: "Display name" },
+              role: { type: "string", description: "required, optional, chair, or nonParticipant" },
+            },
+            required: ["email"],
+          },
+        },
         recurrence: recurrenceSchema,
         futureEvents: { type: "boolean", description: "Apply to future occurrences (update/delete recurring)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only — ignored by MCP server)" },
@@ -90,6 +103,19 @@ export const tools = [
               url: { type: "string" },
               allDay: { type: "boolean" },
               alarm: { type: "array", items: { type: "number" } },
+              attendees: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    email: { type: "string" },
+                    name: { type: "string" },
+                    role: { type: "string", description: "required, optional, chair, or nonParticipant" },
+                  },
+                  required: ["email"],
+                },
+                description: "Event attendees (batch_create)",
+              },
               recurrence: recurrenceSchema,
             },
             required: ["title", "start"],

--- a/lib/tool-args.js
+++ b/lib/tool-args.js
@@ -21,6 +21,9 @@ export function buildCalendarCreateArgs(args, targetCalendar) {
   if (args.recurrence) {
     cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
   }
+  if (args.attendees) {
+    cliArgs.push("--attendees", JSON.stringify(args.attendees));
+  }
   return cliArgs;
 }
 
@@ -33,6 +36,7 @@ export function buildCalendarUpdateArgs(args) {
   if (args.notes) cliArgs.push("--notes", args.notes);
   if (args.url) cliArgs.push("--url", args.url);
   if (args.recurrence) cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
+  if (args.attendees) cliArgs.push("--attendees", JSON.stringify(args.attendees));
   if (args.futureEvents) cliArgs.push("--future-events");
   return cliArgs;
 }

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -77411,6 +77411,19 @@ var tools = [
         allDay: { type: "boolean", description: "All-day event" },
         alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before event" },
         url: { type: "string", description: "URL" },
+        attendees: {
+          type: "array",
+          description: "Event attendees (create/update). Replaces all existing attendees on update.",
+          items: {
+            type: "object",
+            properties: {
+              email: { type: "string", description: "Email address (required)" },
+              name: { type: "string", description: "Display name" },
+              role: { type: "string", description: "required, optional, chair, or nonParticipant" }
+            },
+            required: ["email"]
+          }
+        },
         recurrence: recurrenceSchema,
         futureEvents: { type: "boolean", description: "Apply to future occurrences (update/delete recurring)" },
         configDir: { type: "string", description: "Override PIM config directory (OpenClaw only \u2014 ignored by MCP server)" },
@@ -77431,6 +77444,19 @@ var tools = [
               url: { type: "string" },
               allDay: { type: "boolean" },
               alarm: { type: "array", items: { type: "number" } },
+              attendees: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    email: { type: "string" },
+                    name: { type: "string" },
+                    role: { type: "string", description: "required, optional, chair, or nonParticipant" }
+                  },
+                  required: ["email"]
+                },
+                description: "Event attendees (batch_create)"
+              },
               recurrence: recurrenceSchema
             },
             required: ["title", "start"]
@@ -78030,6 +78056,9 @@ function buildCalendarCreateArgs(args, targetCalendar) {
   if (args.recurrence) {
     cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
   }
+  if (args.attendees) {
+    cliArgs.push("--attendees", JSON.stringify(args.attendees));
+  }
   return cliArgs;
 }
 function buildCalendarUpdateArgs(args) {
@@ -78048,6 +78077,8 @@ function buildCalendarUpdateArgs(args) {
     cliArgs.push("--url", args.url);
   if (args.recurrence)
     cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
+  if (args.attendees)
+    cliArgs.push("--attendees", JSON.stringify(args.attendees));
   if (args.futureEvents)
     cliArgs.push("--future-events");
   return cliArgs;

--- a/mcp-server/test/tool-args.test.js
+++ b/mcp-server/test/tool-args.test.js
@@ -50,6 +50,28 @@ describe("buildCalendarCreateArgs", () => {
       JSON.stringify({ frequency: "weekly", daysOfTheWeek: ["monday"] }),
     ]);
   });
+
+  it("passes attendees as JSON-stringified --attendees flag", () => {
+    const attendees = [
+      { email: "alice@example.com", name: "Alice", role: "required" },
+      { email: "bob@example.com" },
+    ];
+    const args = buildCalendarCreateArgs(
+      { title: "Meeting", start: "2026-03-01 14:00", attendees },
+      "Work"
+    );
+    expect(args).toContain("--attendees");
+    const attIndex = args.indexOf("--attendees");
+    expect(JSON.parse(args[attIndex + 1])).toEqual(attendees);
+  });
+
+  it("omits --attendees when not provided", () => {
+    const args = buildCalendarCreateArgs(
+      { title: "Solo", start: "2026-03-01 14:00" },
+      "Work"
+    );
+    expect(args).not.toContain("--attendees");
+  });
 });
 
 describe("buildCalendarUpdateArgs", () => {
@@ -67,6 +89,14 @@ describe("buildCalendarUpdateArgs", () => {
       JSON.stringify({ frequency: "monthly", daysOfTheMonth: [1, 15] }),
       "--future-events",
     ]);
+  });
+
+  it("passes attendees as JSON-stringified --attendees flag on update", () => {
+    const attendees = [{ email: "carol@example.com", role: "chair" }];
+    const args = buildCalendarUpdateArgs({ id: "evt_2", attendees });
+    expect(args).toContain("--attendees");
+    const attIndex = args.indexOf("--attendees");
+    expect(JSON.parse(args[attIndex + 1])).toEqual(attendees);
   });
 });
 

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -430,13 +430,21 @@ private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [At
         let attendee = ekAttendeeClass.init()
 
         // UUID is required — EventKit's _addNewAttendeesToRecentsIfNeeded
-        // uses it as a dictionary key and crashes with nil if missing
-        safeSetValue(attendee, UUID().uuidString, forKey: "UUID")
+        // uses it as a dictionary key and crashes with nil if missing.
+        // Fail loudly if UUID can't be set rather than risking a later NSException.
+        guard safeSetValue(attendee, UUID().uuidString, forKey: "UUID") else {
+            throw CLIError.invalidInput(
+                "EKAttendee on this macOS version does not support setUUID:. " +
+                "Cannot safely create attendees without UUID support."
+            )
+        }
         safeSetValue(attendee, input.email, forKey: "emailAddress")
 
-        if let name = input.name {
+        if let name = input.name, !name.isEmpty {
             let parts = name.split(separator: " ", maxSplits: 1)
-            safeSetValue(attendee, String(parts[0]), forKey: "firstName")
+            if let first = parts.first {
+                safeSetValue(attendee, String(first), forKey: "firstName")
+            }
             if parts.count > 1 {
                 safeSetValue(attendee, String(parts[1]), forKey: "lastName")
             }
@@ -458,7 +466,14 @@ private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [At
         attendeeObjects.append(attendee)
     }
 
-    // Set attendees on the event via KVC (replaces any existing attendees)
+    // Set attendees on the event via KVC (replaces any existing attendees).
+    // Guard against NSException if EKEvent doesn't expose this key.
+    guard event.responds(to: NSSelectorFromString("setAttendees:")) else {
+        throw CLIError.invalidInput(
+            "EKEvent on this macOS version does not support setAttendees:. " +
+            "Attendee write support is not available."
+        )
+    }
     event.setValue(attendeeObjects, forKey: "attendees")
 }
 

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -376,6 +376,92 @@ func buildVerification(event: EKEvent, requestedStart: String, requestedEnd: Str
     return dict
 }
 
+// MARK: - Attendee Write Support (Private API)
+
+struct AttendeeJSON: Codable {
+    let email: String
+    let name: String?
+    let role: String?
+}
+
+func addAttendeesToEvent(_ event: EKEvent, json: String) throws {
+    guard let data = json.data(using: .utf8) else {
+        throw CLIError.invalidInput("Invalid attendees JSON encoding")
+    }
+    let attendeeInputs = try JSONDecoder().decode([AttendeeJSON].self, from: data)
+    try setAttendeesOnEvent(event, attendees: attendeeInputs)
+}
+
+func addAttendeesToEvent(_ event: EKEvent, attendees attendeeInputs: [AttendeeJSON]) throws {
+    try setAttendeesOnEvent(event, attendees: attendeeInputs)
+}
+
+/// Safely set a value via KVC, checking that the setter exists first.
+/// Returns true if the setter was found and called, false otherwise.
+/// This avoids uncatchable NSException crashes from setValue:forUndefinedKey:.
+@discardableResult
+private func safeSetValue(_ object: NSObject, _ value: Any?, forKey key: String) -> Bool {
+    let setter = NSSelectorFromString("set\(key.prefix(1).uppercased())\(key.dropFirst()):")
+    guard object.responds(to: setter) else { return false }
+    object.setValue(value, forKey: key)
+    return true
+}
+
+private func setAttendeesOnEvent(_ event: EKEvent, attendees attendeeInputs: [AttendeeJSON]) throws {
+    guard let ekAttendeeClass = NSClassFromString("EKAttendee") as? NSObject.Type else {
+        throw CLIError.invalidInput(
+            "EKAttendee class not available on this macOS version. " +
+            "Attendee write support requires the private EKAttendee class."
+        )
+    }
+
+    // Verify required KVC keys are available on this macOS version
+    let probe = ekAttendeeClass.init()
+    guard probe.responds(to: NSSelectorFromString("setEmailAddress:")) else {
+        throw CLIError.invalidInput(
+            "EKAttendee on this macOS version does not support setEmailAddress:. " +
+            "Attendee write support is not available."
+        )
+    }
+
+    var attendeeObjects: [NSObject] = []
+
+    for input in attendeeInputs {
+        let attendee = ekAttendeeClass.init()
+
+        // UUID is required — EventKit's _addNewAttendeesToRecentsIfNeeded
+        // uses it as a dictionary key and crashes with nil if missing
+        safeSetValue(attendee, UUID().uuidString, forKey: "UUID")
+        safeSetValue(attendee, input.email, forKey: "emailAddress")
+
+        if let name = input.name {
+            let parts = name.split(separator: " ", maxSplits: 1)
+            safeSetValue(attendee, String(parts[0]), forKey: "firstName")
+            if parts.count > 1 {
+                safeSetValue(attendee, String(parts[1]), forKey: "lastName")
+            }
+        }
+
+        let role: Int
+        switch input.role?.lowercased() {
+        case "optional":
+            role = EKParticipantRole.optional.rawValue
+        case "chair":
+            role = EKParticipantRole.chair.rawValue
+        case "nonparticipant":
+            role = EKParticipantRole.nonParticipant.rawValue
+        default:
+            role = EKParticipantRole.required.rawValue
+        }
+        safeSetValue(attendee, role, forKey: "participantRole")
+
+        attendeeObjects.append(attendee)
+    }
+
+    // Set attendees on the event via KVC (replaces any existing attendees)
+    event.setValue(attendeeObjects, forKey: "attendees")
+}
+
 // MARK: - Config Helpers
 
 /// Get only the calendars allowed by the current PIM config.
@@ -747,6 +833,9 @@ struct CreateEvent: AsyncParsableCommand {
     @Option(name: .long, help: "Recurrence rule as JSON (e.g., '{\"frequency\":\"weekly\",\"interval\":1}')")
     var recurrence: String?
 
+    @Option(name: .long, help: "Attendees as JSON array (e.g., '[{\"email\":\"a@b.com\",\"name\":\"Name\"}]')")
+    var attendees: String?
+
     func run() async throws {
         try await requestCalendarAccess()
 
@@ -793,6 +882,11 @@ struct CreateEvent: AsyncParsableCommand {
         // Add recurrence rule if specified
         if let recurrenceJSON = recurrence, let rule = parseRecurrenceRule(recurrenceJSON) {
             event.addRecurrenceRule(rule)
+        }
+
+        // Add attendees if specified
+        if let attendeesJSON = attendees {
+            try addAttendeesToEvent(event, json: attendeesJSON)
         }
 
         try eventStore.save(event, span: .thisEvent)
@@ -842,6 +936,9 @@ struct UpdateEvent: AsyncParsableCommand {
 
     @Option(name: .long, help: "Recurrence rule as JSON (e.g., '{\"frequency\":\"weekly\",\"interval\":1}')")
     var recurrence: String?
+
+    @Option(name: .long, help: "Attendees as JSON array (replaces all existing attendees)")
+    var attendees: String?
 
     @Flag(name: .long, help: "Apply changes to all future events in a recurring series")
     var futureEvents: Bool = false
@@ -894,6 +991,11 @@ struct UpdateEvent: AsyncParsableCommand {
             if let rule = parseRecurrenceRule(recurrenceJSON) {
                 event.addRecurrenceRule(rule)
             }
+        }
+
+        // Update attendees if specified
+        if let attendeesJSON = attendees {
+            try addAttendeesToEvent(event, json: attendeesJSON)
         }
 
         // Only use futureEvents span when explicitly requested by user
@@ -971,6 +1073,7 @@ struct BatchEventInput: Codable {
     let allDay: Bool?
     let alarm: [Int]?
     let recurrence: RecurrenceJSON?
+    let attendees: [AttendeeJSON]?
 }
 
 func decodeBatchEvents(_ json: String) throws -> [BatchEventInput] {
@@ -1063,6 +1166,11 @@ struct BatchCreateEvent: AsyncParsableCommand {
                        let rule = parseRecurrenceRule(recurrenceStr) {
                         event.addRecurrenceRule(rule)
                     }
+                }
+
+                // Add attendees if specified
+                if let attendeeInputs = eventInput.attendees {
+                    try addAttendeesToEvent(event, attendees: attendeeInputs)
                 }
 
                 // Save with commit: false to batch changes

--- a/swift/Tests/CalendarCLITests/BatchCreateEventValidationTests.swift
+++ b/swift/Tests/CalendarCLITests/BatchCreateEventValidationTests.swift
@@ -76,7 +76,8 @@ final class BatchCreateEventValidationTests: XCTestCase {
             url: nil,
             allDay: nil,
             alarm: nil,
-            recurrence: nil
+            recurrence: nil,
+            attendees: nil
         )
 
         let dates = try resolveBatchEventDates(input)
@@ -96,7 +97,8 @@ final class BatchCreateEventValidationTests: XCTestCase {
             url: nil,
             allDay: nil,
             alarm: nil,
-            recurrence: nil
+            recurrence: nil,
+            attendees: nil
         )
 
         let dates = try resolveBatchEventDates(input)
@@ -116,7 +118,8 @@ final class BatchCreateEventValidationTests: XCTestCase {
             url: nil,
             allDay: nil,
             alarm: nil,
-            recurrence: nil
+            recurrence: nil,
+            attendees: nil
         )
 
         XCTAssertThrowsError(try resolveBatchEventDates(input)) { error in
@@ -140,7 +143,8 @@ final class BatchCreateEventValidationTests: XCTestCase {
             url: nil,
             allDay: nil,
             alarm: nil,
-            recurrence: nil
+            recurrence: nil,
+            attendees: nil
         )
 
         XCTAssertThrowsError(try resolveBatchEventDates(input)) { error in


### PR DESCRIPTION
## Summary

Adds attendee write support to calendar create, update, and batch_create using the private `EKAttendee` class via KVC. Based on @larrywal's work in #43.

- `--attendees` flag accepts JSON array of `{email, name?, role?}` objects
- Uses `safeSetValue()` helper to check `responds(to:)` before KVC (prevents uncatchable `NSException` crashes)
- UUID generation per attendee (required by EventKit internals)
- When attendees are added to CalDAV-backed calendars (e.g. Google Calendar), the server sends invitation emails
- Schema: `attendees` array on both top-level calendar properties and `batch_create` event items

### Private API safety
- `NSClassFromString("EKAttendee")` guard: throws descriptive error if class unavailable
- Probe check: verifies `setEmailAddress:` selector exists before proceeding
- KVC keys used: `emailAddress`, `firstName`, `lastName`, `participantRole`, `UUID` (all stable 13+ years)

### Changes
| File | What |
|------|------|
| `swift/Sources/CalendarCLI/CalendarCLI.swift` | `AttendeeJSON`, `safeSetValue()`, `setAttendeesOnEvent()`, wired into create/update/batch_create |
| `lib/schemas.js` | `attendees` array property on calendar tool and batch_create items |
| `lib/tool-args.js` | `--attendees` flag with `JSON.stringify` in create and update builders |
| `mcp-server/test/tool-args.test.js` | 3 new tests for attendee arg construction |
| `mcp-server/dist/server.js` | Rebuilt bundle |

## Test plan
- [x] `swift build -c release` succeeds
- [x] All 44 MCP server tests pass (3 new)
- [x] All 137 deterministic eval tests pass
- [ ] End-to-end: create event with attendee, verify in Calendar.app
- [ ] End-to-end: Google Calendar sends invitation email via CalDAV

Based on work by @larrywal (PR #43). Thank you for the contribution!

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)