### PR TITLE
feat: configurable calendar date output format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Each Swift CLI is a standalone binary that reads from macOS frameworks, validate
 - The MCP server does NOT do any config filtering — it passes `--profile` to CLIs when set.
 - **OpenClaw plugin** (`openclaw/`): Registers tools that spawn CLIs directly (no MCP). Supports per-call `configDir`/`profile` parameters for multi-agent workspace isolation. See [`docs/multi-agent-setup.md`](docs/multi-agent-setup.md).
 - **Direct CLI usage:** `APPLE_PIM_CONFIG_DIR` overrides the config root directory; `APPLE_PIM_PROFILE` selects a profile.
+- **Date format:** `APPLE_PIM_DATE_FORMAT` selects calendar date output format. Presets: `utc` (default, `2026-03-20T14:00:00Z`), `local` (`2026-03-20T07:00:00-07:00`), `day-utc` (`Friday, 2026-03-20T14:00:00Z`), `day-local` (`Friday, 2026-03-20T07:00:00-07:00`). CalendarCLI only.
 
 ## Testing Notes
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ openclaw plugins install -l ./openclaw
 
 ## Configuration
 
-You can optionally restrict which domains and items the plugin can access. This is useful for:
-- Privacy — hide calendars you don't need the agent to see
-- Reducing noise — only show relevant reminder lists
-- Avoiding conflicts — disable mail here if you use a separate email MCP
-- Multi-agent setups — give each agent a profile with different access
+The plugin includes a full access control system (PIMConfig) that lets you restrict which calendars, reminder lists, and domains each agent can see. This is useful for:
+- **Access control** — allowlist or blocklist specific calendars and reminder lists
+- **Privacy** — hide calendars you don't need the agent to see
+- **Reducing noise** — only show relevant reminder lists
+- **Avoiding conflicts** — disable mail here if you use a separate email MCP
+- **Multi-agent setups** — give each agent a profile with different access
+- **Read-only calendars** — let agents see but not modify certain calendars
 
 ### Interactive Setup (Claude Code)
 
