### PR TITLE
feat(openclaw): add mail channel ingress, egress, and thread policy

### DIFF
--- a/openclaw/src/mail-channel/policy.test.ts
+++ b/openclaw/src/mail-channel/policy.test.ts
@@ -75,12 +75,23 @@ describe("ingress admission", () => {
     });
   });
 
+  it("thread permission waives the allowlist but not authentication", () => {
+    // Greptile P1: an attacker who learns a participant's address and an agent
+    // Message-ID could otherwise spoof From and inherit the thread grant.
+    assert.deepEqual(
+      decideIngress(
+        ingress({ allowlisted: false, strengths: UNAUTHENTICATED, threadPermitted: true }),
+      ),
+      { admission: "drop", reason: "identifier_authentication_too_weak" },
+    );
+  });
+
   it("I9: dispatches a thread reply from a sender who is not allowlisted", () => {
     assert.deepEqual(
       decideIngress(
         ingress({
           allowlisted: false,
-          strengths: AUTHENTICATED_STRANGER,
+          strengths: VERIFIED,
           threadPermitted: true,
         }),
       ),
@@ -128,10 +139,38 @@ describe("egress", () => {
     );
   });
 
-  it("E1: permits a reply inside an agent-originated thread", () => {
-    const d = decideEgress({ ...base, recipients: ["stranger@example.com"], threadPermitted: true });
+  it("E1: permits a reply to an existing thread participant", () => {
+    const d = decideEgress({
+      ...base,
+      recipients: ["stranger@example.com"],
+      threadPermitted: true,
+      threadParticipants: ["stranger@example.com"],
+    });
     assert.deepEqual(d.permitted, ["stranger@example.com"]);
     assert.equal(d.reason, "thread_originated_by_agent");
+  });
+
+  it("thread permission does not let a reply-all add new recipients", () => {
+    // Greptile P1: otherwise a permitted thread becomes a general send capability.
+    const d = decideEgress({
+      ...base,
+      recipients: ["stranger@example.com", "outsider@example.com"],
+      threadPermitted: true,
+      threadParticipants: ["stranger@example.com"],
+    });
+    assert.deepEqual(d.permitted, ["stranger@example.com"]);
+    assert.deepEqual(d.denied, [
+      { address: "outsider@example.com", reason: "recipient_not_permitted" },
+    ]);
+  });
+
+  it("thread permission with no recorded participants grants nothing", () => {
+    const d = decideEgress({
+      ...base,
+      recipients: ["stranger@example.com"],
+      threadPermitted: true,
+    });
+    assert.deepEqual(d.permitted, []);
   });
 
   it("E8: narrows reply-all instead of leaking to unknown recipients", () => {
@@ -150,6 +189,7 @@ describe("egress", () => {
       ...base,
       recipients: ["lobster@example.com"],
       threadPermitted: true,
+      threadParticipants: ["lobster@example.com"],
     });
     assert.deepEqual(d.permitted, []);
     assert.equal(d.denied[0]?.reason, "self_addressed");

--- a/openclaw/src/mail-channel/policy.test.ts
+++ b/openclaw/src/mail-channel/policy.test.ts
@@ -1,0 +1,170 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { decideEgress, decideIngress, type IngressInput } from "./policy.ts";
+import type { MailIdentifierStrengths } from "../mail-auth/strength.ts";
+
+const VERIFIED: MailIdentifierStrengths = {
+  address: "verified",
+  domain: "verified",
+  displayName: "mutable",
+};
+const AUTHENTICATED_STRANGER: MailIdentifierStrengths = {
+  address: "asserted",
+  domain: "verified",
+  displayName: "mutable",
+};
+const UNAUTHENTICATED: MailIdentifierStrengths = {
+  address: "asserted",
+  domain: "asserted",
+  displayName: "mutable",
+};
+
+function ingress(overrides: Partial<IngressInput> = {}): IngressInput {
+  return {
+    strengths: VERIFIED,
+    senderAddress: "omar@shahine.com",
+    allowlisted: true,
+    minIdentifierAuthentication: "verified",
+    selfAddressed: false,
+    threadPermitted: false,
+    ...overrides,
+  };
+}
+
+describe("ingress admission", () => {
+  it("I1: dispatches an authenticated, allowlisted sender", () => {
+    assert.deepEqual(decideIngress(ingress()), {
+      admission: "dispatch",
+      reason: "allowlisted_and_authenticated",
+    });
+  });
+
+  it("I2: drops an allowlisted sender whose message did not authenticate", () => {
+    // The operator gets no exception. Making one would invert the whole model.
+    assert.deepEqual(decideIngress(ingress({ strengths: UNAUTHENTICATED })), {
+      admission: "drop",
+      reason: "identifier_authentication_too_weak",
+    });
+  });
+
+  it("I5: observes an authenticated stranger, never dispatches", () => {
+    assert.deepEqual(
+      decideIngress(ingress({ strengths: AUTHENTICATED_STRANGER, allowlisted: false })),
+      { admission: "observe", reason: "authenticated_but_not_allowlisted" },
+    );
+  });
+
+  it("I6: drops an unauthenticated stranger", () => {
+    assert.deepEqual(decideIngress(ingress({ strengths: UNAUTHENTICATED, allowlisted: false })), {
+      admission: "drop",
+      reason: "unauthenticated_sender",
+    });
+  });
+
+  it("I7/I8: a forged or unaligned pass lands as unauthenticated, not as a stranger to read", () => {
+    // Both attacks resolve to asserted/asserted upstream, so they cannot even reach observe.
+    const forged = decideIngress(ingress({ strengths: UNAUTHENTICATED, allowlisted: false }));
+    assert.equal(forged.admission, "drop");
+  });
+
+  it("I13: drops self-addressed mail before any grant applies", () => {
+    // Loop guard must outrank thread permission, which would otherwise dispatch it.
+    assert.deepEqual(decideIngress(ingress({ selfAddressed: true, threadPermitted: true })), {
+      admission: "drop",
+      reason: "self_addressed",
+    });
+  });
+
+  it("I9: dispatches a thread reply from a sender who is not allowlisted", () => {
+    assert.deepEqual(
+      decideIngress(
+        ingress({
+          allowlisted: false,
+          strengths: AUTHENTICATED_STRANGER,
+          threadPermitted: true,
+        }),
+      ),
+      { admission: "dispatch", reason: "thread_originated_by_agent" },
+    );
+  });
+
+  it("honors a relaxed minimum, matching today's default behavior", () => {
+    // minIdentifierAuthentication: "asserted" is the shipped default, under which an
+    // allowlisted sender is admitted without any authentication improvement.
+    assert.equal(
+      decideIngress(
+        ingress({ strengths: UNAUTHENTICATED, minIdentifierAuthentication: "asserted" }),
+      ).admission,
+      "dispatch",
+    );
+  });
+});
+
+describe("egress", () => {
+  const base = {
+    operatorAddresses: ["omar@shahine.com"],
+    egressAllowlist: ["known@example.com"],
+    selfAddresses: ["lobster@example.com"],
+    threadPermitted: false,
+    operatorInstructed: false,
+  };
+
+  it("E3: always permits the operator", () => {
+    const d = decideEgress({ ...base, recipients: ["omar@shahine.com"] });
+    assert.deepEqual(d.permitted, ["omar@shahine.com"]);
+    assert.equal(d.denied.length, 0);
+  });
+
+  it("E5: denies an arbitrary address by default", () => {
+    const d = decideEgress({ ...base, recipients: ["stranger@example.com"] });
+    assert.deepEqual(d.permitted, []);
+    assert.equal(d.denied[0]?.reason, "recipient_not_permitted");
+  });
+
+  it("E4: permits an explicitly allowlisted recipient", () => {
+    assert.deepEqual(
+      decideEgress({ ...base, recipients: ["known@example.com"] }).permitted,
+      ["known@example.com"],
+    );
+  });
+
+  it("E1: permits a reply inside an agent-originated thread", () => {
+    const d = decideEgress({ ...base, recipients: ["stranger@example.com"], threadPermitted: true });
+    assert.deepEqual(d.permitted, ["stranger@example.com"]);
+    assert.equal(d.reason, "thread_originated_by_agent");
+  });
+
+  it("E8: narrows reply-all instead of leaking to unknown recipients", () => {
+    const d = decideEgress({
+      ...base,
+      recipients: ["omar@shahine.com", "known@example.com", "stranger@example.com"],
+    });
+    assert.deepEqual(d.permitted, ["omar@shahine.com", "known@example.com"]);
+    assert.deepEqual(d.denied, [
+      { address: "stranger@example.com", reason: "recipient_not_permitted" },
+    ]);
+  });
+
+  it("E10: never sends to itself, even inside a permitted thread", () => {
+    const d = decideEgress({
+      ...base,
+      recipients: ["lobster@example.com"],
+      threadPermitted: true,
+    });
+    assert.deepEqual(d.permitted, []);
+    assert.equal(d.denied[0]?.reason, "self_addressed");
+  });
+
+  it("inbound trust grants nothing outbound", () => {
+    // An address can be fully verified inbound and still not be a permitted recipient.
+    const d = decideEgress({ ...base, recipients: ["verified-inbound@example.com"] });
+    assert.deepEqual(d.permitted, []);
+  });
+
+  it("matches recipients case-insensitively", () => {
+    assert.deepEqual(
+      decideEgress({ ...base, recipients: ["Known@Example.COM"] }).permitted,
+      ["Known@Example.COM"],
+    );
+  });
+});

--- a/openclaw/src/mail-channel/policy.test.ts
+++ b/openclaw/src/mail-channel/policy.test.ts
@@ -122,7 +122,7 @@ describe("egress", () => {
 
   it("E3: always permits the operator", () => {
     const d = decideEgress({ ...base, recipients: ["omar@shahine.com"] });
-    assert.deepEqual(d.permitted, ["omar@shahine.com"]);
+    assert.deepEqual(d.permitted.map((e) => e.address), ["omar@shahine.com"]);
     assert.equal(d.denied.length, 0);
   });
 
@@ -134,7 +134,7 @@ describe("egress", () => {
 
   it("E4: permits an explicitly allowlisted recipient", () => {
     assert.deepEqual(
-      decideEgress({ ...base, recipients: ["known@example.com"] }).permitted,
+      decideEgress({ ...base, recipients: ["known@example.com"] }).permitted.map((e) => e.address),
       ["known@example.com"],
     );
   });
@@ -146,8 +146,8 @@ describe("egress", () => {
       threadPermitted: true,
       threadParticipants: ["stranger@example.com"],
     });
-    assert.deepEqual(d.permitted, ["stranger@example.com"]);
-    assert.equal(d.reason, "thread_originated_by_agent");
+    assert.deepEqual(d.permitted.map((e) => e.address), ["stranger@example.com"]);
+    assert.deepEqual(d.reasons, ["thread_originated_by_agent"]);
   });
 
   it("thread permission does not let a reply-all add new recipients", () => {
@@ -158,7 +158,7 @@ describe("egress", () => {
       threadPermitted: true,
       threadParticipants: ["stranger@example.com"],
     });
-    assert.deepEqual(d.permitted, ["stranger@example.com"]);
+    assert.deepEqual(d.permitted.map((e) => e.address), ["stranger@example.com"]);
     assert.deepEqual(d.denied, [
       { address: "outsider@example.com", reason: "recipient_not_permitted" },
     ]);
@@ -173,12 +173,36 @@ describe("egress", () => {
     assert.deepEqual(d.permitted, []);
   });
 
+  it("does not credit the thread grant when no thread participant was admitted", () => {
+    // Codex finding on #83: the basis was read off the input flags, so any non-empty send
+    // with threadPermitted set was logged as thread authority it never used.
+    const d = decideEgress({
+      ...base,
+      recipients: ["omar@shahine.com", "known@example.com"],
+      threadPermitted: true,
+      threadParticipants: ["someone-else@example.com"],
+    });
+    assert.deepEqual(d.reasons.sort(), ["operator_recipient", "recipient_allowlisted"]);
+    assert.equal(d.reasons.includes("thread_originated_by_agent"), false);
+  });
+
+  it("reports each recipient's own basis, not one basis for the send", () => {
+    const d = decideEgress({
+      ...base,
+      recipients: ["omar@shahine.com", "known@example.com"],
+    });
+    assert.deepEqual(d.permitted, [
+      { address: "omar@shahine.com", reason: "operator_recipient" },
+      { address: "known@example.com", reason: "recipient_allowlisted" },
+    ]);
+  });
+
   it("E8: narrows reply-all instead of leaking to unknown recipients", () => {
     const d = decideEgress({
       ...base,
       recipients: ["omar@shahine.com", "known@example.com", "stranger@example.com"],
     });
-    assert.deepEqual(d.permitted, ["omar@shahine.com", "known@example.com"]);
+    assert.deepEqual(d.permitted.map((e) => e.address), ["omar@shahine.com", "known@example.com"]);
     assert.deepEqual(d.denied, [
       { address: "stranger@example.com", reason: "recipient_not_permitted" },
     ]);
@@ -203,7 +227,7 @@ describe("egress", () => {
 
   it("matches recipients case-insensitively", () => {
     assert.deepEqual(
-      decideEgress({ ...base, recipients: ["Known@Example.COM"] }).permitted,
+      decideEgress({ ...base, recipients: ["Known@Example.COM"] }).permitted.map((e) => e.address),
       ["Known@Example.COM"],
     );
   });

--- a/openclaw/src/mail-channel/policy.ts
+++ b/openclaw/src/mail-channel/policy.ts
@@ -1,0 +1,187 @@
+/**
+ * Admission and egress policy for the Apple Mail channel.
+ *
+ * Implements the scenarios enumerated in docs/mail-channel-scenarios.md. Kept as pure
+ * functions with no I/O so the policy can be tested exhaustively without a gateway, a
+ * mailbox, or a running agent.
+ *
+ * Two rules run through everything here:
+ *   - inbound authentication strength grants nothing outbound
+ *   - every default is closed
+ */
+
+import type { IdentifierAuthentication, MailIdentifierStrengths } from "../mail-auth/strength.ts";
+import { meetsMinimum } from "../mail-auth/strength.ts";
+
+/** What the channel does with an inbound message. */
+export type Admission = "dispatch" | "observe" | "drop";
+
+export type IngressReason =
+  | "self_addressed"
+  | "thread_originated_by_agent"
+  | "allowlisted_and_authenticated"
+  | "identifier_authentication_too_weak"
+  | "authenticated_but_not_allowlisted"
+  | "unauthenticated_sender";
+
+export type IngressDecision = {
+  admission: Admission;
+  reason: IngressReason;
+};
+
+export type IngressInput = {
+  strengths: MailIdentifierStrengths;
+  /** Sender address, already normalized. */
+  senderAddress: string;
+  /** True when the sender matches an inbound allowlist entry or the operator. */
+  allowlisted: boolean;
+  /** Minimum strength an identifier needs before it may authorize. */
+  minIdentifierAuthentication: IdentifierAuthentication;
+  /** True when this message came from an address the agent itself sends as. */
+  selfAddressed: boolean;
+  /** Result of the thread rule, when the message claims thread membership. */
+  threadPermitted: boolean;
+};
+
+/**
+ * Decides admission for one inbound message.
+ *
+ * Order matters and is deliberate:
+ *   1. loop guard, before any policy can grant anything
+ *   2. thread permission, which is narrower than the allowlist and independent of it
+ *   3. allowlist plus sufficient address strength
+ *   4. authenticated-but-unknown, which is readable and nothing more
+ *   5. everything else
+ */
+export function decideIngress(input: IngressInput): IngressDecision {
+  // I13. An agent that can send and read mail can answer itself.
+  if (input.selfAddressed) {
+    return { admission: "drop", reason: "self_addressed" };
+  }
+
+  // I9. Thread permission does not require the sender to be allowlisted, because the agent
+  // already chose to contact them when it started the thread.
+  if (input.threadPermitted) {
+    return { admission: "dispatch", reason: "thread_originated_by_agent" };
+  }
+
+  const addressStrongEnough = meetsMinimum(
+    input.strengths.address,
+    input.minIdentifierAuthentication,
+  );
+
+  // I1, I4.
+  if (input.allowlisted && addressStrongEnough) {
+    return { admission: "dispatch", reason: "allowlisted_and_authenticated" };
+  }
+
+  // I2. An allowlisted sender whose message did not authenticate is dropped, not escalated.
+  // The operator is not exempt: making an exception for the most valuable identity in the
+  // system would invert the model the rest of this file rests on.
+  if (input.allowlisted) {
+    return { admission: "drop", reason: "identifier_authentication_too_weak" };
+  }
+
+  // I5, I11. The transport proved a domain; nothing proved this human may direct an agent.
+  if (input.strengths.domain === "verified") {
+    return { admission: "observe", reason: "authenticated_but_not_allowlisted" };
+  }
+
+  // I6, I7, I8.
+  return { admission: "drop", reason: "unauthenticated_sender" };
+}
+
+export type EgressReason =
+  | "self_addressed"
+  | "thread_originated_by_agent"
+  | "operator_recipient"
+  | "operator_instructed"
+  | "recipient_allowlisted"
+  | "recipient_not_permitted";
+
+export type EgressDecision = {
+  /** Recipients the message may be sent to. Empty means the send is denied entirely. */
+  permitted: string[];
+  /** Recipients removed from the send, each with why. */
+  denied: { address: string; reason: EgressReason }[];
+  /** Overall basis, for audit. */
+  reason: EgressReason;
+};
+
+export type EgressInput = {
+  recipients: readonly string[];
+  /** Addresses belonging to the operator. Always permitted. */
+  operatorAddresses: readonly string[];
+  /** Explicit egress allowlist. Separate from the inbound allowlist by design. */
+  egressAllowlist: readonly string[];
+  /** Addresses the agent sends as. Sending to itself is a loop. */
+  selfAddresses: readonly string[];
+  /** True when replying inside a thread the agent originated. */
+  threadPermitted: boolean;
+  /** True when the operator explicitly asked for this specific send. */
+  operatorInstructed: boolean;
+};
+
+function lower(values: readonly string[]): Set<string> {
+  return new Set(values.map((value) => value.trim().toLowerCase()));
+}
+
+/**
+ * Decides which recipients an outbound message may go to.
+ *
+ * Egress is default-deny. Unknown recipients are dropped from the send rather than
+ * silently included, so a reply-all narrows instead of leaking (E8).
+ */
+export function decideEgress(input: EgressInput): EgressDecision {
+  const operators = lower(input.operatorAddresses);
+  const allowed = lower(input.egressAllowlist);
+  const selves = lower(input.selfAddresses);
+
+  const permitted: string[] = [];
+  const denied: { address: string; reason: EgressReason }[] = [];
+
+  for (const recipient of input.recipients) {
+    const address = recipient.trim().toLowerCase();
+
+    // E10. Loop guard outranks every grant below it.
+    if (selves.has(address)) {
+      denied.push({ address: recipient, reason: "self_addressed" });
+      continue;
+    }
+    // E3.
+    if (operators.has(address)) {
+      permitted.push(recipient);
+      continue;
+    }
+    // E1. Thread permission is scoped to the thread, not widened to the address.
+    if (input.threadPermitted) {
+      permitted.push(recipient);
+      continue;
+    }
+    // E6.
+    if (input.operatorInstructed) {
+      permitted.push(recipient);
+      continue;
+    }
+    // E4.
+    if (allowed.has(address)) {
+      permitted.push(recipient);
+      continue;
+    }
+    // E5, E7.
+    denied.push({ address: recipient, reason: "recipient_not_permitted" });
+  }
+
+  const reason: EgressReason =
+    permitted.length === 0
+      ? (denied[0]?.reason ?? "recipient_not_permitted")
+      : input.threadPermitted
+        ? "thread_originated_by_agent"
+        : input.operatorInstructed
+          ? "operator_instructed"
+          : permitted.every((address) => operators.has(address.trim().toLowerCase()))
+            ? "operator_recipient"
+            : "recipient_allowlisted";
+
+  return { permitted, denied, reason };
+}

--- a/openclaw/src/mail-channel/policy.ts
+++ b/openclaw/src/mail-channel/policy.ts
@@ -105,12 +105,20 @@ export type EgressReason =
   | "recipient_not_permitted";
 
 export type EgressDecision = {
-  /** Recipients the message may be sent to. Empty means the send is denied entirely. */
-  permitted: string[];
+  /**
+   * Recipients the message may be sent to, each with the grant that actually admitted it.
+   * Empty means the send is denied entirely.
+   */
+  permitted: { address: string; reason: EgressReason }[];
   /** Recipients removed from the send, each with why. */
   denied: { address: string; reason: EgressReason }[];
-  /** Overall basis, for audit. */
-  reason: EgressReason;
+  /**
+   * Distinct grants actually used, for audit. Derived from the per-recipient outcomes
+   * rather than from the input flags: a send where `threadPermitted` was set but only the
+   * operator was admitted must not be recorded as having used the thread grant. Audit is
+   * part of the control surface here, so overstating authority is itself a defect.
+   */
+  reasons: EgressReason[];
 };
 
 export type EgressInput = {
@@ -152,7 +160,7 @@ export function decideEgress(input: EgressInput): EgressDecision {
   // would turn a narrow exception into a general send capability.
   const participants = lower(input.threadParticipants ?? []);
 
-  const permitted: string[] = [];
+  const permitted: { address: string; reason: EgressReason }[] = [];
   const denied: { address: string; reason: EgressReason }[] = [];
 
   for (const recipient of input.recipients) {
@@ -165,38 +173,31 @@ export function decideEgress(input: EgressInput): EgressDecision {
     }
     // E3.
     if (operators.has(address)) {
-      permitted.push(recipient);
+      permitted.push({ address: recipient, reason: "operator_recipient" });
       continue;
     }
     // E1. Thread permission covers existing participants only.
     if (input.threadPermitted && participants.has(address)) {
-      permitted.push(recipient);
+      permitted.push({ address: recipient, reason: "thread_originated_by_agent" });
       continue;
     }
     // E6.
     if (input.operatorInstructed) {
-      permitted.push(recipient);
+      permitted.push({ address: recipient, reason: "operator_instructed" });
       continue;
     }
     // E4.
     if (allowed.has(address)) {
-      permitted.push(recipient);
+      permitted.push({ address: recipient, reason: "recipient_allowlisted" });
       continue;
     }
     // E5, E7.
     denied.push({ address: recipient, reason: "recipient_not_permitted" });
   }
 
-  const reason: EgressReason =
-    permitted.length === 0
-      ? (denied[0]?.reason ?? "recipient_not_permitted")
-      : input.threadPermitted
-        ? "thread_originated_by_agent"
-        : input.operatorInstructed
-          ? "operator_instructed"
-          : permitted.every((address) => operators.has(address.trim().toLowerCase()))
-            ? "operator_recipient"
-            : "recipient_allowlisted";
+  // Report only the grants that actually admitted someone. Reading these off the input
+  // flags would credit the thread rule for a send it never authorized.
+  const reasons = [...new Set(permitted.map((entry) => entry.reason))];
 
-  return { permitted, denied, reason };
+  return { permitted, denied, reasons };
 }

--- a/openclaw/src/mail-channel/policy.ts
+++ b/openclaw/src/mail-channel/policy.ts
@@ -59,16 +59,21 @@ export function decideIngress(input: IngressInput): IngressDecision {
     return { admission: "drop", reason: "self_addressed" };
   }
 
-  // I9. Thread permission does not require the sender to be allowlisted, because the agent
-  // already chose to contact them when it started the thread.
-  if (input.threadPermitted) {
-    return { admission: "dispatch", reason: "thread_originated_by_agent" };
-  }
-
   const addressStrongEnough = meetsMinimum(
     input.strengths.address,
     input.minIdentifierAuthentication,
   );
+
+  // I9. Thread permission waives the *allowlist*, because the agent already chose to
+  // contact this person when it started the thread. It does not waive *authentication*.
+  // decideThreadReply matches on the sender address, and an unauthenticated address is a
+  // claim: anyone who learns a participant's address and an agent Message-ID could
+  // otherwise spoof their way into a dispatch.
+  if (input.threadPermitted) {
+    return addressStrongEnough
+      ? { admission: "dispatch", reason: "thread_originated_by_agent" }
+      : { admission: "drop", reason: "identifier_authentication_too_weak" };
+  }
 
   // I1, I4.
   if (input.allowlisted && addressStrongEnough) {
@@ -118,6 +123,12 @@ export type EgressInput = {
   selfAddresses: readonly string[];
   /** True when replying inside a thread the agent originated. */
   threadPermitted: boolean;
+  /**
+   * Addresses the agent actually addressed in that thread. Thread permission extends only
+   * to these; it is not a licence to add recipients. Ignored when `threadPermitted` is
+   * false. Empty means thread permission grants nothing, which is the safe default.
+   */
+  threadParticipants?: readonly string[];
   /** True when the operator explicitly asked for this specific send. */
   operatorInstructed: boolean;
 };
@@ -136,6 +147,10 @@ export function decideEgress(input: EgressInput): EgressDecision {
   const operators = lower(input.operatorAddresses);
   const allowed = lower(input.egressAllowlist);
   const selves = lower(input.selfAddresses);
+  // Thread permission is scoped to the people already in the thread. Without this, a
+  // reply-all inside a permitted thread could introduce arbitrary new recipients, which
+  // would turn a narrow exception into a general send capability.
+  const participants = lower(input.threadParticipants ?? []);
 
   const permitted: string[] = [];
   const denied: { address: string; reason: EgressReason }[] = [];
@@ -153,8 +168,8 @@ export function decideEgress(input: EgressInput): EgressDecision {
       permitted.push(recipient);
       continue;
     }
-    // E1. Thread permission is scoped to the thread, not widened to the address.
-    if (input.threadPermitted) {
+    // E1. Thread permission covers existing participants only.
+    if (input.threadPermitted && participants.has(address)) {
       permitted.push(recipient);
       continue;
     }

--- a/openclaw/src/mail-channel/thread.test.ts
+++ b/openclaw/src/mail-channel/thread.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { decideThreadReply, type AgentThreadRecord } from "./thread.ts";
+
+const record: AgentThreadRecord = {
+  sentMessageIds: ["<agent-root@lobster.local>", "<agent-2@lobster.local>"],
+  addressedRecipients: ["friend@example.com"],
+};
+
+describe("thread reply permission", () => {
+  it("permits a reply from an addressed participant to an agent-sent message", () => {
+    const d = decideThreadReply(
+      { inReplyTo: "<agent-root@lobster.local>", senderAddress: "friend@example.com" },
+      [record],
+    );
+    assert.equal(d.permitted, true);
+    assert.equal(d.reason, "thread_originated_by_agent");
+  });
+
+  it("denies a message with no thread claim at all", () => {
+    const d = decideThreadReply({ senderAddress: "friend@example.com" }, [record]);
+    assert.equal(d.permitted, false);
+    assert.equal(d.reason, "no_thread_claim");
+  });
+
+  // The P1 this rule exists to close: References and In-Reply-To are sender-controlled.
+  it("denies a forged claim against a Message-ID the agent never sent", () => {
+    const d = decideThreadReply(
+      { inReplyTo: "<invented-by-attacker@evil.example>", senderAddress: "friend@example.com" },
+      [record],
+    );
+    assert.equal(d.permitted, false);
+    assert.equal(d.reason, "claimed_parent_not_sent_by_agent");
+  });
+
+  // The subtler half: a real agent Message-ID, leaked to someone never addressed.
+  it("denies a real agent Message-ID claimed by a non-participant", () => {
+    const d = decideThreadReply(
+      { inReplyTo: "<agent-root@lobster.local>", senderAddress: "attacker@evil.example" },
+      [record],
+    );
+    assert.equal(d.permitted, false);
+    assert.equal(d.reason, "sender_not_addressed_in_thread");
+  });
+
+  it("resolves a claim through the References chain, not just In-Reply-To", () => {
+    const d = decideThreadReply(
+      {
+        references: ["<unrelated@example.com>", "<agent-2@lobster.local>"],
+        senderAddress: "friend@example.com",
+      },
+      [record],
+    );
+    assert.equal(d.permitted, true);
+    assert.equal(d.matchedMessageId, "agent-2@lobster.local");
+  });
+
+  it("denies everything when the agent has sent nothing", () => {
+    const d = decideThreadReply(
+      { inReplyTo: "<agent-root@lobster.local>", senderAddress: "friend@example.com" },
+      [],
+    );
+    assert.equal(d.permitted, false);
+  });
+
+  it("normalizes angle brackets and case on both sides", () => {
+    const d = decideThreadReply(
+      { inReplyTo: "AGENT-ROOT@LOBSTER.LOCAL", senderAddress: "  Friend@Example.com " },
+      [record],
+    );
+    assert.equal(d.permitted, true);
+  });
+
+  it("does not let one thread's permission leak into another", () => {
+    const other: AgentThreadRecord = {
+      sentMessageIds: ["<other-root@lobster.local>"],
+      addressedRecipients: ["colleague@example.com"],
+    };
+    // friend@ is addressed in `record`, not in `other`; claiming other's root must fail.
+    const d = decideThreadReply(
+      { inReplyTo: "<other-root@lobster.local>", senderAddress: "friend@example.com" },
+      [record, other],
+    );
+    assert.equal(d.permitted, false);
+    assert.equal(d.reason, "sender_not_addressed_in_thread");
+  });
+});

--- a/openclaw/src/mail-channel/thread.test.ts
+++ b/openclaw/src/mail-channel/thread.test.ts
@@ -71,6 +71,28 @@ describe("thread reply permission", () => {
     assert.equal(d.permitted, true);
   });
 
+  it("resolves across records instead of stopping at the first ID match", () => {
+    // Greptile P2: a References chain can name IDs from several agent threads. Stopping at
+    // the first match denied a legitimate participant whose record sorted later.
+    const first: AgentThreadRecord = {
+      sentMessageIds: ["<agent-a@lobster.local>"],
+      addressedRecipients: ["someone-else@example.com"],
+    };
+    const second: AgentThreadRecord = {
+      sentMessageIds: ["<agent-b@lobster.local>"],
+      addressedRecipients: ["friend@example.com"],
+    };
+    const d = decideThreadReply(
+      {
+        references: ["<agent-a@lobster.local>", "<agent-b@lobster.local>"],
+        senderAddress: "friend@example.com",
+      },
+      [first, second],
+    );
+    assert.equal(d.permitted, true);
+    assert.equal(d.matchedMessageId, "agent-b@lobster.local");
+  });
+
   it("does not let one thread's permission leak into another", () => {
     const other: AgentThreadRecord = {
       sentMessageIds: ["<other-root@lobster.local>"],

--- a/openclaw/src/mail-channel/thread.ts
+++ b/openclaw/src/mail-channel/thread.ts
@@ -85,34 +85,37 @@ export function decideThreadReply(
 
   // A claim only resolves against Message-IDs the agent generated. Anything else is a
   // sender asserting thread membership, which is a claim rather than a credential.
-  let matchedMessageId: string | undefined;
-  let matchedRecord: AgentThreadRecord | undefined;
+  //
+  // A References chain can name IDs from several agent threads, so this searches all
+  // records for one that both matches a claimed ID and has this sender addressed. Stopping
+  // at the first ID match would deny a legitimate participant whose record happened to sort
+  // later, turning a correctness bug into a mysterious permission failure.
+  let sawIdMatch: string | undefined;
   for (const record of records) {
-    for (const sentId of record.sentMessageIds) {
-      const normalized = normalizeId(sentId);
-      if (normalized && claimed.has(normalized)) {
-        matchedMessageId = normalized;
-        matchedRecord = record;
-        break;
-      }
+    const matchedId = record.sentMessageIds
+      .map(normalizeId)
+      .find((sentId) => sentId && claimed.has(sentId));
+    if (!matchedId) {
+      continue;
     }
-    if (matchedRecord) {
-      break;
+    sawIdMatch ??= matchedId;
+    const addressed = record.addressedRecipients.some(
+      (recipient) => normalizeAddress(recipient) === sender,
+    );
+    if (addressed) {
+      return {
+        permitted: true,
+        reason: "thread_originated_by_agent",
+        matchedMessageId: matchedId,
+      };
     }
   }
 
-  if (!matchedRecord || !matchedMessageId) {
+  if (!sawIdMatch) {
     return { permitted: false, reason: "claimed_parent_not_sent_by_agent" };
   }
 
-  // Forging In-Reply-To gains nothing unless you were already addressed, and anyone
-  // already addressed had permission regardless.
-  const addressed = matchedRecord.addressedRecipients.some(
-    (recipient) => normalizeAddress(recipient) === sender,
-  );
-  if (!addressed) {
-    return { permitted: false, reason: "sender_not_addressed_in_thread", matchedMessageId };
-  }
-
-  return { permitted: true, reason: "thread_originated_by_agent", matchedMessageId };
+  // The claim named a real agent message, but this sender was never addressed in any thread
+  // it belongs to. Forging In-Reply-To gains nothing unless you were already a participant.
+  return { permitted: false, reason: "sender_not_addressed_in_thread", matchedMessageId: sawIdMatch };
 }

--- a/openclaw/src/mail-channel/thread.ts
+++ b/openclaw/src/mail-channel/thread.ts
@@ -1,0 +1,118 @@
+/**
+ * Thread-scoped reply permission.
+ *
+ * The rule is `isThread && threadOriginatedFromAgent`, but membership cannot be taken from
+ * the message: `References` and `In-Reply-To` are sender-controlled headers, exactly like
+ * `From`. A sender who learns a Message-ID from an agent-originated thread could otherwise
+ * claim membership and earn reply permission, turning the thread rule into a hole in
+ * default-deny rather than a narrow exception to it.
+ *
+ * Both halves of the check therefore read state the agent wrote when it sent, never the
+ * inbound message:
+ *
+ *   1. the claimed parent must be a Message-ID the agent generated
+ *   2. the sender must be an address the agent actually addressed in that thread
+ *
+ * See docs/mail-channel-scenarios.md scenarios I9, I10, I10a and E1, E2.
+ */
+
+/** One thread the agent originated, as recorded at send time. */
+export type AgentThreadRecord = {
+  /** Message-IDs the agent generated in this thread. Never populated from inbound mail. */
+  sentMessageIds: readonly string[];
+  /** Addresses the agent actually sent to. Membership is checked against this. */
+  addressedRecipients: readonly string[];
+};
+
+/** Everything the decision needs from an inbound message. */
+export type InboundThreadClaim = {
+  /** `In-Reply-To`, sender-controlled. */
+  inReplyTo?: string | null;
+  /** `References` chain, sender-controlled. */
+  references?: readonly string[];
+  /** Envelope/From address of whoever sent this reply. */
+  senderAddress: string;
+};
+
+export type ThreadDecision = {
+  permitted: boolean;
+  /** Stable reason code, suitable for audit output. */
+  reason:
+    | "thread_originated_by_agent"
+    | "no_thread_claim"
+    | "claimed_parent_not_sent_by_agent"
+    | "sender_not_addressed_in_thread";
+  /** The agent-generated Message-ID the claim resolved to, when it resolved. */
+  matchedMessageId?: string;
+};
+
+function normalizeId(raw: string | null | undefined): string {
+  return raw?.trim().replace(/^<|>$/g, "").toLowerCase() ?? "";
+}
+
+function normalizeAddress(raw: string | null | undefined): string {
+  return raw?.trim().toLowerCase() ?? "";
+}
+
+/**
+ * Decides whether the agent may reply to this message under the thread rule.
+ *
+ * `records` is the agent's own send log, keyed however the caller likes; only its values
+ * are read. Passing an empty collection denies everything, which is the correct resting
+ * state for an agent that has never sent anything.
+ */
+export function decideThreadReply(
+  claim: InboundThreadClaim,
+  records: Iterable<AgentThreadRecord>,
+): ThreadDecision {
+  const claimed = new Set<string>();
+  const inReplyTo = normalizeId(claim.inReplyTo);
+  if (inReplyTo) {
+    claimed.add(inReplyTo);
+  }
+  for (const reference of claim.references ?? []) {
+    const id = normalizeId(reference);
+    if (id) {
+      claimed.add(id);
+    }
+  }
+
+  if (claimed.size === 0) {
+    return { permitted: false, reason: "no_thread_claim" };
+  }
+
+  const sender = normalizeAddress(claim.senderAddress);
+
+  // A claim only resolves against Message-IDs the agent generated. Anything else is a
+  // sender asserting thread membership, which is a claim rather than a credential.
+  let matchedMessageId: string | undefined;
+  let matchedRecord: AgentThreadRecord | undefined;
+  for (const record of records) {
+    for (const sentId of record.sentMessageIds) {
+      const normalized = normalizeId(sentId);
+      if (normalized && claimed.has(normalized)) {
+        matchedMessageId = normalized;
+        matchedRecord = record;
+        break;
+      }
+    }
+    if (matchedRecord) {
+      break;
+    }
+  }
+
+  if (!matchedRecord || !matchedMessageId) {
+    return { permitted: false, reason: "claimed_parent_not_sent_by_agent" };
+  }
+
+  // Forging In-Reply-To gains nothing unless you were already addressed, and anyone
+  // already addressed had permission regardless.
+  const addressed = matchedRecord.addressedRecipients.some(
+    (recipient) => normalizeAddress(recipient) === sender,
+  );
+  if (!addressed) {
+    return { permitted: false, reason: "sender_not_addressed_in_thread", matchedMessageId };
+  }
+
+  return { permitted: true, reason: "thread_originated_by_agent", matchedMessageId };
+}


### PR DESCRIPTION
The decision layer for the Apple Mail channel. Pure functions, no I/O, so every scenario in `docs/mail-channel-scenarios.md` is testable without a gateway, a mailbox, or a running agent.

## What Problem This Solves

The channel needs to decide three things per message: may this reach the agent, may the agent reply, and may the agent send. Those are separate questions with separate defaults, and conflating them is how mail agents get abused.

## Why This Change Was Made

**`decideIngress` (I1-I13).** Ordering is deliberate:

- the loop guard outranks every grant, including thread permission
- thread permission is checked *before* the allowlist, because the agent already chose to contact that person when it started the thread
- an allowlisted sender whose message failed to authenticate is **dropped, not escalated**, and the operator gets no exception (I2). An exception for the most valuable identity in the system would invert the model
- an authenticated stranger reaches `observe` and never `dispatch` (I5)

**`decideEgress` (E1-E10).** Default-deny. Unknown recipients are dropped from the send rather than silently included, so a reply-all **narrows instead of leaking** (E8). Inbound authentication strength grants nothing outbound, which has its own test.

**`decideThreadReply`.** Implements `isThread && threadOriginatedFromAgent` with the membership test moved off the message, closing the P1 from #82. `References` and `In-Reply-To` are sender-controlled, so a claim resolves only against Message-IDs **the agent generated**, and only for an address **the agent actually addressed**. Forging `In-Reply-To` gains nothing unless you were already a participant, and a participant already had permission.

## User Impact

None yet. Nothing imports these; they ship with the channel entry.

## Evidence

- **39 tests, 6 suites, all passing** (`npm test`, `node:test` on native type stripping, no test-runner dependency)
- Both halves of the forged-ancestry attack covered: a fabricated Message-ID, and a *real* agent Message-ID claimed by a non-participant
- A test proving one thread's permission cannot leak into another
- Production modules **typecheck clean under `--strict`** (`tsc --noEmit`, 0 errors)

## Known Gaps

The channel entry is **not** wired here. The path is settled (`defineChannelPluginEntry` from `openclaw/plugin-sdk/channel-core` plus `"channels": [...]` in the manifest, per `extensions/qa-channel`), but the SDK is not installed in this package, so that code could not be typechecked. Writing it unverified would have been guesswork; installing the dep is the next step.

Test files show `Cannot find module 'node:test'` under `tsc` because `@types/node` is not installed either. Not a real type error, and the tests execute fine.

**Not merging without your approval.**