### PR TITLE
docs: enumerate every mail ingress and egress scenario

### DIFF
--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -70,8 +70,9 @@ not act or reply. `drop` means it never reaches the agent.
 | I6 | Unauthenticated stranger | `asserted` | `asserted` | `drop` |
 | I7 | Spoofed operator, forged `Authentication-Results` | `asserted` | `asserted` | `drop`, forged header never read |
 | I8 | Spoofed operator, valid SPF for the attacker's own domain | `asserted` | `asserted` | `drop`, unaligned pass does not count |
-| I9 | Reply inside a thread the agent started | inherits | inherits | `dispatch` (see E4) |
+| I9 | Reply inside a thread the agent started, from an addressed participant | inherits | inherits | `dispatch` (see E1) |
 | I10 | Reply inside a thread the agent did not start | per I1-I6 | | as if new |
+| I10a | Claimed thread membership from a non-participant | per I1-I6 | | thread claim ignored, treated as new |
 | I11 | Bulk or marketing mail, authenticated | `verified` | `asserted` | `observe` |
 | I12 | Forwarded mail | usually `asserted` | `asserted` | `observe` at best |
 | I13 | Mail from the agent's own address | n/a | n/a | `drop`, loop guard |
@@ -148,14 +149,33 @@ Nothing more. No inactivity window, no turn cap, no explicit close. If the agent
 the conversation, it may continue it; if it did not, replying is originating and falls under
 default-deny.
 
-Two properties this rule must preserve:
+**Thread membership cannot be taken from the message.** `References` and `In-Reply-To` are
+sender-controlled headers, exactly like `From`. A sender who learns a `Message-ID` from an
+agent-originated thread, by being forwarded a copy or by any other leak, can set
+`In-Reply-To` to it and claim membership. Under a naive reading of the rule that claim would
+earn reply permission, which would make the thread rule a hole in default-deny rather than a
+narrow exception to it.
+
+So the claim is checked against the agent's own record, on both ends:
+
+1. The claimed parent must be a `Message-ID` **the agent itself generated**. A thread root
+   the agent never sent is not an agent-originated thread, whatever the headers say.
+2. The sender must be an address **the agent actually addressed** in that thread. Forging
+   `In-Reply-To` gains nothing unless you were already a participant, and a participant
+   already had permission.
+
+Both conditions come from state the agent wrote down when it sent the message. Neither is
+read from the inbound message. That is the same discipline the rest of this document applies
+to authentication: the evidence must come from a side the sender does not control.
+
+Two further properties the rule must preserve:
 
 - **It is scoped to the thread, not the sender.** Replying inside a thread must never widen
   into standing permission to contact that address. When the thread ends, so does the
   permission.
-- **Thread membership comes from the message, not from the address.** Identity is the
-  `References` / `In-Reply-To` chain back to a root the agent originated. Two messages from
-  the same person in different threads are two different decisions.
+- **Two messages from the same person in different threads are two different decisions.**
+  Permission does not generalize across threads any more than it generalizes across
+  addresses.
 
 **E2 deserves its own note**, because it is the case people expect to work. Someone
 authenticated writes to the agent unprompted; the agent may read it (I5) but not answer it.
@@ -193,6 +213,8 @@ what the agent is even allowed to see.
 - **Escalating the operator past authentication.** See I2.
 - **Inferring egress permission from inbound trust.** They are separate grants.
 - **Standing permission earned by replying.** See the thread rule.
+- **Thread membership asserted by the sender.** `References` and `In-Reply-To` are claims,
+  not credentials. Membership is checked against what the agent recorded sending.
 - **Authenticating a mailbox from a domain proof.** Requires an explicit per-sender
   assertion; nothing derives it.
 