@@ -271,6 +273,24 @@ apple_pim_mail({ action: "auth_check", id: "<message-id>" })
 ```
 
 The `--trusted-senders` flag overrides the default config path. If the file doesn't exist, the verdict is `unknown` with a warning.
+
+### Date Output Format
+
+Set `APPLE_PIM_DATE_FORMAT` to control how CalendarCLI formats dates in JSON output. This helps LLM agents avoid wasting tokens computing day-of-week from raw ISO dates.
+
+| Preset | Example |
+|--------|---------|
+| `utc` (default) | `2026-03-20T14:00:00Z` |
+| `local` | `2026-03-20T07:00:00-07:00` |
+| `day-utc` | `Friday, 2026-03-20T14:00:00Z` |
+| `day-local` | `Friday, 2026-03-20T07:00:00-07:00` |
+
+```bash
+# Set in your shell profile or agent environment
+export APPLE_PIM_DATE_FORMAT=day-local
+```
+
+No env var = `utc` (current behavior, fully backwards compatible). CalendarCLI only; ReminderCLI uses a different date codepath.
 
 ### Notes
 

--- a/swift/Sources/CalendarCLI/CalendarCLI.swift
+++ b/swift/Sources/CalendarCLI/CalendarCLI.swift
@@ -96,6 +96,40 @@ func outputJSON(_ value: Any) {
     }
 }
 
+// MARK: - Date Output Formatting
+
+private let posixLocale = Locale(identifier: "en_US_POSIX")
+
+/// Format a date using the preset from APPLE_PIM_DATE_FORMAT (or an explicit override).
+/// Presets: utc (default), local, day-utc, day-local. Unknown values fall back to utc.
+func formatDate(_ date: Date, preset: String? = nil) -> String {
+    let preset = (preset ?? ProcessInfo.processInfo.environment["APPLE_PIM_DATE_FORMAT"] ?? "utc").lowercased()
+    let useLocal = preset == "local" || preset == "day-local"
+    let useDay = preset == "day-utc" || preset == "day-local"
+
+    let iso: String
+    if useLocal {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd'T'HH:mm:ssxxxxx"
+        fmt.locale = posixLocale
+        iso = fmt.string(from: date)
+    } else {
+        iso = ISO8601DateFormatter().string(from: date)
+    }
+
+    if useDay {
+        let dayFmt = DateFormatter()
+        dayFmt.dateFormat = "EEEE"
+        dayFmt.locale = posixLocale
+        dayFmt.timeZone = useLocal ? TimeZone.current : TimeZone(identifier: "UTC")!
+        return "\(dayFmt.string(from: date)), \(iso)"
+    }
+
+    return iso
+}
+
+// MARK: - Date-Only Detection
+
 private let dateOnlyISO = try! NSRegularExpression(pattern: #"^\d{4}-\d{2}-\d{2}$"#)
 private let dateOnlyUS  = try! NSRegularExpression(pattern: #"^\d{2}/\d{2}/\d{4}$"#)
 
@@ -219,8 +253,8 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
     var dict: [String: Any] = [
         "id": event.eventIdentifier ?? "",
         "title": event.title ?? "",
-        "startDate": ISO8601DateFormatter().string(from: event.startDate),
-        "endDate": ISO8601DateFormatter().string(from: event.endDate),
+        "startDate": formatDate(event.startDate),
+        "endDate": formatDate(event.endDate),
         "localStart": localDateFormatter.string(from: event.startDate),
         "localEnd": localDateFormatter.string(from: event.endDate),
         "isAllDay": event.isAllDay,
@@ -257,7 +291,7 @@ func ruleToDict(_ rule: EKRecurrenceRule) -> [String: Any] {
     ]
     if let end = rule.recurrenceEnd {
         if let endDate = end.endDate {
-            dict["endDate"] = ISO8601DateFormatter().string(from: endDate)
+            dict["endDate"] = formatDate(endDate)
         } else {
             dict["occurrenceCount"] = end.occurrenceCount
         }
@@ -326,9 +360,8 @@ func participantRoleString(_ role: EKParticipantRole) -> String {
 /// Build a verification dict comparing requested inputs against stored event values.
 /// Gives calling agents an immediate signal if date parsing produced wrong times.
 func buildVerification(event: EKEvent, requestedStart: String, requestedEnd: String?, requestedCalendar: String?) -> [String: Any] {
-    let isoFmt = ISO8601DateFormatter()
-    let storedStart = isoFmt.string(from: event.startDate)
-    let storedEnd = isoFmt.string(from: event.endDate)
+    let storedStart = formatDate(event.startDate)
+    let storedEnd = formatDate(event.endDate)
 
     // Re-parse the requested strings to compare as Date values (tolerating 1s for rounding)
     let startMatch: Bool
@@ -705,8 +738,8 @@ struct ListEvents: AsyncParsableCommand {
             "events": Array(events),
             "count": events.count,
             "dateRange": [
-                "from": ISO8601DateFormatter().string(from: startDate),
-                "to": ISO8601DateFormatter().string(from: endDate)
+                "from": formatDate(startDate),
+                "to": formatDate(endDate)
             ]
         ])
     }

--- a/swift/Tests/CalendarCLITests/DateParsingTests.swift
+++ b/swift/Tests/CalendarCLITests/DateParsingTests.swift
@@ -155,4 +155,47 @@ final class DateParsingTests: XCTestCase {
         XCTAssertEqual(result, "2026-03-16T04:00:00Z",
             "9 PM PDT should be 4 AM UTC next day")
     }
+
+    // MARK: - formatDate presets (APPLE_PIM_DATE_FORMAT)
+
+    private let testDate = ISO8601DateFormatter().date(from: "2026-03-20T14:00:00Z")!
+
+    func testFormatDateDefaultUTC() {
+        XCTAssertEqual(formatDate(testDate, preset: "utc"), "2026-03-20T14:00:00Z")
+    }
+
+    func testFormatDateLocal() {
+        let result = formatDate(testDate, preset: "local")
+        XCTAssertTrue(result.contains("T"), "Local format should contain T separator")
+        XCTAssertFalse(result.hasSuffix("Z"), "Local format should not end with Z")
+        XCTAssertTrue(result.contains("+") || result.contains("-"),
+            "Local format should include timezone offset")
+    }
+
+    func testFormatDateDayUTC() {
+        XCTAssertEqual(formatDate(testDate, preset: "day-utc"), "Friday, 2026-03-20T14:00:00Z")
+    }
+
+    func testFormatDateDayLocal() {
+        let result = formatDate(testDate, preset: "day-local")
+        // Don't hardcode day name — local timezone may shift the date (e.g. UTC+10 sees Saturday)
+        let parts = result.split(separator: ",", maxSplits: 1)
+        XCTAssertEqual(parts.count, 2, "day-local should contain a comma separating day name and ISO timestamp")
+        XCTAssertFalse(result.hasSuffix("Z"), "day-local should not end with Z")
+        XCTAssertTrue(result.contains("+") || result.dropFirst(10).contains("-"),
+            "day-local should include timezone offset")
+    }
+
+    func testFormatDateUnknownPreset() {
+        XCTAssertEqual(formatDate(testDate, preset: "bogus"), "2026-03-20T14:00:00Z",
+            "Unknown preset should fall back to UTC")
+    }
+
+    func testFormatDateNilPresetFallsBackToEnv() {
+        // With no preset and no APPLE_PIM_DATE_FORMAT env var, should default to UTC
+        let result = formatDate(testDate)
+        XCTAssertEqual(result, "2026-03-20T14:00:00Z",
+            "With no preset and no APPLE_PIM_DATE_FORMAT env var, should default to UTC")
+    }
+
 }


### PR DESCRIPTION
## Summary

- Adds `APPLE_PIM_DATE_FORMAT` env var to control CalendarCLI date output (presets: `utc`, `local`, `day-utc`, `day-local`)
- `day-*` presets surface day-of-week directly, saving LLM agents from computing it from raw ISO dates
- `local` presets show timezone offset instead of UTC, reducing mental math for users

## Changes

- `formatDate(_:preset:)` helper replaces 7 `ISO8601DateFormatter().string()` call sites
- Optional `preset:` parameter for direct testing without env var mutation
- 6 new tests covering all presets + unknown fallback + nil preset behavior
- README: document date format feature with preset table
- README: improve Configuration section intro to highlight access control features (allowlist, blocklist, read-only) for better discoverability

Based on #47 by @juan-deere-4000, with improved test design and documentation.

## Test plan

- [x] All 53 Swift tests pass (27 DateParsingTests including 6 new format tests)
- [x] All 125 agent eval tests pass
- [x] Backwards compatible (no env var = UTC, same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)