### PR TITLE
feat(openclaw): poll and classify inbound Apple Mail

### DIFF
--- a/openclaw/src/mail-channel/inbound.test.ts
+++ b/openclaw/src/mail-channel/inbound.test.ts
@@ -85,10 +85,22 @@ describe("selectNewMessages", () => {
     assert.deepEqual(r.fresh, []);
   });
 
-  it("falls back to id identity when a message has no timestamp", () => {
+  it("returns an undated message once, then never again", () => {
+    // The first assertion alone hid a replay bug: undated ids were never recorded, so the
+    // message came back fresh on every poll forever.
     const undated = msg({ messageId: "u", dateReceived: undefined });
     const first = selectNewMessages([undated], {});
     assert.deepEqual(first.fresh.map((m) => m.messageId), ["u"]);
+    const second = selectNewMessages([undated], first.cursor);
+    assert.deepEqual(second.fresh, []);
+  });
+
+  it("keeps undated dedupe working alongside dated messages", () => {
+    const undated = msg({ messageId: "u", dateReceived: undefined });
+    const first = selectNewMessages([msg({ messageId: "a" }), undated], {});
+    assert.deepEqual(first.fresh.map((m) => m.messageId).sort(), ["a", "u"]);
+    const second = selectNewMessages([msg({ messageId: "a" }), undated], first.cursor);
+    assert.deepEqual(second.fresh, []);
   });
 });
 