--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -1,0 +1,211 @@
+---
+title: "Mail Channel Scenarios"
+description: "Every inbound and outbound mail scenario for an agent and its operator, and how the channel decides each one."
+---
+
+# Mail Channel Scenarios
+
+Mail is the only common agent channel where the transport authenticates the *message*
+rather than the *session*. Every other channel hands the agent a sender identity that some
+gateway already proved. Mail hands it a string the sender typed, plus optional evidence
+about that string, plus the possibility that the evidence itself was typed by the sender.
+
+This document enumerates the scenarios that follow, and how the channel decides each one.
+It is written to be readable without the implementation in front of you, because the point
+of writing it down is to make the policy arguable before it is code.
+
+## The three questions
+
+Every decision in this document reduces to three independent questions. Conflating any two
+of them produces a bug, and most mail-agent designs conflate at least one.
+
+| Question | Answered by | Failure if conflated |
+| --- | --- | --- |
+| **Who does this message claim to be from?** | The `From` header | Trusting a string anyone can type |
+| **Did our own trust boundary prove that claim?** | DKIM/SPF/DMARC results stamped by a pinned `authserv-id` | Reading evidence the sender wrote |
+| **Is that identity enrolled with us?** | Operator configuration | Treating an authenticated stranger as a known correspondent, or as a spoofer |
+
+The channel keeps these separate. Authentication is evaluated for **every** sender,
+including strangers, and enrollment gates only what the identity is permitted to do.
+
+### Strength, per identifier
+
+One message yields several identifiers, and they are not equally trustworthy. This matters
+because DMARC alignment authenticates a **domain**, never a mailbox.
+
+| Identifier | Reaches `verified` when |
+| --- | --- |
+| Display name | Never. It is sender-chosen. |
+| Sender domain | An aligned DKIM signature, or an aligned SPF pass, from a trusted boundary |
+| Full address | The above, **and** the signing domain is one the operator listed for that specific sender |
+
+That last row is the only thing that carries a claim from "this domain sent it" to "this
+person sent it", and it requires an explicit operator assertion. Nothing infers it.
+
+### Provenance
+
+`Authentication-Results` is a header inside the message. A sender can write one. RFC 8601
+only requires a receiving boundary to strip instances bearing *its own* identifier, so a
+forged header using any other identifier arrives intact.
+
+The channel therefore accepts authentication results only from an `authserv-id` the
+operator configured for that account, and fails closed when none is configured. This is
+per account, not per channel, because a single mailbox aggregates accounts sitting behind
+different boundaries.
+
+---
+
+## Ingress: mail arriving
+
+`dispatch` means the agent acts on it. `observe` means the agent may read and summarize but
+not act or reply. `drop` means it never reaches the agent.
+
+| # | Scenario | Domain | Address | Outcome |
+| --- | --- | --- | --- | --- |
+| I1 | Operator, authenticated, enrolled | `verified` | `verified` | `dispatch` |
+| I2 | Operator's address, authentication failed | `asserted` | `asserted` | `drop` |
+| I3 | Operator's address, no trusted `authserv-id` configured | `asserted` | `asserted` | `drop`, with a config warning |
+| I4 | Enrolled non-operator (family, colleague) | `verified` | `verified` | `dispatch`, subject to sender policy |
+| I5 | Authenticated stranger | `verified` | `asserted` | `observe` |
+| I6 | Unauthenticated stranger | `asserted` | `asserted` | `drop` |
+| I7 | Spoofed operator, forged `Authentication-Results` | `asserted` | `asserted` | `drop`, forged header never read |
+| I8 | Spoofed operator, valid SPF for the attacker's own domain | `asserted` | `asserted` | `drop`, unaligned pass does not count |
+| I9 | Reply inside a thread the agent started | inherits | inherits | `dispatch` (see E4) |
+| I10 | Reply inside a thread the agent did not start | per I1-I6 | | as if new |
+| I11 | Bulk or marketing mail, authenticated | `verified` | `asserted` | `observe` |
+| I12 | Forwarded mail | usually `asserted` | `asserted` | `observe` at best |
+| I13 | Mail from the agent's own address | n/a | n/a | `drop`, loop guard |
+| I14 | Mail in Junk | n/a | n/a | not polled |
+| I15 | Mail with attachments | per above | | admission unchanged; attachments separately gated |
+
+### The scenarios worth explaining
+
+**I2, and why the operator is not special.** An operator's address that fails
+authentication is dropped, not escalated. The whole point of the model is that the `From`
+header carries no weight on its own, and making an exception for the most valuable identity
+in the system would invert that. If the operator's own mail stops arriving, the correct
+response is to fix the authentication path, not to add a bypass.
+
+**I3, fail-closed and why it is loud.** With no configured `authserv-id`, the channel
+cannot distinguish a genuine result from a forged one, so it trusts neither. This means a
+misconfigured install processes nothing, which is the safe direction but an opaque failure.
+The channel therefore reports the `authserv-id` values it actually observed on the message,
+so configuring it is a copy step rather than an investigation.
+
+**I5 is the scenario that justifies the whole design.** An authenticated stranger is not a
+threat and not a correspondent. The transport genuinely proved which domain sent the
+message; nothing proved this human should be able to direct an agent. Reading it is useful.
+Acting on it is not acceptable. A binary allow/deny model cannot express this, which is why
+the older "sender is in my address book" rule could not either: it never fired for
+strangers at all, so an authenticated stranger and a spoofed one were equally invisible.
+
+**I7 and I8 are the two live attacks.** Both were real defects in this codebase before the
+current design. I7 is a forged `Authentication-Results` header that a naive parser reads as
+genuine. I8 is an SPF pass for the attacker's own envelope domain being counted as
+authentication of a `From` address it has nothing to do with. Neither requires anything
+exotic; both are trivially reachable by any sender.
+
+**I12, forwarding, is a real and unavoidable loss.** Forwarding usually breaks SPF and often
+breaks DKIM alignment. Forwarded mail from a person the operator trusts will generally not
+reach `verified`, and will be treated as a stranger. This is correct: the forwarder, not the
+original author, is who the transport can speak for. Operators who need forwarded mail
+handled should enroll the forwarding address.
+
+**I13, loop prevention, is not optional.** An agent that can send mail and read mail can
+answer itself. The channel drops mail from any address it sends as, before policy is
+consulted.
+
+---
+
+## Egress: mail leaving
+
+Egress is **default-deny**. The agent may not originate mail to an address unless the
+operator has permitted it. Inbound authentication strength grants nothing outbound: proving
+who sent you a message says nothing about who you may contact.
+
+| # | Scenario | Permitted | Basis |
+| --- | --- | --- | --- |
+| E1 | Reply within a thread the agent originated | yes | Thread rule |
+| E2 | Reply within a thread the agent did not originate | no | Not covered by the thread rule |
+| E3 | New mail to the operator | yes | Operator is always a permitted recipient |
+| E4 | New mail to an enrolled correspondent | only if allowlisted for egress | Enrollment is inbound; egress is separate |
+| E5 | New mail to an arbitrary address | no | Default-deny |
+| E6 | Mail the operator explicitly asked the agent to send | yes, for that instruction | Operator instruction is the authority |
+| E7 | Forwarding an inbound message onward | no, unless the recipient is permitted | Forwarding is originating |
+| E8 | Reply-all where some recipients are unknown | reply narrowed to permitted recipients | Unknown recipients are not silently included |
+| E9 | Mail with attachments | separately gated | Attachment policy is default-deny with explicit allowed roots |
+| E10 | Mail to the agent's own address | no | Loop guard |
+
+### The thread rule
+
+A reply is permitted when both hold:
+
+```
+isThread && threadOriginatedFromAgent
+```
+
+Nothing more. No inactivity window, no turn cap, no explicit close. If the agent started
+the conversation, it may continue it; if it did not, replying is originating and falls under
+default-deny.
+
+Two properties this rule must preserve:
+
+- **It is scoped to the thread, not the sender.** Replying inside a thread must never widen
+  into standing permission to contact that address. When the thread ends, so does the
+  permission.
+- **Thread membership comes from the message, not from the address.** Identity is the
+  `References` / `In-Reply-To` chain back to a root the agent originated. Two messages from
+  the same person in different threads are two different decisions.
+
+**E2 deserves its own note**, because it is the case people expect to work. Someone
+authenticated writes to the agent unprompted; the agent may read it (I5) but not answer it.
+That asymmetry is deliberate. Answering is how an unknown party discovers the agent exists,
+confirms a human is behind it, and starts a conversation on their terms. The operator can
+always permit the address explicitly, which is the point: it should be a decision.
+
+---
+
+## Cross-cutting concerns
+
+**Approvals.** Where a scenario is denied by policy but reasonable to allow case by case,
+the channel should raise an approval rather than fail silently. A denial the operator never
+sees is indistinguishable from a bug.
+
+**Audit.** Every admission decision records the reason code and the strengths that produced
+it. "Why did the agent not answer that?" must be answerable after the fact, and the answer
+must not require re-reading the mailbox.
+
+**Rate and volume.** Default-deny bounds *who* the agent may contact, not *how much*. A
+permitted recipient plus a loop the loop guard does not catch is still a way to send a
+hundred messages. Volume limits are a separate control and are not covered here.
+
+**Attachments.** Orthogonal to admission. Inbound attachments do not change a sender's
+strength; outbound attachments are default-denied unless the operator opts specific paths in.
+
+**Polling, not push.** The channel reads the local mail store on an interval rather than
+depending on a mail-client rule to wake it. That removes a GUI dependency, and it means the
+filter lives in the channel where policy belongs, instead of upstream where it would decide
+what the agent is even allowed to see.
+
+## Deliberately not supported
+
+- **Trusting a `From` header on its own.** There is no configuration that enables it.
+- **Escalating the operator past authentication.** See I2.
+- **Inferring egress permission from inbound trust.** They are separate grants.
+- **Standing permission earned by replying.** See the thread rule.
+- **Authenticating a mailbox from a domain proof.** Requires an explicit per-sender
+  assertion; nothing derives it.
+
+## Configuration summary
+
+| Control | Governs | Default |
+| --- | --- | --- |
+| Trusted `authserv-id`, per account | Which authentication results are believed | none, fails closed |
+| Per-sender expected signing domains | Whether an address can reach `verified` | none, so no address is verified |
+| Minimum identifier strength | The bar for admission | `asserted`, matching existing behavior |
+| Egress recipient allowlist | Who the agent may originate mail to | empty, default-deny |
+| Attachment allowed roots | Outbound attachments | empty, default-deny |
+
+Every default is closed. An install that configures nothing reads nothing and sends nothing,
+which is the correct resting state for a system whose failure mode is an agent acting on a
+stranger's instructions.


