### PR TITLE
fix(mail-cli): pin authserv-id and require SPF alignment in auth-check

### DIFF
--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -2428,7 +2428,11 @@ struct AuthCheck: AsyncParsableCommand {
                 // Parse spf=
                 if let spfMatch = trimPart.range(of: #"spf\s*=\s*(\w+)"#, options: [.regularExpression, .caseInsensitive]) {
                     let resultStr = extractRegexGroup(trimPart, pattern: #"spf\s*=\s*(\w+)"#)?.lowercased() ?? "none"
-                    let mailFrom = extractRegexGroup(trimPart, pattern: #"smtp\.mailfrom\s*=\s*([\w@.\-]+)"#)?.lowercased()
+                    // Capture to the next delimiter rather than an allowlist of characters:
+                    // local-parts legitimately contain `+`, `=`, and other atext, and this value
+                    // now gates SPF alignment, so truncating it silently weakens a real verdict.
+                    let mailFrom = extractRegexGroup(trimPart, pattern: #"smtp\.mailfrom\s*=\s*([^\s;()]+)"#)
+                        .map(sanitizeMailFrom)
                     spfResult = SPFResult(result: resultStr, mailFrom: mailFrom)
                     _ = spfMatch
                 }
@@ -2460,6 +2464,13 @@ struct AuthCheck: AsyncParsableCommand {
             ids.append(contentsOf: scoped)
         }
         return Array(Set(ids.map { $0.lowercased() })).sorted()
+    }
+
+    /// Normalize a captured smtp.mailfrom value: strip angle brackets, quotes, and trailing
+    /// punctuation. The null sender used by bounces (`<>`) normalizes to empty, which never aligns.
+    private func sanitizeMailFrom(_ raw: String) -> String {
+        raw.trimmingCharacters(in: CharacterSet(charactersIn: "<>\"' ,"))
+            .lowercased()
     }
 
     /// Strip the optional RFC 8601 version token, so "mx.example.com 1" matches "mx.example.com".

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -2061,6 +2061,12 @@ private struct TrustedSender: Decodable {
 private struct TrustedSendersFile: Decodable {
     let version: Int?
     let trustedSenders: [TrustedSender]
+    /// authserv-id values our own trust boundary stamps, keyed by Mail.app account name.
+    /// `"*"` applies to every account. Mail.app aggregates accounts whose boundaries differ
+    /// (iCloud, Gmail-over-IMAP, Exchange), so this cannot be a single global list.
+    /// Empty or absent means no Authentication-Results header can be trusted: a sender can
+    /// write that header themselves, so an unpinned authserv-id is a spoofing oracle.
+    let trustedAuthservIds: [String: [String]]?
 }
 
 /// Parsed DKIM result from Authentication-Results header
@@ -2141,6 +2147,10 @@ struct AuthCheck: AsyncParsableCommand {
             try {
                 result.allHeaders = msg.allHeaders();
             } catch(e) {}
+            // Account decides which authserv-id is authoritative for this message.
+            try {
+                result.account = msg.mailbox().account().name();
+            } catch(e) {}
             JSON.stringify(result);
         }
         """
@@ -2201,15 +2211,55 @@ struct AuthCheck: AsyncParsableCommand {
         }
 
         // Parse Authentication-Results
-        let authResults = parseAuthenticationResults(headerText)
+        let allAuthResults = parseAuthenticationResults(headerText)
 
-        guard !authResults.isEmpty else {
+        guard !allAuthResults.isEmpty else {
             outputJSON([
                 "verdict": "unknown",
                 "sender": senderEmail,
                 "matchedContact": senderConfig.name,
                 "checks": [String: Any](),
                 "warnings": ["No Authentication-Results headers found"]
+            ])
+            return
+        }
+
+        // Keep only results stamped by our own boundary. Authentication-Results lives inside
+        // the message, so a sender can forge one; RFC 8601 only makes the boundary strip
+        // instances carrying its *own* authserv-id, so a forged id survives untouched.
+        let accountName = msgDict["account"] as? String
+        let trustedIds = trustedAuthservIds(file: trustedFile, account: accountName)
+        let observedIds = allAuthResults.map { normalizeAuthservId($0.authservId) }.filter { !$0.isEmpty }
+
+        guard !trustedIds.isEmpty else {
+            outputJSON([
+                "verdict": "unknown",
+                "sender": senderEmail,
+                "matchedContact": senderConfig.name,
+                "checks": [String: Any](),
+                "warnings": [
+                    "No trustedAuthservIds configured\(accountName.map { " for account '\($0)'" } ?? "") — "
+                        + "refusing to trust Authentication-Results headers, which senders can forge. "
+                        + "Observed authserv-ids on this message: \(Set(observedIds).sorted().joined(separator: ", ")). "
+                        + "Add the ones your own boundary stamps to trustedAuthservIds in trusted-senders.json."
+                ]
+            ])
+            return
+        }
+
+        let authResults = allAuthResults.filter { authservIdMatches($0.authservId, trusted: trustedIds) }
+
+        guard !authResults.isEmpty else {
+            outputJSON([
+                "verdict": "suspicious",
+                "sender": senderEmail,
+                "matchedContact": senderConfig.name,
+                "checks": [String: Any](),
+                "warnings": [
+                    "No Authentication-Results header from a trusted authserv-id "
+                        + "(trusted: \(trustedIds.joined(separator: ", ")); "
+                        + "observed: \(Set(observedIds).sorted().joined(separator: ", ")))"
+                ]
             ])
             return
         }
@@ -2243,17 +2293,33 @@ struct AuthCheck: AsyncParsableCommand {
             dkimCheck = ["result": "none", "signingDomain": "", "expected": expectedDkim, "match": false, "allSigningDomains": [String]()]
         }
 
-        // Build SPF check report
-        var spfCheck: [String: Any] = ["result": "none", "match": false]
+        // Build SPF check report. An SPF pass authenticates the envelope sender, not the
+        // From header, so it only says something about this message's claimed identity when
+        // smtp.mailfrom aligns with the From domain. Unaligned passes are reported but do
+        // not count as a pass.
+        let senderDomain = senderEmail.split(separator: "@").last.map(String.init)?.lowercased() ?? ""
+        var spfCheck: [String: Any] = ["result": "none", "match": false, "aligned": false]
         if let spf = aggregatedSpf {
+            let mailFromDomain = spf.mailFrom?.split(separator: "@").last.map(String.init)?.lowercased() ?? ""
+            let aligned = domainAligns(mailFromDomain, senderDomain)
             spfCheck["result"] = spf.result
-            spfCheck["match"] = spf.result == "pass"
+            spfCheck["mailFrom"] = spf.mailFrom ?? ""
+            spfCheck["aligned"] = aligned
+            spfCheck["match"] = spf.result == "pass" && aligned
+            if spf.result == "pass" && !aligned {
+                warnings.append(
+                    "SPF passed for '\(mailFromDomain.isEmpty ? "unknown" : mailFromDomain)' "
+                        + "but that does not align with From domain '\(senderDomain)', so it does not "
+                        + "authenticate this sender. Relayed mail usually authenticates via DKIM instead; "
+                        + "set requireSpf=false for this sender if DKIM carries it."
+                )
+            }
         }
 
-        // Determine verdict
+        // Determine verdict. `spfPass` requires alignment, not just a pass result.
         let dkimPass = (dkimCheck["result"] as? String) == "pass"
         let dkimDomainOk = (dkimCheck["match"] as? Bool) ?? false
-        let spfPass = (spfCheck["result"] as? String) == "pass"
+        let spfPass = (spfCheck["match"] as? Bool) ?? false
 
         let verdict: String
         if dkimPass && dkimDomainOk && spfPass {
@@ -2383,6 +2449,40 @@ struct AuthCheck: AsyncParsableCommand {
             return nil
         }
         return String(text[range])
+    }
+
+    /// authserv-id values trusted for this account: the `"*"` entry plus any account-specific
+    /// entry. Empty result means fail closed.
+    private func trustedAuthservIds(file: TrustedSendersFile, account: String?) -> [String] {
+        guard let map = file.trustedAuthservIds else { return [] }
+        var ids = map["*"] ?? []
+        if let account, let scoped = map[account] {
+            ids.append(contentsOf: scoped)
+        }
+        return Array(Set(ids.map { $0.lowercased() })).sorted()
+    }
+
+    /// Strip the optional RFC 8601 version token, so "mx.example.com 1" matches "mx.example.com".
+    private func normalizeAuthservId(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespaces)
+            .split(separator: " ")
+            .first
+            .map(String.init)?
+            .lowercased() ?? ""
+    }
+
+    private func authservIdMatches(_ raw: String, trusted: [String]) -> Bool {
+        let id = normalizeAuthservId(raw)
+        guard !id.isEmpty else { return false }
+        return trusted.contains(id)
+    }
+
+    /// Relaxed-alignment approximation: exact match, or one domain is a subdomain of the other.
+    /// Without a public-suffix list this cannot compute true organizational domains, so it is
+    /// deliberately narrower than DMARC relaxed alignment rather than wider.
+    private func domainAligns(_ a: String, _ b: String) -> Bool {
+        guard !a.isEmpty, !b.isEmpty else { return false }
+        return a == b || a.hasSuffix("." + b) || b.hasSuffix("." + a)
     }
 
     /// Check if a signing domain matches any expected domain (exact or subdomain).


### PR DESCRIPTION
## What Problem This Solves

`mail-cli auth-check` could be spoofed. Two independent defects, each sufficient on its own:

1. **authserv-id was parsed and never compared to anything.** `AuthResult.authservId` was populated and then only referenced in a comment. `Authentication-Results` is a header *inside* the message, so a sender can write one. RFC 8601 only requires a boundary to strip instances bearing its **own** authserv-id, so a forged header using any other id survives and was counted.
2. **SPF passes were not aligned.** `smtp.mailfrom` was extracted but never compared to the `From` domain, so an SPF pass for the attacker's own envelope domain counted as authentication of the claimed sender.

Combined, a message that forges its own `Authentication-Results` and passes SPF for the attacker's domain resolved to `verified` with both `requireDkim` and `requireSpf` enabled.

## Why This Change Was Made

This verdict gates whether an agent trusts a sender identity, so a bypass here is an identity-spoofing primitive, not a cosmetic issue.

## User Impact

**Breaking until configured.** `trustedAuthservIds` is new and required. Without it every verdict fails closed to `unknown`. To make discovery a copy step rather than research, the unconfigured path reports the authserv-ids observed on that message.

Config is keyed by Mail.app account name because Mail.app aggregates accounts behind different trust boundaries (iCloud, Gmail over IMAP, Exchange), so a single global list is wrong. Note the key must be the **JXA** account name; the SQLite engine reports a bare UUID for the same account.

```jsonc
"trustedAuthservIds": {
  "iCloud": ["dkim-verifier.icloud.com", "spf.icloud.com", "dmarc.icloud.com"]
}
```

Senders whose mail is relayed such that SPF no longer aligns may drop to `suspicious`. The right fix there is `requireSpf: false` for that sender, since `expectedDkimDomains` is doing the real work.

## Evidence

Built with `swift build --product mail-cli -c release`, clean apart from pre-existing `SSL*` deprecation warnings.

Against real messages on a live mailbox:

- Correct config, two messages (one relayed via Fastmail, one direct): `verified`, `dkim.signingDomain=shahine.com` matching `expectedDkimDomains`, `spf.aligned=true`.
- `trustedAuthservIds` pointed at a bogus id: the same message drops to `suspicious`, with all five real headers ignored. This is the forged-header bypass being closed, demonstrated rather than asserted.
- Verified through the calling wrapper, not just the binary.

Not covered: the `untrusted` (sender absent from `trusted-senders.json`) branch is unchanged but was not re-exercised.
