### PR TITLE
fix(mail-cli): evaluate authentication for unenrolled senders too

### DIFF
--- a/openclaw/src/mail-auth/strength.test.ts
+++ b/openclaw/src/mail-auth/strength.test.ts
@@ -125,17 +125,40 @@ describe("mailAuthToIdentifierStrengths", () => {
     });
   });
 
-  it("does not verify the address for a sender who is not enrolled", () => {
+  // Shape taken from a real `mail-cli auth-check` run against an unenrolled sender.
+  // Before mail-cli was fixed it returned empty `checks` here, which made this case
+  // indistinguishable from an unauthenticated stranger.
+  it("verifies the domain but not the address for an authenticated stranger", () => {
     const stranger = result({
       verdict: "untrusted",
-      sender: "someone@example.com",
-      checks: { dkim: { result: "pass", signingDomain: "example.com", match: false } },
+      sender: "noreply@email.apple.com",
+      checks: {
+        dkim: { result: "pass", signingDomain: "email.apple.com", match: false },
+        spf: { result: "pass", mailFrom: "bounce@email.apple.com", aligned: true, match: true },
+      },
     });
     const strengths = mailAuthToIdentifierStrengths(stranger);
+    // No expectedDkimDomains binds this address to a signer, so no mailbox claim.
     assert.equal(strengths.address, "asserted");
-    // Provenance held and DKIM passed, so the domain claim still stands. This is what
-    // makes "authenticated stranger, readable but not repliable" expressible.
+    // The transport did prove the domain. This is what makes "read an authenticated
+    // stranger, do not reply to them" expressible at all.
     assert.equal(strengths.domain, "verified");
+  });
+
+  it("keeps an unauthenticated stranger fully asserted", () => {
+    const stranger = result({
+      verdict: "untrusted",
+      sender: "spoofed@example.com",
+      checks: {
+        dkim: { result: "none", signingDomain: "", match: false },
+        spf: { result: "fail", aligned: false, match: false },
+      },
+    });
+    assert.deepEqual(mailAuthToIdentifierStrengths(stranger), {
+      address: "asserted",
+      domain: "asserted",
+      displayName: "mutable",
+    });
   });
 
   it("treats missing checks as unproven rather than absent-therefore-fine", () => {

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -2220,16 +2220,13 @@ struct AuthCheck: AsyncParsableCommand {
             sender.emails.contains { $0.lowercased() == senderEmail }
         }
 
-        guard let senderConfig = senderConfig else {
-            outputJSON([
-                "verdict": "untrusted",
-                "sender": senderEmail,
-                "matchedContact": "",
-                "checks": [String: Any](),
-                "warnings": ["Sender \(senderEmail) not in trusted-senders.json"]
-            ])
-            return
-        }
+        // Deliberately NOT short-circuiting on an unenrolled sender. Enrollment answers
+        // "may this mailbox speak for a known person", authentication answers "did the
+        // transport prove the domain". They are different questions, and returning early
+        // here made the second unanswerable for strangers, which in turn made any graduated
+        // policy (read an authenticated stranger, do not reply to them) impossible to build.
+        // Unenrolled senders still get their headers evaluated; they just cannot reach
+        // `verified`, because no expectedDkimDomains binds the address to a signer.
 
         // Get allHeaders
         let headerText = normalizeHeaders(msgDict["allHeaders"])
@@ -2238,7 +2235,7 @@ struct AuthCheck: AsyncParsableCommand {
             outputJSON([
                 "verdict": "unknown",
                 "sender": senderEmail,
-                "matchedContact": senderConfig.name,
+                "matchedContact": senderConfig?.name ?? "",
                 "checks": [String: Any](),
                 "warnings": ["allHeaders field is empty — JXA may not have returned headers"]
             ])
@@ -2252,7 +2249,7 @@ struct AuthCheck: AsyncParsableCommand {
             outputJSON([
                 "verdict": "unknown",
                 "sender": senderEmail,
-                "matchedContact": senderConfig.name,
+                "matchedContact": senderConfig?.name ?? "",
                 "checks": [String: Any](),
                 "warnings": ["No Authentication-Results headers found"]
             ])
@@ -2270,7 +2267,7 @@ struct AuthCheck: AsyncParsableCommand {
             outputJSON([
                 "verdict": "unknown",
                 "sender": senderEmail,
-                "matchedContact": senderConfig.name,
+                "matchedContact": senderConfig?.name ?? "",
                 "checks": [String: Any](),
                 "warnings": [
                     // The engines identify accounts differently: JXA yields the display name,
@@ -2290,7 +2287,7 @@ struct AuthCheck: AsyncParsableCommand {
             outputJSON([
                 "verdict": "suspicious",
                 "sender": senderEmail,
-                "matchedContact": senderConfig.name,
+                "matchedContact": senderConfig?.name ?? "",
                 "checks": [String: Any](),
                 "warnings": [
                     "No Authentication-Results header from a trusted authserv-id "
@@ -2302,9 +2299,13 @@ struct AuthCheck: AsyncParsableCommand {
         }
 
         // Evaluate
-        let expectedDkim = senderConfig.expectedDkimDomains ?? []
-        let requireDkim = senderConfig.requireDkim ?? true
-        let requireSpf = senderConfig.requireSpf ?? true
+        // An unenrolled sender has no configured expectations, so no signature can match
+        // and the address claim cannot be made. Its headers are still evaluated so the
+        // domain-level result is available to callers.
+        let enrolled = senderConfig != nil
+        let expectedDkim = senderConfig?.expectedDkimDomains ?? []
+        let requireDkim = senderConfig?.requireDkim ?? true
+        let requireSpf = senderConfig?.requireSpf ?? true
         var warnings = [String]()
 
         // Aggregate DKIM results from all AR headers
@@ -2323,7 +2324,9 @@ struct AuthCheck: AsyncParsableCommand {
         } else if anyDkimPass {
             let firstPass = allDkim.first { $0.result == "pass" }!
             dkimCheck = ["result": "pass", "signingDomain": firstPass.signingDomain, "expected": expectedDkim, "match": false, "allSigningDomains": allSigningDomains]
-            warnings.append("DKIM passed but no signing domain in \(allSigningDomains) matches expected \(expectedDkim)")
+            if enrolled {
+                warnings.append("DKIM passed but no signing domain in \(allSigningDomains) matches expected \(expectedDkim)")
+            }
         } else if let first = allDkim.first {
             dkimCheck = ["result": first.result, "signingDomain": first.signingDomain, "expected": expectedDkim, "match": false, "allSigningDomains": allSigningDomains]
         } else {
@@ -2358,7 +2361,7 @@ struct AuthCheck: AsyncParsableCommand {
         let dkimDomainOk = (dkimCheck["match"] as? Bool) ?? false
         let spfPass = (spfCheck["match"] as? Bool) ?? false
 
-        let verdict: String
+        var verdict: String
         if dkimPass && dkimDomainOk && spfPass {
             verdict = "verified"
         } else if dkimPass && dkimDomainOk && !requireSpf {
@@ -2372,7 +2375,8 @@ struct AuthCheck: AsyncParsableCommand {
             if requireDkim && !dkimPass {
                 warnings.append("DKIM required but result is '\(dkimCheck["result"] ?? "none")'")
             }
-            if requireDkim && dkimPass && !dkimDomainOk {
+            // Only meaningful when the operator configured an expectation to violate.
+            if enrolled && requireDkim && dkimPass && !dkimDomainOk {
                 warnings.append("DKIM passed but signing domain mismatch — possible spoofing")
             }
             if requireSpf && !spfPass {
@@ -2380,10 +2384,20 @@ struct AuthCheck: AsyncParsableCommand {
             }
         }
 
+        // Enrollment is the last word on the verdict, but not on the checks. An unenrolled
+        // sender can never be `verified`, because nothing binds that address to a signer,
+        // yet the DKIM/SPF results above still describe what the transport proved about the
+        // domain. Callers use that to treat an authenticated stranger differently from an
+        // unauthenticated one.
+        if !enrolled {
+            verdict = "untrusted"
+            warnings.append("Sender \(senderEmail) not in trusted-senders.json")
+        }
+
         outputJSON([
             "verdict": verdict,
             "sender": senderEmail,
-            "matchedContact": senderConfig.name,
+            "matchedContact": senderConfig?.name ?? "",
             "checks": [
                 "dkim": dkimCheck,
                 "spf": spfCheck

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -2350,8 +2350,10 @@ struct AuthCheck: AsyncParsableCommand {
                 warnings.append(
                     "SPF passed for '\(mailFromDomain.isEmpty ? "unknown" : mailFromDomain)' "
                         + "but that does not align with From domain '\(senderDomain)', so it does not "
-                        + "authenticate this sender. Relayed mail usually authenticates via DKIM instead; "
-                        + "set requireSpf=false for this sender if DKIM carries it."
+                        + "authenticate this sender."
+                        + (enrolled
+                            ? " Relayed mail usually authenticates via DKIM instead; set requireSpf=false for this sender if DKIM carries it."
+                            : "")
                 )
             }
         }
@@ -2372,14 +2374,15 @@ struct AuthCheck: AsyncParsableCommand {
             if !dkimPass { warnings.append("DKIM result is '\(dkimCheck["result"] ?? "none")' but not required for this sender") }
         } else {
             verdict = "suspicious"
-            if requireDkim && !dkimPass {
+            // "required" only means something when the operator configured a requirement.
+            if enrolled && requireDkim && !dkimPass {
                 warnings.append("DKIM required but result is '\(dkimCheck["result"] ?? "none")'")
             }
             // Only meaningful when the operator configured an expectation to violate.
             if enrolled && requireDkim && dkimPass && !dkimDomainOk {
                 warnings.append("DKIM passed but signing domain mismatch — possible spoofing")
             }
-            if requireSpf && !spfPass {
+            if enrolled && requireSpf && !spfPass {
                 warnings.append("SPF required but result is '\(spfCheck["result"] ?? "none")'")
             }
         }


### PR DESCRIPTION
Follow-up to #80, which was wrong in a way the tests hid.

## What Problem This Solves

`auth-check` returned `untrusted` with **empty `checks`** and returned *before headers were read* (previously `MailCLI.swift:2223`). So it could never answer whether a stranger's mail authenticated.

That conflates two different questions:

- **Enrollment**: may this mailbox speak for a known person?
- **Authentication**: did the transport prove the domain?

## Why This Change Was Made

The consequence is not cosmetic. **"Read an authenticated stranger, do not reply to them" was unbuildable**, because every unenrolled sender looked identical to a spoofed one. That is precisely the limitation of the Apple Mail `From Contacts` rule we just retired, which only ever fired for known contacts.

Unenrolled senders now get their headers evaluated and their DKIM/SPF results reported. The verdict stays `untrusted`, because no `expectedDkimDomains` binds that address to a signer, so no mailbox-level claim can be made. Only the verdict is gated on enrollment; the evidence is not.

Expectation-violation warnings are now gated on enrollment too. Without a configured expectation there is nothing to violate, and emitting "possible spoofing" on every newsletter is noise that would train the reader to ignore it.

## User Impact

`untrusted` results now carry `checks`. Additive; nothing that read the verdict changes behavior.

## Evidence

15 tests passing. The fabricated test from #80 (which asserted a payload shape `auth-check` could not emit) is replaced with a real captured one, plus a new case for an unauthenticated stranger.

Live, against the real mailbox:

| sender | verdict | strengths |
| --- | --- | --- |
| enrolled (`omar@shahine.com`) | `verified` | `{address: verified, domain: verified}` |
| authenticated stranger (`noreply@email.apple.com`, aligned DKIM + aligned SPF) | `untrusted` | `{address: asserted, domain: verified}` |
| unauthenticated stranger | `untrusted` | `{address: asserted, domain: asserted}` |

That middle row is the one that was unreachable before, and it is what the graduated sender policy needs.