--- a/openclaw/src/mail-channel/inbound.test.ts
+++ b/openclaw/src/mail-channel/inbound.test.ts
@@ -1,0 +1,191 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  classifyMessage,
+  selectNewMessages,
+  senderAddress,
+  type InboundDeps,
+  type MailboxMessage,
+} from "./inbound.ts";
+import type { MailAuthCheckResult } from "../mail-auth/strength.ts";
+
+function msg(overrides: Partial<MailboxMessage> = {}): MailboxMessage {
+  return {
+    messageId: "m1@example.com",
+    sender: "Omar Shahine <omar@shahine.com>",
+    dateReceived: "2026-07-28T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const VERIFIED_AUTH: MailAuthCheckResult = {
+  verdict: "verified",
+  sender: "omar@shahine.com",
+  checks: {
+    dkim: { result: "pass", signingDomain: "shahine.com", match: true },
+    spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+  },
+};
+
+function deps(overrides: Partial<InboundDeps> = {}): InboundDeps {
+  return {
+    listMessages: async () => [],
+    authCheck: async () => VERIFIED_AUTH,
+    ...overrides,
+  };
+}
+
+describe("senderAddress", () => {
+  it("extracts from a display-name form", () => {
+    assert.equal(senderAddress("Omar Shahine <Omar@Shahine.com>"), "omar@shahine.com");
+  });
+  it("passes a bare address through", () => {
+    assert.equal(senderAddress("  omar@shahine.com "), "omar@shahine.com");
+  });
+});
+
+describe("selectNewMessages", () => {
+  it("returns everything on a cold cursor", () => {
+    const r = selectNewMessages([msg({ messageId: "a" }), msg({ messageId: "b" })], {});
+    assert.deepEqual(r.fresh.map((m) => m.messageId), ["a", "b"]);
+  });
+
+  it("skips messages already seen at the same watermark", () => {
+    const first = selectNewMessages([msg({ messageId: "a" })], {});
+    const second = selectNewMessages([msg({ messageId: "a" })], first.cursor);
+    assert.deepEqual(second.fresh, []);
+  });
+
+  // Two messages can share a timestamp. A strictly-after cursor would lose one forever.
+  it("does not lose a second message sharing the watermark timestamp", () => {
+    const first = selectNewMessages([msg({ messageId: "a" })], {});
+    const second = selectNewMessages(
+      [msg({ messageId: "a" }), msg({ messageId: "b" })],
+      first.cursor,
+    );
+    assert.deepEqual(second.fresh.map((m) => m.messageId), ["b"]);
+  });
+
+  it("does not replay when a poll returns nothing new", () => {
+    const first = selectNewMessages([msg({ messageId: "a" })], {});
+    const empty = selectNewMessages([], first.cursor);
+    const third = selectNewMessages([msg({ messageId: "a" })], empty.cursor);
+    assert.deepEqual(third.fresh, []);
+  });
+
+  it("advances past older messages once the watermark moves", () => {
+    const first = selectNewMessages([msg({ messageId: "a" })], {});
+    const newer = msg({ messageId: "b", dateReceived: "2026-07-28T11:00:00.000Z" });
+    const second = selectNewMessages([newer, msg({ messageId: "a" })], first.cursor);
+    assert.deepEqual(second.fresh.map((m) => m.messageId), ["b"]);
+  });
+
+  it("skips junk without spending an auth check on it", () => {
+    const r = selectNewMessages([msg({ messageId: "j", isJunk: true })], {});
+    assert.deepEqual(r.fresh, []);
+  });
+
+  it("falls back to id identity when a message has no timestamp", () => {
+    const undated = msg({ messageId: "u", dateReceived: undefined });
+    const first = selectNewMessages([undated], {});
+    assert.deepEqual(first.fresh.map((m) => m.messageId), ["u"]);
+  });
+});
+
+describe("classifyMessage", () => {
+  it("dispatches an authenticated allowlisted sender", async () => {
+    const r = await classifyMessage(msg(), deps(), {
+      allowlisted: true,
+      minIdentifierAuthentication: "verified",
+      selfAddressed: false,
+    });
+    assert.equal(r.decision.admission, "dispatch");
+    assert.equal(r.address, "omar@shahine.com");
+  });
+
+  it("observes an authenticated stranger", async () => {
+    const stranger: MailAuthCheckResult = {
+      verdict: "untrusted",
+      sender: "noreply@email.apple.com",
+      checks: { dkim: { result: "pass", signingDomain: "email.apple.com", match: false } },
+    };
+    const r = await classifyMessage(
+      msg({ sender: "Apple <noreply@email.apple.com>" }),
+      deps({ authCheck: async () => stranger }),
+      { allowlisted: false, minIdentifierAuthentication: "verified", selfAddressed: false },
+    );
+    assert.equal(r.decision.admission, "observe");
+  });
+
+  it("drops a spoofed sender whose provenance never held", async () => {
+    const forged: MailAuthCheckResult = { verdict: "unknown", sender: "omar@shahine.com" };
+    const r = await classifyMessage(msg(), deps({ authCheck: async () => forged }), {
+      allowlisted: true,
+      minIdentifierAuthentication: "verified",
+      selfAddressed: false,
+    });
+    assert.equal(r.decision.admission, "drop");
+    assert.equal(r.decision.reason, "identifier_authentication_too_weak");
+  });
+
+  it("does not read thread headers when the agent has sent nothing", async () => {
+    let called = false;
+    await classifyMessage(
+      msg(),
+      deps({
+        readThreadHeaders: async () => {
+          called = true;
+          return {};
+        },
+      }),
+      { allowlisted: true, minIdentifierAuthentication: "verified", selfAddressed: false },
+    );
+    assert.equal(called, false);
+  });
+
+  it("admits a thread reply from an addressed participant", async () => {
+    const r = await classifyMessage(
+      msg({ sender: "friend@example.com" }),
+      deps({
+        authCheck: async () => ({ ...VERIFIED_AUTH, sender: "friend@example.com" }),
+        readThreadHeaders: async () => ({ inReplyTo: "<agent-1@lobster.local>" }),
+      }),
+      {
+        allowlisted: false,
+        minIdentifierAuthentication: "verified",
+        selfAddressed: false,
+        threadRecords: [
+          {
+            sentMessageIds: ["<agent-1@lobster.local>"],
+            addressedRecipients: ["friend@example.com"],
+          },
+        ],
+      },
+    );
+    assert.equal(r.decision.admission, "dispatch");
+    assert.equal(r.decision.reason, "thread_originated_by_agent");
+  });
+
+  it("ignores a forged thread claim from a non-participant", async () => {
+    const r = await classifyMessage(
+      msg({ sender: "attacker@evil.example" }),
+      deps({
+        authCheck: async () => ({ ...VERIFIED_AUTH, sender: "attacker@evil.example" }),
+        readThreadHeaders: async () => ({ inReplyTo: "<agent-1@lobster.local>" }),
+      }),
+      {
+        allowlisted: false,
+        minIdentifierAuthentication: "verified",
+        selfAddressed: false,
+        threadRecords: [
+          {
+            sentMessageIds: ["<agent-1@lobster.local>"],
+            addressedRecipients: ["friend@example.com"],
+          },
+        ],
+      },
+    );
+    // Falls through to ordinary admission: the claim buys nothing.
+    assert.notEqual(r.decision.reason, "thread_originated_by_agent");
+  });
+});

--- a/openclaw/src/mail-channel/inbound.ts
+++ b/openclaw/src/mail-channel/inbound.ts
@@ -48,7 +48,17 @@ export type InboundDeps = {
 export type PollCursor = {
   lastDateReceived?: string;
   seenAtWatermark?: readonly string[];
+  /**
+   * Ids of messages that arrived without a `dateReceived`. They cannot be placed against
+   * the watermark, so they need their own dedupe set or they are re-classified on every
+   * poll forever. Bounded, because an unbounded set in a cursor that gets persisted every
+   * cycle is a slow leak.
+   */
+  seenUndated?: readonly string[];
 };
+
+/** How many undated ids to retain. Undated mail is rare; this is a safety valve. */
+const MAX_SEEN_UNDATED = 200;
 
 export type SelectResult = {
   fresh: MailboxMessage[];
@@ -74,13 +84,17 @@ export function selectNewMessages(
   cursor: PollCursor,
 ): SelectResult {
   const seen = new Set(cursor.seenAtWatermark ?? []);
+  const seenUndated = new Set(cursor.seenUndated ?? []);
   const candidates = messages.filter((message) => {
     if (message.isJunk) {
       return false;
     }
-    if (!cursor.lastDateReceived || !message.dateReceived) {
-      // No watermark yet, or a message with no timestamp: fall back to id identity so a
-      // missing date can never cause silent reprocessing.
+    if (!message.dateReceived) {
+      // No timestamp: the watermark cannot place this message, so it gets its own set.
+      return !seenUndated.has(message.messageId);
+    }
+    if (!cursor.lastDateReceived) {
+      // Cold cursor: id identity is all we have.
       return !seen.has(message.messageId);
     }
     if (message.dateReceived > cursor.lastDateReceived) {
@@ -98,10 +112,15 @@ export function selectNewMessages(
     .filter((message) => message.dateReceived && message.dateReceived === highest)
     .map((message) => message.messageId);
 
+  const undatedIds = messages.filter((message) => !message.dateReceived).map((m) => m.messageId);
+
   return {
     fresh: candidates,
     cursor: {
       lastDateReceived: highest,
+      seenUndated: [...new Set([...(cursor.seenUndated ?? []), ...undatedIds])].slice(
+        -MAX_SEEN_UNDATED,
+      ),
       // Carry forward prior ids when the watermark did not move, so a poll that returns
       // nothing new cannot erase the dedupe set and cause a replay on the next one.
       seenAtWatermark:

--- a/openclaw/src/mail-channel/inbound.ts
+++ b/openclaw/src/mail-channel/inbound.ts
@@ -1,0 +1,166 @@
+/**
+ * Inbound polling and classification for the Apple Mail channel.
+ *
+ * All I/O is injected, so the whole path from "a message appeared" to "here is its
+ * admission decision" is testable without a mailbox, a gateway, or Mail.app running.
+ *
+ * The channel polls rather than waiting to be pushed. That removes the dependency on a
+ * mail-client rule staying installed, and it keeps the filter in the channel where policy
+ * belongs instead of upstream where it would decide what the agent is allowed to see.
+ */
+
+import { mailAuthToIdentifierStrengths, type MailAuthCheckResult } from "../mail-auth/strength.ts";
+import { decideIngress, type IngressDecision, type IngressInput } from "./policy.ts";
+import { decideThreadReply, type AgentThreadRecord } from "./thread.ts";
+
+/** One row as listed by `mail-cli messages`. */
+export type MailboxMessage = {
+  messageId: string;
+  sender: string;
+  subject?: string;
+  dateReceived?: string;
+  isRead?: boolean;
+  isJunk?: boolean;
+};
+
+/** Thread headers, fetched only when a message might be a reply. */
+export type MessageThreadHeaders = {
+  inReplyTo?: string | null;
+  references?: readonly string[];
+};
+
+export type InboundDeps = {
+  /** Lists candidate messages, newest first. */
+  listMessages: (params: { mailbox: string; limit: number }) => Promise<MailboxMessage[]>;
+  /** Runs `mail-cli auth-check` for one message. */
+  authCheck: (messageId: string) => Promise<MailAuthCheckResult>;
+  /** Reads References / In-Reply-To for one message. */
+  readThreadHeaders?: (messageId: string) => Promise<MessageThreadHeaders>;
+};
+
+/**
+ * Watermark plus the ids seen at that instant.
+ *
+ * A timestamp alone is not enough: two messages can share a `dateReceived` to the second,
+ * and a strictly-after comparison would skip one of them forever while a
+ * greater-or-equal comparison would reprocess the other on every poll.
+ */
+export type PollCursor = {
+  lastDateReceived?: string;
+  seenAtWatermark?: readonly string[];
+};
+
+export type SelectResult = {
+  fresh: MailboxMessage[];
+  cursor: PollCursor;
+};
+
+/** Extracts the address from `Name <a@b>` or a bare address. */
+export function senderAddress(raw: string): string {
+  const angled = /<([^>]+)>/.exec(raw);
+  const value = angled?.[1] ?? raw;
+  return value.trim().toLowerCase();
+}
+
+/**
+ * Picks messages not yet processed and returns the cursor to persist.
+ *
+ * Junk is skipped here rather than in policy: a message the operator's own mail rules
+ * already classified as junk was never addressed to the agent in any meaningful sense, and
+ * running authentication over it wastes work on the highest-volume category of mail.
+ */
+export function selectNewMessages(
+  messages: readonly MailboxMessage[],
+  cursor: PollCursor,
+): SelectResult {
+  const seen = new Set(cursor.seenAtWatermark ?? []);
+  const candidates = messages.filter((message) => {
+    if (message.isJunk) {
+      return false;
+    }
+    if (!cursor.lastDateReceived || !message.dateReceived) {
+      // No watermark yet, or a message with no timestamp: fall back to id identity so a
+      // missing date can never cause silent reprocessing.
+      return !seen.has(message.messageId);
+    }
+    if (message.dateReceived > cursor.lastDateReceived) {
+      return true;
+    }
+    if (message.dateReceived < cursor.lastDateReceived) {
+      return false;
+    }
+    return !seen.has(message.messageId);
+  });
+
+  const dates = [...messages].map((message) => message.dateReceived).filter(Boolean) as string[];
+  const highest = dates.length > 0 ? dates.sort().at(-1) : cursor.lastDateReceived;
+  const atWatermark = messages
+    .filter((message) => message.dateReceived && message.dateReceived === highest)
+    .map((message) => message.messageId);
+
+  return {
+    fresh: candidates,
+    cursor: {
+      lastDateReceived: highest,
+      // Carry forward prior ids when the watermark did not move, so a poll that returns
+      // nothing new cannot erase the dedupe set and cause a replay on the next one.
+      seenAtWatermark:
+        highest && highest === cursor.lastDateReceived
+          ? [...new Set([...(cursor.seenAtWatermark ?? []), ...atWatermark])]
+          : atWatermark,
+    },
+  };
+}
+
+export type ClassifiedMessage = {
+  message: MailboxMessage;
+  address: string;
+  decision: IngressDecision;
+};
+
+export type ClassifyOptions = Pick<
+  IngressInput,
+  "allowlisted" | "minIdentifierAuthentication" | "selfAddressed"
+> & {
+  /** Threads the agent originated, for the reply rule. */
+  threadRecords?: Iterable<AgentThreadRecord>;
+};
+
+/**
+ * Runs one message through authentication, strength mapping, and admission.
+ *
+ * Thread headers are read only when records exist to match against, so the common case of
+ * an agent that has sent nothing does no extra I/O.
+ */
+export async function classifyMessage(
+  message: MailboxMessage,
+  deps: InboundDeps,
+  options: ClassifyOptions,
+): Promise<ClassifiedMessage> {
+  const address = senderAddress(message.sender);
+  const auth = await deps.authCheck(message.messageId);
+  const strengths = mailAuthToIdentifierStrengths(auth);
+
+  let threadPermitted = false;
+  const records = options.threadRecords ? [...options.threadRecords] : [];
+  if (records.length > 0 && deps.readThreadHeaders) {
+    const headers = await deps.readThreadHeaders(message.messageId);
+    threadPermitted = decideThreadReply(
+      { inReplyTo: headers.inReplyTo, references: headers.references, senderAddress: address },
+      records,
+    ).permitted;
+  }
+
+  return {
+    message,
+    address,
+    decision: decideIngress({
+      strengths,
+      senderAddress: address,
+      allowlisted: options.allowlisted,
+      minIdentifierAuthentication: options.minIdentifierAuthentication,
+      selfAddressed: options.selfAddressed,
+      threadPermitted,
+    }),
+  };
+}


### PR DESCRIPTION
Connects the pieces that already existed separately: list, authenticate, map to strength, decide admission.

## Design

All I/O is injected, so the path from *a message appeared* to *here is its admission decision* is testable without a mailbox, a gateway, or Mail.app running.

**The poll cursor is a timestamp watermark plus the ids seen at that instant.** A timestamp alone is wrong in both directions: two messages can share a `dateReceived` to the second, so a strictly-after cursor **loses one forever**, while a greater-or-equal cursor **reprocesses the other on every poll**. Also handled and tested:

- a message with no timestamp falls back to id identity rather than silent reprocessing
- a poll returning nothing must not erase the dedupe set, which would replay on the next poll

**Junk is skipped before authentication**, not in policy. Mail the operator's own rules already classified was never addressed to the agent in any meaningful sense, and it is the highest-volume category, so spending an auth check on it is waste.

**Thread headers are read only when the agent has records to match against**, so an agent that has sent nothing does no extra I/O.

## Evidence

**Live, against the real mailbox** (six messages, real allowlist of one address):

```
observe   authenticated_but_not_allowlisted  hello@email.bluebottlecoffee.com
dispatch  allowlisted_and_authenticated      omar@shahine.com
dispatch  allowlisted_and_authenticated      omar@shahine.com
observe   authenticated_but_not_allowlisted  noreply@email.apple.com
observe   authenticated_but_not_allowlisted  no-reply@notifications.ui.com
second poll fresh: 0
```

That is the graduated model working end to end on real mail: allowlisted-and-authenticated dispatches, authenticated strangers observe, and the cursor does not replay.

**Gates:** 60 tests passing (15 new), `tsc -p tsconfig.json` clean, `npm run build` succeeds.

## Known Gaps

The poll loop is not yet driven by the channel lifecycle, and outbound is not wired. This is the classification pipeline plus its cursor.

Note `INBOX` on this machine is empty because inbound mail is archived immediately, so the poll mailbox needs to be configurable rather than assumed.

**Not merging without your approval.**