### PR TITLE
[codex] Update OpenClaw plugin for SDK 2026.6.5

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -40,6 +40,11 @@ jobs:
           fi
           echo "text=$MSG" >> "$GITHUB_OUTPUT"
 
+      - name: Install dependencies
+        run: |
+          cd openclaw
+          npm install --force
+
       - name: Resolve lib/ symlink for packaging
         run: |
           cd openclaw
@@ -48,7 +53,6 @@ jobs:
       - name: Install + build (compile TS so clawhub validator finds dist/)
         run: |
           cd openclaw
-          npm install --force
           npm run build
 
       - name: Sync manifest version to tag (tag is source of truth)

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -3,31 +3,6 @@
   "name": "Apple PIM",
   "description": "macOS-only. Wraps four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh — no binaries are downloaded by the registry. Grants the agent read/write access to Calendar, Reminders, Contacts, and Mail.app (including send/delete) once you approve the corresponding macOS TCC and Automation prompts.",
   "version": "3.8.0",
-  "platforms": [
-    "darwin"
-  ],
-  "requires": {
-    "binaries": [
-      "calendar-cli",
-      "reminder-cli",
-      "contacts-cli",
-      "mail-cli"
-    ],
-    "osPermissions": [
-      "macos:calendars",
-      "macos:reminders",
-      "macos:contacts",
-      "macos:mail-automation"
-    ],
-    "envVars": {
-      "optional": {
-        "APPLE_PIM_PROFILE": "Selects a named PIM profile under ~/.config/apple-pim/profiles/{name}.json. Filters calendars/lists/contacts.",
-        "APPLE_PIM_CONFIG_DIR": "Overrides the PIM config root directory (default: ~/.config/apple-pim/).",
-        "APPLE_PIM_DATE_FORMAT": "Calendar date output format. One of: utc (default), local, day-utc, day-local.",
-        "APPLE_PIM_MAIL_ATTACHMENTS_CONFIG": "Overrides the path to the mail attachment policy file (default: ~/.config/apple-pim/mail-attachments.json). Mail send/reply attachments are default-denied; this file is the opt-in mechanism."
-      }
-    }
-  },
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -4,21 +4,22 @@
   "description": "OpenClaw plugin for macOS Calendar, Reminders, Contacts, and Mail. macOS-only; depends on four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh. The registry does not download or install binaries.",
   "type": "module",
   "scripts": {
-    "prepack": "rm -rf lib && cp -R ../lib .",
-    "postpack": "rm -rf lib && ln -s ../lib .",
+    "prepack": "node -e \"const fs=require('node:fs'); fs.rmSync('lib', { recursive: true, force: true }); fs.cpSync('../lib', 'lib', { recursive: true });\" && npm run build",
+    "postpack": "node -e \"const fs=require('node:fs'); fs.rmSync('lib', { recursive: true, force: true }); fs.symlinkSync('../lib', 'lib', 'dir');\"",
     "plugin:check": "npx --yes @openclaw/plugin-inspector inspect --no-openclaw",
     "plugin:ci": "npx --yes @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute",
-    "build": "tsup src/index.ts --format esm --out-dir dist --dts --clean --target node20"
+    "build": "tsup src/index.ts --format esm --out-dir dist --clean --target node20"
   },
   "openclaw": {
     "extensions": [
       "./src/index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.3.23"
+      "pluginApi": ">=2026.6.5"
     },
     "build": {
-      "openclawVersion": "2026.3.28"
+      "openclawVersion": "2026.6.5",
+      "pluginSdkVersion": "2026.6.5"
     },
     "environment": {
       "binaries": [
@@ -78,11 +79,11 @@
     "darwin"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22.19.0"
   },
   "dependencies": {
     "mailparser": "^3.9.3",
-    "openclaw": "^2026.3.23",
+    "openclaw": "^2026.6.5",
     "turndown": "^7.2.2"
   },
   "main": "./dist/index.js",

--- a/openclaw/tsconfig.json
+++ b/openclaw/tsconfig.json
@@ -8,9 +8,14 @@
     "strict": true,
     "outDir": "dist",
     "rootDir": ".",
-    "declaration": true,
+    "declaration": false,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
## Summary
- update OpenClaw plugin metadata and package configuration for OpenClaw SDK 2026.6.5
- declare direct plugin dependencies where OpenClaw no longer provides transitive runtime packages
- keep local source entrypoints while ensuring published packages include compiled runtime output

## Validation
- ran plugin builds across the OpenClaw plugin inventory
- ran `@openclaw/plugin-inspector@latest inspect --openclaw /Users/omarshahine/GitHub/openclaw/openclaw --no-runtime` across the 16-plugin inventory with no live P0/P1 issues
- ran `npm pack --dry-run` checks for published packages to confirm compiled runtime files are included
- verified Trakt as both an unbuilt local linked plugin and a tarball install to confirm source and packaged runtime behavior
