### PR TITLE
feat(mail-cli): let auth-check read headers without Mail.app

### DIFF
--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -2109,8 +2109,10 @@ struct AuthCheck: AsyncParsableCommand {
     @Option(name: .long, help: "Account name hint (speeds up lookup)")
     var account: String?
 
+    @Option(name: .long, help: "Read engine: auto (SQLite with JXA fallback), sqlite, or jxa")
+    var engine: EngineChoice = .auto
+
     func run() async throws {
-        try ensureMailRunning()
         let config = pimOptions.loadConfig()
         try checkMailEnabled(config: config)
 
@@ -2131,7 +2133,37 @@ struct AuthCheck: AsyncParsableCommand {
             return
         }
 
-        // Fetch message with allHeaders via JXA
+        // Prefer the SQLite/emlx path: it reads headers off disk, so a channel that
+        // authenticates every inbound message does not depend on Mail.app staying up.
+        var msgDict: [String: Any]? = nil
+        if engine != .jxa {
+            do {
+                let sqliteResult = try SQLiteEngine().get(
+                    id: id, includeSource: false, mailboxHint: mailbox, accountHint: account)
+                if let message = sqliteResult["message"] as? [String: Any] {
+                    msgDict = message
+                } else {
+                    msgDict = sqliteResult
+                }
+            } catch {
+                try rethrowIfForcedSQLite(engine, error)
+            }
+        }
+
+        if msgDict == nil {
+            msgDict = try await fetchMessageViaJXA()
+        }
+
+        guard let msgDict else {
+            throw CLIError.jxaError("Unexpected result from message lookup")
+        }
+
+        try await evaluate(msgDict: msgDict, trustedFile: trustedFile)
+    }
+
+    /// JXA fallback for header access when the SQLite/emlx path cannot serve the message.
+    private func fetchMessageViaJXA() async throws -> [String: Any] {
+        try ensureMailRunning()
         let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
         let script = """
         \(findHelper)
@@ -2164,7 +2196,10 @@ struct AuthCheck: AsyncParsableCommand {
         if let error = msgDict["error"] as? String {
             throw CLIError.notFound(error)
         }
+        return msgDict
+    }
 
+    private func evaluate(msgDict: [String: Any], trustedFile: TrustedSendersFile) async throws {
         // Extract sender email
         let senderRaw = msgDict["sender"] as? String ?? ""
         let senderEmail = extractEmailAddress(from: senderRaw)
@@ -2238,7 +2273,9 @@ struct AuthCheck: AsyncParsableCommand {
                 "matchedContact": senderConfig.name,
                 "checks": [String: Any](),
                 "warnings": [
-                    "No trustedAuthservIds configured\(accountName.map { " for account '\($0)'" } ?? "") — "
+                    // The engines identify accounts differently: JXA yields the display name,
+                    // SQLite yields the account UUID. Echo the exact key so config is a copy step.
+                    "No trustedAuthservIds configured\(accountName.map { " for account key '\($0)'" } ?? "") — "
                         + "refusing to trust Authentication-Results headers, which senders can forge. "
                         + "Observed authserv-ids on this message: \(Set(observedIds).sorted().joined(separator: ", ")). "
                         + "Add the ones your own boundary stamps to trustedAuthservIds in trusted-senders.json."


### PR DESCRIPTION
## What Problem This Solves

`auth-check` was JXA-only and called `ensureMailRunning()`, so authenticating a sender required Mail.app to be up. That blocks an email *channel*, which must authenticate every inbound message and cannot depend on a GUI app staying alive.

## Why This Change Was Made

`SQLiteEngine` already reads `allHeaders` from the emlx file on disk (`SQLiteEngine.swift:224`), so the headers were reachable without Mail.app all along. This adds the same `--engine` option `get` already has, defaulting to `auto` (SQLite first, JXA fallback).

## User Impact

Faster, and no longer launches Mail.app for a routine check. Existing behavior is preserved via fallback and `--engine jxa`.

One sharp edge, handled: the engines identify accounts differently. JXA reports the **display name** (`iCloud`), SQLite reports the **account UUID**. Since `trustedAuthservIds` is keyed per account, a naive wiring fails closed on every message. Both keys may now be configured for the same account, and the fail-closed warning echoes the exact key it looked for, so configuring is a copy step rather than a debugging session.

## Evidence

Against the live mailbox with **Mail.app quit**:

| invocation | Mail.app | result |
| --- | --- | --- |
| `--engine sqlite` | down | `verified`, dkim `shahine.com`, `spfAligned=true` |
| default (`auto`) | down | `verified`, and Mail.app was **not** launched |
| `--engine jxa` | up | `verified` |

Before the config carried the UUID key, the same run failed closed with a warning naming the exact missing key, which is the intended behavior and is how the mismatch was caught.