### PR TITLE
fix(mail): reply no longer sends an empty body (#73)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "apple-pim",
       "source": "./",
       "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
-      "version": "3.8.2",
+      "version": "3.8.3",
       "keywords": [
         "calendar",
         "reminders",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
   "author": {
     "name": "Omar Shahine",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-mcp",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "MCP server for Apple PIM (Calendar, Reminders, Contacts, Mail)",
   "type": "module",
   "main": "dist/server.js",

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "apple-pim-cli",
   "name": "Apple PIM",
   "description": "macOS-only. Wraps four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh — no binaries are downloaded by the registry. Grants the agent read/write access to Calendar, Reminders, Contacts, and Mail.app (including send/delete) once you approve the corresponding macOS TCC and Automation prompts.",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-cli",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "OpenClaw plugin for macOS Calendar, Reminders, Contacts, and Mail. macOS-only; depends on four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh. The registry does not download or install binaries.",
   "type": "module",
   "scripts": {

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -474,6 +474,10 @@ func findMessageJXA(targetId: String, mailbox: String?, account: String?) -> Str
 /// -1728 (errAENoSuchObject) for nested mailboxes — notably Gmail/Workspace, where
 /// "All Mail" is nested under the "[Gmail]" container. See issue #67.
 ///
+/// The reply is composed `without opening window` so it stays in plain-text mode,
+/// where the `content` property is writable. `with opening window` forces HTML mode
+/// and drops the body silently. See issue #73.
+///
 /// `attachmentLines` is the pre-built `make new attachment …` snippet (may be empty).
 func buildReplyAppleScript(bodyPath: String, accountName: String, appleMailId: Int, attachmentLines: String) -> String {
     let escapedAccount = escapeForAppleScript(accountName)
@@ -511,8 +515,12 @@ func buildReplyAppleScript(bodyPath: String, accountName: String, appleMailId: I
         set theAccount to (first account whose name is "\(escapedAccount)")
         set origMsg to my findMsgById(\(appleMailId), (mailboxes of theAccount))
         if origMsg is missing value then error "Could not locate the original message (id \(appleMailId)) in account \\"\(escapedAccount)\\" to reply to"
-        set replyMsg to reply origMsg with opening window
-        set content of replyMsg to replyBody & return & return & content of replyMsg\(attachmentBlock)
+        -- `without opening window` is REQUIRED, not cosmetic: `with opening window`
+        -- makes Mail compose the reply in rich-text/HTML mode, where the plain-text
+        -- `content` property is read-only. Setting it then silently no-ops and the
+        -- reply sends with an empty body. See issue #73. Do not change back.
+        set replyMsg to reply origMsg without opening window
+        set content of replyMsg to replyBody\(attachmentBlock)
         send replyMsg
     end tell
     """

--- a/swift/Tests/MailCLITests/ScriptHelpersTests.swift
+++ b/swift/Tests/MailCLITests/ScriptHelpersTests.swift
@@ -61,8 +61,26 @@ final class ScriptHelpersTests: XCTestCase {
         XCTAssertTrue(script.contains("first account whose name is \"Google\""))
         XCTAssertTrue(script.contains("messages of mb whose id is theId"))
         XCTAssertTrue(script.contains("mailboxes of mb"))
-        XCTAssertTrue(script.contains("reply origMsg with opening window"))
+        XCTAssertTrue(script.contains("reply origMsg without opening window"))
         XCTAssertTrue(script.contains("send replyMsg"))
+    }
+
+    func testReplyScriptComposesWithoutOpeningWindow() {
+        // `with opening window` forces HTML mode, which makes the plain-text `content`
+        // property read-only — the reply then sends with an empty body. See issue #73.
+        let script = buildReplyAppleScript(
+            bodyPath: "/tmp/body.txt",
+            accountName: "Google",
+            appleMailId: 12345,
+            attachmentLines: ""
+        )
+        XCTAssertTrue(script.contains("reply origMsg without opening window"),
+                      "reply must compose without opening the window to keep content writable")
+        XCTAssertFalse(script.contains("reply origMsg with opening window"),
+                       "opening the window regresses the empty-body bug (issue #73)")
+        // Body is assigned directly, not concatenated onto the quoted original.
+        XCTAssertTrue(script.contains("set content of replyMsg to replyBody"))
+        XCTAssertFalse(script.contains("replyBody & return & return & content of replyMsg"))
     }
 
     func testReplyScriptEscapesAccountAndOmitsAttachmentBlockWhenEmpty() {


### PR DESCRIPTION
## Problem

The `reply` action (`apple_pim_mail`) sent replies with an **empty body**. `reply origMsg with opening window` composes the reply in rich-text/HTML mode, where the plain-text `content` property is read-only — so `set content of replyMsg to …` silently no-ops and the reply goes out with no text.

Fixes #73.

## Fix

`swift/Sources/MailCLI/MailCLI.swift` — `buildReplyAppleScript`:

- `reply origMsg with opening window` → `reply origMsg without opening window` (keeps the message in plain-text mode where `content` is writable)
- `set content of replyMsg to replyBody & return & return & content of replyMsg` → `set content of replyMsg to replyBody` (assign directly instead of concatenating onto the now-empty quoted original)
- Added an inline AppleScript comment **and** a doc comment marking `without opening window` as required, so it isn't "cleaned up" back into the bug

## Tests

- New `testReplyScriptComposesWithoutOpeningWindow` regression guard asserts the reply command never uses `with opening window` and assigns the body directly
- Updated `testReplyScriptSearchesAccountMailboxTreeRecursively` to match the new command
- Full `MailCLITests` suite: 26/26 pass

## Verification

- `swift build -c release`: clean (only pre-existing SSL deprecation warnings)
- `osacompile`: `reply origMsg without opening window` + `set content` grammar valid
- Not live-sent (Mail.app not running; would send real outbound mail) — the same change was previously validated live on a downstream fork

## Also

Bumps all five version sources to **3.8.3** (`scripts/check-versions.sh` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)