### PR TITLE
feat(openclaw): map mail auth results onto per-identifier strength

### DIFF
--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -8,7 +8,8 @@
     "postpack": "node -e \"const fs=require('node:fs'); fs.rmSync('lib', { recursive: true, force: true }); fs.symlinkSync('../lib', 'lib', 'dir');\"",
     "plugin:check": "npx --yes @openclaw/plugin-inspector inspect --no-openclaw",
     "plugin:ci": "npx --yes @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute",
-    "build": "tsup src/index.ts --format esm --out-dir dist --clean --target node20"
+    "build": "tsup src/index.ts --format esm --out-dir dist --clean --target node20",
+    "test": "node --test \"src/**/*.test.ts\""
   },
   "openclaw": {
     "extensions": [

--- a/openclaw/src/mail-auth/strength.test.ts
+++ b/openclaw/src/mail-auth/strength.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  mailAuthToIdentifierStrengths,
+  meetsMinimum,
+  weakest,
+  type MailAuthCheckResult,
+} from "./strength.ts";
+
+/** Builds an auth-check result without restating unrelated fields in every case. */
+function result(overrides: Partial<MailAuthCheckResult> = {}): MailAuthCheckResult {
+  return {
+    verdict: "verified",
+    sender: "omar@shahine.com",
+    checks: {
+      dkim: { result: "pass", signingDomain: "shahine.com", match: true },
+      spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+    },
+    ...overrides,
+  };
+}
+
+describe("ordering", () => {
+  it("ranks verified above asserted above mutable", () => {
+    assert.equal(meetsMinimum("verified", "asserted"), true);
+    assert.equal(meetsMinimum("asserted", "asserted"), true);
+    assert.equal(meetsMinimum("mutable", "asserted"), false);
+    assert.equal(meetsMinimum("asserted", "verified"), false);
+  });
+
+  it("takes the weaker side, which is how entry and subject combine", () => {
+    assert.equal(weakest("verified", "mutable"), "mutable");
+    assert.equal(weakest("verified", "asserted"), "asserted");
+    assert.equal(weakest("verified", "verified"), "verified");
+  });
+});
+
+describe("mailAuthToIdentifierStrengths", () => {
+  it("a display name is never promoted, whatever the verdict", () => {
+    for (const verdict of ["verified", "suspicious", "unknown", "untrusted"] as const) {
+      assert.equal(mailAuthToIdentifierStrengths(result({ verdict })).displayName, "mutable");
+    }
+  });
+
+  it("genuine mail from an enrolled sender verifies both address and domain", () => {
+    assert.deepEqual(mailAuthToIdentifierStrengths(result()), {
+      address: "verified",
+      domain: "verified",
+      displayName: "mutable",
+    });
+  });
+
+  // The forged-header case. auth-check reports `unknown` when no Authentication-Results
+  // came from a trusted authserv-id, so the only headers present are sender-writable.
+  it("refuses to promote anything when provenance was never established", () => {
+    const forged = result({
+      verdict: "unknown",
+      checks: {
+        dkim: { result: "pass", signingDomain: "shahine.com", match: true },
+        spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+      },
+      warnings: ["No trustedAuthservIds configured for account key 'iCloud'"],
+    });
+    assert.deepEqual(mailAuthToIdentifierStrengths(forged), {
+      address: "asserted",
+      domain: "asserted",
+      displayName: "mutable",
+    });
+  });
+
+  it("an unaligned SPF pass does not verify the domain", () => {
+    const unaligned = result({
+      verdict: "suspicious",
+      checks: {
+        dkim: { result: "none", signingDomain: "", match: false },
+        spf: { result: "pass", mailFrom: "bounce@attacker.example", aligned: false, match: false },
+      },
+    });
+    assert.equal(mailAuthToIdentifierStrengths(unaligned).domain, "asserted");
+    assert.equal(mailAuthToIdentifierStrengths(unaligned).address, "asserted");
+  });
+
+  // The case that motivates per-identifier scoring: the transport proved a domain but
+  // nothing binds this mailbox to that signer, so the two identifiers differ.
+  it("verifies the domain but not the address when the signer is unexpected", () => {
+    const unexpectedSigner = result({
+      verdict: "suspicious",
+      checks: {
+        dkim: { result: "pass", signingDomain: "bulk-sender.example", match: false },
+        spf: { result: "none", match: false },
+      },
+    });
+    assert.deepEqual(mailAuthToIdentifierStrengths(unexpectedSigner), {
+      address: "asserted",
+      domain: "verified",
+      displayName: "mutable",
+    });
+  });
+
+  it("does not verify the address for a sender who is not enrolled", () => {
+    const stranger = result({
+      verdict: "untrusted",
+      sender: "someone@example.com",
+      checks: { dkim: { result: "pass", signingDomain: "example.com", match: false } },
+    });
+    const strengths = mailAuthToIdentifierStrengths(stranger);
+    assert.equal(strengths.address, "asserted");
+    // Provenance held and DKIM passed, so the domain claim still stands. This is what
+    // makes "authenticated stranger, readable but not repliable" expressible.
+    assert.equal(strengths.domain, "verified");
+  });
+
+  it("treats missing checks as unproven rather than absent-therefore-fine", () => {
+    assert.deepEqual(mailAuthToIdentifierStrengths({ verdict: "suspicious" }), {
+      address: "asserted",
+      domain: "asserted",
+      displayName: "mutable",
+    });
+  });
+});
+
+describe("policy composition", () => {
+  // Mirrors the RFC's min(entry, subject) rule: a display-name allowlist entry stays weak
+  // no matter how strongly the message authenticated.
+  it("a mutable allowlist entry cannot be rescued by a verified message", () => {
+    const subject = mailAuthToIdentifierStrengths(result()).address;
+    assert.equal(meetsMinimum(weakest("mutable", subject), "asserted"), false);
+  });
+
+  it("a verified message clears a verified minimum on the address entry", () => {
+    const subject = mailAuthToIdentifierStrengths(result()).address;
+    assert.equal(meetsMinimum(weakest("verified", subject), "verified"), true);
+  });
+
+  it("today's default minimum admits anything non-mutable, preserving current behavior", () => {
+    const subject = mailAuthToIdentifierStrengths(result({ verdict: "suspicious" })).address;
+    assert.equal(meetsMinimum(weakest("verified", subject), "asserted"), true);
+  });
+});

--- a/openclaw/src/mail-auth/strength.test.ts
+++ b/openclaw/src/mail-auth/strength.test.ts
@@ -80,17 +80,45 @@ describe("mailAuthToIdentifierStrengths", () => {
     assert.equal(mailAuthToIdentifierStrengths(unaligned).address, "asserted");
   });
 
-  // The case that motivates per-identifier scoring: the transport proved a domain but
-  // nothing binds this mailbox to that signer, so the two identifiers differ.
-  it("verifies the domain but not the address when the signer is unexpected", () => {
-    const unexpectedSigner = result({
+  // A DKIM pass authenticates header.d, not the From domain. An unaligned signature means
+  // some unrelated domain signed this message, which vouches for nobody.
+  it("does not verify the domain on an unaligned DKIM signature", () => {
+    const unalignedSigner = result({
       verdict: "suspicious",
       checks: {
         dkim: { result: "pass", signingDomain: "bulk-sender.example", match: false },
         spf: { result: "none", match: false },
       },
     });
-    assert.deepEqual(mailAuthToIdentifierStrengths(unexpectedSigner), {
+    assert.deepEqual(mailAuthToIdentifierStrengths(unalignedSigner), {
+      address: "asserted",
+      domain: "asserted",
+      displayName: "mutable",
+    });
+  });
+
+  it("accepts a subdomain signature as aligned", () => {
+    const subdomainSigner = result({
+      verdict: "suspicious",
+      checks: {
+        dkim: { result: "pass", signingDomain: "mail.shahine.com", match: false },
+        spf: { result: "none", match: false },
+      },
+    });
+    assert.equal(mailAuthToIdentifierStrengths(subdomainSigner).domain, "verified");
+  });
+
+  // The case that motivates per-identifier scoring: the signature aligns, so the domain
+  // claim stands, but nothing binds this mailbox to that signer.
+  it("verifies the domain but not the address when the signer is aligned but unexpected", () => {
+    const alignedUnexpected = result({
+      verdict: "suspicious",
+      checks: {
+        dkim: { result: "pass", signingDomain: "shahine.com", match: false },
+        spf: { result: "none", match: false },
+      },
+    });
+    assert.deepEqual(mailAuthToIdentifierStrengths(alignedUnexpected), {
       address: "asserted",
       domain: "verified",
       displayName: "mutable",

--- a/openclaw/src/mail-auth/strength.ts
+++ b/openclaw/src/mail-auth/strength.ts
@@ -73,6 +73,29 @@ function provenanceEstablished(result: MailAuthCheckResult): boolean {
   return result.verdict !== "unknown";
 }
 
+/** Domain part of an address, lowercased. Empty when absent, which never aligns. */
+function senderDomain(address: string | undefined): string {
+  if (!address?.includes("@")) {
+    return "";
+  }
+  return address.split("@").pop()?.trim().toLowerCase() ?? "";
+}
+
+/**
+ * Relaxed-alignment approximation: exact match, or one domain is a subdomain of the other.
+ * Without a public-suffix list this cannot compute true organizational domains, so it is
+ * deliberately narrower than DMARC relaxed alignment rather than wider. Mirrors
+ * `domainAligns` in MailCLI.swift so the two sides cannot drift apart in interpretation.
+ */
+function domainsAlign(a: string | undefined, b: string | undefined): boolean {
+  const x = a?.trim().toLowerCase() ?? "";
+  const y = b?.trim().toLowerCase() ?? "";
+  if (!x || !y) {
+    return false;
+  }
+  return x === y || x.endsWith(`.${y}`) || y.endsWith(`.${x}`);
+}
+
 /**
  * Maps one auth-check result onto per-identifier strengths.
  *
@@ -93,12 +116,17 @@ export function mailAuthToIdentifierStrengths(
     return { address: "asserted", domain: "asserted", displayName };
   }
 
+  // A DKIM pass authenticates the *signing* domain (header.d), which is not automatically
+  // the sender's domain. Promoting on an unaligned signature would let any domain that can
+  // sign anything vouch for this sender, the same defect alignment fixes for SPF.
   const dkimPassed = result.checks?.dkim?.result === "pass";
+  const dkimAligned =
+    dkimPassed && domainsAlign(result.checks?.dkim?.signingDomain, senderDomain(result.sender));
   // `match` on spf already folds in alignment; `aligned` is kept for diagnostics.
   const spfPassedAligned = result.checks?.spf?.match === true;
 
   const domain: IdentifierAuthentication =
-    dkimPassed || spfPassedAligned ? "verified" : "asserted";
+    dkimAligned || spfPassedAligned ? "verified" : "asserted";
 
   // auth-check only returns `verified` when a DKIM signature matched the sender's
   // configured expectedDkimDomains (and SPF, unless that sender sets requireSpf=false).

--- a/openclaw/src/mail-auth/strength.ts
+++ b/openclaw/src/mail-auth/strength.ts
@@ -1,0 +1,109 @@
+/**
+ * Maps `mail-cli auth-check` output onto per-identifier authentication strength.
+ *
+ * This is the shim boundary for OpenClaw RFC 0027
+ * (https://github.com/openclaw/rfcs/pull/51). Core does not yet ship
+ * `IdentifierAuthentication`, so the type is declared locally and the gate is applied
+ * plugin-side. When the kernel lands the primitive, this module keeps its logic and only
+ * its consumers change: the strengths below are handed to the ingress subject instead of
+ * being enforced here.
+ *
+ * The invariant this module exists to hold: strength is derived only from transport
+ * metadata that our own boundary authenticated, never from sender-controlled message
+ * content. `mail-cli auth-check` enforces the provenance half (authserv-id pinning, SPF
+ * alignment); this module refuses to promote anything it cannot justify.
+ */
+
+/** Ordered authentication strength. Mirrors the RFC 0027 scale. */
+export type IdentifierAuthentication = "verified" | "asserted" | "mutable";
+
+const RANK: Record<IdentifierAuthentication, number> = {
+  verified: 2,
+  asserted: 1,
+  mutable: 0,
+};
+
+/** Returns true when `actual` meets or exceeds the required minimum. */
+export function meetsMinimum(
+  actual: IdentifierAuthentication,
+  minimum: IdentifierAuthentication,
+): boolean {
+  return RANK[actual] >= RANK[minimum];
+}
+
+/** Returns the weaker of two strengths, which is how entry and subject sides combine. */
+export function weakest(
+  a: IdentifierAuthentication,
+  b: IdentifierAuthentication,
+): IdentifierAuthentication {
+  return RANK[a] <= RANK[b] ? a : b;
+}
+
+/** Verdict vocabulary emitted by `mail-cli auth-check`. */
+export type MailAuthVerdict = "verified" | "suspicious" | "unknown" | "untrusted";
+
+/** Parsed shape of one `mail-cli auth-check` invocation. */
+export type MailAuthCheckResult = {
+  verdict: MailAuthVerdict;
+  sender?: string;
+  matchedContact?: string;
+  checks?: {
+    dkim?: { result?: string; signingDomain?: string; match?: boolean };
+    spf?: { result?: string; mailFrom?: string; aligned?: boolean; match?: boolean };
+  };
+  warnings?: string[];
+};
+
+/** Strength for each identifier one inbound message yields. */
+export type MailIdentifierStrengths = {
+  /** Full sender address. Needs an operator assertion binding address to signing domain. */
+  address: IdentifierAuthentication;
+  /** Sender domain. Needs only a passing check from a trusted boundary. */
+  domain: IdentifierAuthentication;
+  /** Display name. Sender-chosen, so never above `mutable`. */
+  displayName: IdentifierAuthentication;
+};
+
+/**
+ * `unknown` means auth-check could not establish provenance at all: no trusted
+ * authserv-id configured for the account, or no Authentication-Results from one. Nothing
+ * in the message may be promoted, because the only evidence available is sender-writable.
+ */
+function provenanceEstablished(result: MailAuthCheckResult): boolean {
+  return result.verdict !== "unknown";
+}
+
+/**
+ * Maps one auth-check result onto per-identifier strengths.
+ *
+ * The address and the domain are deliberately scored differently, which is the whole
+ * reason RFC 0027 is per-identifier rather than one per-message trust score:
+ *
+ * - A passing DKIM signature, or an aligned SPF pass, proves something about the *domain*.
+ * - Only a DKIM signature from a domain the operator listed in that sender's
+ *   `expectedDkimDomains` says anything about the *mailbox*, which is what auth-check's
+ *   own `verified` verdict already requires.
+ */
+export function mailAuthToIdentifierStrengths(
+  result: MailAuthCheckResult,
+): MailIdentifierStrengths {
+  const displayName: IdentifierAuthentication = "mutable";
+
+  if (!provenanceEstablished(result)) {
+    return { address: "asserted", domain: "asserted", displayName };
+  }
+
+  const dkimPassed = result.checks?.dkim?.result === "pass";
+  // `match` on spf already folds in alignment; `aligned` is kept for diagnostics.
+  const spfPassedAligned = result.checks?.spf?.match === true;
+
+  const domain: IdentifierAuthentication =
+    dkimPassed || spfPassedAligned ? "verified" : "asserted";
+
+  // auth-check only returns `verified` when a DKIM signature matched the sender's
+  // configured expectedDkimDomains (and SPF, unless that sender sets requireSpf=false).
+  // That operator assertion is what carries the claim from domain to mailbox.
+  const address: IdentifierAuthentication = result.verdict === "verified" ? "verified" : "asserted";
+
+  return { address, domain, displayName };
+}


### PR DESCRIPTION
First code toward the Apple Mail channel, and the shim boundary for [OpenClaw RFC 0027](https://github.com/openclaw/rfcs/pull/51).

## What Problem This Solves

The channel needs to answer "how strongly did the transport authenticate this sender" per inbound message. Core does not ship `IdentifierAuthentication` yet, so the type is declared locally and the gate is applied plugin-side. When the kernel lands the primitive, this module keeps its logic and only its consumers change: the strengths get handed to the ingress subject instead of being enforced here.

## Why This Change Was Made

It scores each identifier a message yields **separately**, which is the whole reason the RFC is per-identifier rather than one per-message trust score:

| identifier | reaches `verified` when |
| --- | --- |
| display name | never, it is sender-chosen |
| domain | DKIM pass, or an aligned SPF pass |
| address | auth-check's own verdict is `verified`, which requires a signature from that sender's configured `expectedDkimDomains` |

Nothing is promoted when provenance was never established (`verdict: unknown`), because the only evidence available then is sender-writable.

The interesting case is an unexpected signer: the transport proved a *domain* but nothing binds this mailbox to that signer, so the two identifiers legitimately differ. A single trust score cannot express that, and it is what makes "authenticated stranger, readable but not repliable" possible.

## User Impact

None yet. Nothing imports this module; it ships with the channel.

## Evidence

**Unit:** 12 tests, all passing, via `npm test`. Uses `node:test` with Node's native type stripping, so **no test-runner dependency was added**. Covers the forged-header case, unaligned SPF, unexpected signer, unenrolled senders, missing checks, and the `min(entry, subject)` composition rule including the row where today's default minimum preserves current behavior.

**Live:** cross-checked against real `mail-cli auth-check --engine sqlite` output on the actual mailbox. Both sample messages produce `{address: verified, domain: verified, displayName: mutable}`, matching the unit expectations, so the mapping is not merely internally consistent.

## Known Gaps

The channel adapter itself (polling, ingress wiring, outbound, security adapter) is not here. This is the piece that is independently testable and that the RFC needs proven; wiring follows once the channel contract work is done.