### PR DESCRIPTION
## What Problem This Solves

Mail is the only common agent channel where the transport authenticates the **message** rather than the **session**. Every other channel hands the agent an identity some gateway already proved; mail hands it a string the sender typed, plus optional evidence about that string, plus the possibility the evidence was also typed by the sender.

That makes the policy surface larger than any other channel, and most of it is not obvious. This writes it down before it is code, so it can be argued rather than discovered.

## What It Covers

**15 ingress scenarios** and **10 egress scenarios**, each with an outcome and a basis. Encodes the decisions taken so far:

- **Egress is default-deny.** Inbound authentication grants nothing outbound.
- **Reply rule is `isThread && threadOriginatedFromAgent`.** No inactivity window, no turn cap.
- **Ingress admission is graduated** by per-identifier strength, so an authenticated stranger can be read without being able to direct the agent.

It also states the three questions the whole design rests on (who is claimed, did our boundary prove it, is that identity enrolled) and why conflating any two produces a bug.

The two attacks this codebase actually shipped appear as scenarios I7 and I8 rather than as footnotes, because they are the reason the design has this shape.

## Notable Positions

Worth disagreeing with explicitly if you do:

- **I2: the operator is not special.** An operator address that fails authentication is dropped, not escalated. Making an exception for the most valuable identity would invert the model.
- **E2: an authenticated stranger can be read but not answered.** Answering is how an unknown party confirms a human-backed agent exists and starts a conversation on their terms.
- **I12: forwarding is an unavoidable loss.** Forwarded mail generally will not reach `verified`, because the forwarder is who the transport can speak for.

## Evidence

Documentation only, no code. Cross-checked against shipped behavior: the strength table matches the merged `mail-auth/strength.ts`, and the fail-closed `authserv-id` default matches `MailCLI.swift`.

Written to be upstreamable into the OpenClaw docs; happy to open that PR separately once the shape is agreed.

**Not merging without your approval.**