### PR TITLE
feat(openclaw): add the inbound poll loop

### DIFF
--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -1,0 +1,210 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { runPollCycle, runPollLoop, type CursorStore, type PollOptions } from "./poll.ts";
+import type { InboundDeps, MailboxMessage, PollCursor } from "./inbound.ts";
+import type { MailAuthCheckResult } from "../mail-auth/strength.ts";
+
+const VERIFIED: MailAuthCheckResult = {
+  verdict: "verified",
+  sender: "omar@shahine.com",
+  checks: {
+    dkim: { result: "pass", signingDomain: "shahine.com", match: true },
+    spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+  },
+};
+
+function memoryStore(): CursorStore & { values: Map<string, PollCursor> } {
+  const values = new Map<string, PollCursor>();
+  return {
+    values,
+    lookup: async (key) => values.get(key),
+    register: async (key, value) => {
+      values.set(key, value);
+    },
+  };
+}
+
+function msg(id: string, date = "2026-07-28T10:00:00.000Z"): MailboxMessage {
+  return { messageId: id, sender: "Omar <omar@shahine.com>", dateReceived: date };
+}
+
+const OPTIONS: PollOptions = {
+  mailbox: "INBOX",
+  limit: 25,
+  cursorKey: "apple-mail:default",
+  classify: {
+    allowlisted: true,
+    minIdentifierAuthentication: "verified",
+    selfAddressed: false,
+  },
+};
+
+function deps(messages: MailboxMessage[][]): InboundDeps & { calls: number } {
+  let calls = 0;
+  return {
+    get calls() {
+      return calls;
+    },
+    listMessages: async () => messages[Math.min(calls++, messages.length - 1)] ?? [],
+    authCheck: async () => VERIFIED,
+  } as InboundDeps & { calls: number };
+}
+
+describe("runPollCycle", () => {
+  it("classifies fresh messages and persists the cursor", async () => {
+    const store = memoryStore();
+    const r = await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
+    assert.equal(r.classified.length, 1);
+    assert.equal(r.classified[0]?.decision.admission, "dispatch");
+    assert.ok(store.values.has(OPTIONS.cursorKey));
+  });
+
+  it("does not reprocess across cycles using the persisted cursor", async () => {
+    const store = memoryStore();
+    const d = deps([[msg("a")], [msg("a")]]);
+    await runPollCycle(d, OPTIONS, store);
+    const second = await runPollCycle(d, OPTIONS, store);
+    assert.deepEqual(second.classified, []);
+  });
+
+  it("keeps separate cursors per key, so accounts do not shadow each other", async () => {
+    const store = memoryStore();
+    await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
+    const other = await runPollCycle(deps([[msg("a")]]), { ...OPTIONS, cursorKey: "other" }, store);
+    assert.equal(other.classified.length, 1);
+  });
+});
+
+describe("runPollLoop", () => {
+  /** Runs the loop for a fixed number of cycles, then aborts. */
+  function boundedSignal(cycles: number) {
+    const controller = new AbortController();
+    let seen = 0;
+    const sleep = async () => {
+      seen += 1;
+      if (seen >= cycles) {
+        controller.abort();
+      }
+    };
+    return { signal: controller.signal, sleep };
+  }
+
+  it("hands admitted messages to the consumer and withholds dropped ones", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(1);
+    const admitted: string[] = [];
+    const unauthenticated: MailAuthCheckResult = { verdict: "unknown", sender: "x@example.com" };
+    await runPollLoop(
+      {
+        listMessages: async () => [msg("a"), msg("b")],
+        authCheck: async (id) => (id === "a" ? VERIFIED : unauthenticated),
+        onAdmitted: (messages) => {
+          admitted.push(...messages.map((m) => m.message.messageId));
+        },
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.deepEqual(admitted, ["a"]);
+  });
+
+  it("does not call the consumer when a cycle admits nothing", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(1);
+    let called = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => [],
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {
+          called += 1;
+        },
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(called, 0);
+  });
+
+  // A background source must not go quiet forever because one poll threw.
+  it("survives a failing cycle and keeps polling", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(3);
+    const errors: unknown[] = [];
+    let attempt = 0;
+    const admitted: string[] = [];
+    await runPollLoop(
+      {
+        listMessages: async () => {
+          attempt += 1;
+          if (attempt === 1) {
+            throw new Error("mailbox unavailable");
+          }
+          return [msg("a")];
+        },
+        authCheck: async () => VERIFIED,
+        onAdmitted: (messages) => {
+          admitted.push(...messages.map((m) => m.message.messageId));
+        },
+        onError: (error) => errors.push(error),
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(errors.length, 1);
+    assert.deepEqual(admitted, ["a"]);
+  });
+
+  it("stops immediately when already aborted", async () => {
+    const store = memoryStore();
+    const controller = new AbortController();
+    controller.abort();
+    let listed = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => {
+          listed += 1;
+          return [];
+        },
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {},
+        sleep: async () => {},
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      controller.signal,
+    );
+    assert.equal(listed, 0);
+  });
+
+  it("does not overlap cycles", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(3);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          inFlight -= 1;
+          return [];
+        },
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {},
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(maxInFlight, 1);
+  });
+});

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -51,27 +51,76 @@ function deps(messages: MailboxMessage[][]): InboundDeps & { calls: number } {
 }
 
 describe("runPollCycle", () => {
-  it("classifies fresh messages and persists the cursor", async () => {
+  it("classifies fresh messages and returns a cursor without persisting it", async () => {
     const store = memoryStore();
     const r = await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
     assert.equal(r.classified.length, 1);
     assert.equal(r.classified[0]?.decision.admission, "dispatch");
-    assert.ok(store.values.has(OPTIONS.cursorKey));
+    // Persisting is the loop's job, gated on delivery.
+    assert.equal(store.values.has(OPTIONS.cursorKey), false);
   });
 
-  it("does not reprocess across cycles using the persisted cursor", async () => {
+  it("does not reprocess across cycles once the cursor is stored", async () => {
     const store = memoryStore();
     const d = deps([[msg("a")], [msg("a")]]);
-    await runPollCycle(d, OPTIONS, store);
+    const first = await runPollCycle(d, OPTIONS, store);
+    await store.register(OPTIONS.cursorKey, first.cursor);
     const second = await runPollCycle(d, OPTIONS, store);
     assert.deepEqual(second.classified, []);
   });
 
   it("keeps separate cursors per key, so accounts do not shadow each other", async () => {
     const store = memoryStore();
-    await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
+    const first = await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
+    await store.register(OPTIONS.cursorKey, first.cursor);
     const other = await runPollCycle(deps([[msg("a")]]), { ...OPTIONS, cursorKey: "other" }, store);
     assert.equal(other.classified.length, 1);
+  });
+
+  // Greptile P1: newest-first paging stops short of the cursor when a burst arrives, and
+  // advancing the watermark from that subset would skip the rest permanently.
+  it("widens the page to reach back past the cursor", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
+    const burst = Array.from({ length: 7 }, (_, i) =>
+      msg(`b${i}`, `2026-07-28T10:0${i}:00.000Z`),
+    );
+    let lastLimit = 0;
+    const d: InboundDeps = {
+      listMessages: async ({ limit }) => {
+        lastLimit = limit;
+        return burst.slice(-limit);
+      },
+      authCheck: async () => VERIFIED,
+    };
+    const r = await runPollCycle(d, { ...OPTIONS, limit: 2, maxLimit: 64 }, store);
+    assert.ok(lastLimit > 2, "should have widened past the initial limit");
+    assert.equal(r.classified.length, 7);
+    assert.equal(r.truncated, false);
+  });
+
+  it("flags truncation instead of silently skipping when the ceiling is hit", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
+    const d: InboundDeps = {
+      // Always returns a full page newer than the cursor: the ceiling is reached.
+      listMessages: async ({ limit }) =>
+        Array.from({ length: limit }, (_, i) => msg(`x${i}`, `2026-07-28T11:00:00.000Z`)),
+      authCheck: async () => VERIFIED,
+    };
+    const r = await runPollCycle(d, { ...OPTIONS, limit: 2, maxLimit: 8 }, store);
+    assert.equal(r.truncated, true);
+  });
+
+  it("takes the page as-is on a cold cursor rather than scanning history", async () => {
+    const store = memoryStore();
+    const d: InboundDeps = {
+      listMessages: async ({ limit }) => Array.from({ length: limit }, (_, i) => msg(`c${i}`)),
+      authCheck: async () => VERIFIED,
+    };
+    const r = await runPollCycle(d, { ...OPTIONS, limit: 3, maxLimit: 64 }, store);
+    assert.equal(r.classified.length, 3);
+    assert.equal(r.truncated, false);
   });
 });
 
@@ -159,6 +208,54 @@ describe("runPollLoop", () => {
     );
     assert.equal(errors.length, 1);
     assert.deepEqual(admitted, ["a"]);
+  });
+
+  // Greptile P1: the cursor used to advance inside the cycle, so a delivery failure
+  // permanently skipped that batch.
+  it("does not advance the cursor when delivery fails", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(1);
+    await runPollLoop(
+      {
+        listMessages: async () => [msg("a")],
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {
+          throw new Error("dispatch failed");
+        },
+        onError: () => {},
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(store.values.has(OPTIONS.cursorKey), false);
+  });
+
+  it("redelivers the batch on the next cycle after a delivery failure", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(2);
+    const delivered: string[] = [];
+    let attempt = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => [msg("a")],
+        authCheck: async () => VERIFIED,
+        onAdmitted: (messages) => {
+          attempt += 1;
+          if (attempt === 1) {
+            throw new Error("dispatch failed");
+          }
+          delivered.push(...messages.map((m) => m.message.messageId));
+        },
+        onError: () => {},
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.deepEqual(delivered, ["a"]);
   });
 
   it("stops immediately when already aborted", async () => {

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -15,6 +15,7 @@ import {
   type ClassifiedMessage,
   type ClassifyOptions,
   type InboundDeps,
+  type MailboxMessage,
   type PollCursor,
 } from "./inbound.ts";
 
@@ -27,6 +28,11 @@ export type CursorStore = {
 export type PollOptions = {
   mailbox: string;
   limit: number;
+  /**
+   * Ceiling when widening the page to reach back to the cursor. Bounds a burst of mail
+   * from turning one cycle into an unbounded scan of the mailbox.
+   */
+  maxLimit?: number;
   /** Store key, so several accounts can poll independently. */
   cursorKey: string;
   classify: ClassifyOptions;
@@ -34,15 +40,61 @@ export type PollOptions = {
 
 export type PollCycleResult = {
   classified: ClassifiedMessage[];
+  /** Cursor to persist once delivery succeeds. Deliberately not persisted here. */
   cursor: PollCursor;
+  /** True when the page ceiling was hit with mail still unread behind it. */
+  truncated: boolean;
 };
 
+const DEFAULT_MAX_LIMIT = 500;
+
 /**
- * Runs one poll cycle: list, filter to unseen, classify each, persist the cursor.
+ * Lists far enough back to reach the previous cursor.
  *
- * The cursor is written **after** classification, not before. A crash mid-cycle therefore
- * reprocesses messages rather than losing them. For mail that is the right trade: a
- * duplicate is visible and recoverable, a silently dropped message is neither.
+ * Listing is newest-first with a limit, so if more than `limit` messages arrive between
+ * cycles the page stops short of the cursor and everything behind it would be skipped
+ * forever once the watermark advanced. This widens the page until it reaches back past the
+ * cursor, the page is no longer full, or the ceiling is hit.
+ *
+ * With no cursor yet the page is taken as-is: a first run starts from now rather than
+ * ingesting the entire mailbox history.
+ */
+async function listBackToCursor(
+  deps: InboundDeps,
+  options: PollOptions,
+  previousWatermark: string | undefined,
+): Promise<{ messages: MailboxMessage[]; truncated: boolean }> {
+  const ceiling = options.maxLimit ?? DEFAULT_MAX_LIMIT;
+  let limit = options.limit;
+  let messages = await deps.listMessages({ mailbox: options.mailbox, limit });
+
+  if (!previousWatermark) {
+    return { messages, truncated: false };
+  }
+
+  while (messages.length >= limit && limit < ceiling) {
+    const dates = messages.map((m) => m.dateReceived).filter(Boolean) as string[];
+    const oldest = dates.sort()[0];
+    if (oldest && oldest <= previousWatermark) {
+      // The page now spans the cursor, so nothing is hiding behind it.
+      return { messages, truncated: false };
+    }
+    limit = Math.min(limit * 4, ceiling);
+    messages = await deps.listMessages({ mailbox: options.mailbox, limit });
+  }
+
+  const dates = messages.map((m) => m.dateReceived).filter(Boolean) as string[];
+  const oldest = dates.sort()[0];
+  const stillShort = messages.length >= limit && !!oldest && oldest > previousWatermark;
+  return { messages, truncated: stillShort };
+}
+
+/**
+ * Runs one poll cycle: list, filter to unseen, classify each.
+ *
+ * The cursor is returned, **not persisted**. Advancing it is the caller's job and must
+ * happen only after the batch has actually been delivered, because a cursor that moves
+ * ahead of delivery turns any delivery failure into permanently skipped mail.
  */
 export async function runPollCycle(
   deps: InboundDeps,
@@ -50,7 +102,7 @@ export async function runPollCycle(
   store: CursorStore,
 ): Promise<PollCycleResult> {
   const previous = (await store.lookup(options.cursorKey)) ?? {};
-  const messages = await deps.listMessages({ mailbox: options.mailbox, limit: options.limit });
+  const { messages, truncated } = await listBackToCursor(deps, options, previous.lastDateReceived);
   const { fresh, cursor } = selectNewMessages(messages, previous);
 
   const classified: ClassifiedMessage[] = [];
@@ -58,8 +110,7 @@ export async function runPollCycle(
     classified.push(await classifyMessage(message, deps, options.classify));
   }
 
-  await store.register(options.cursorKey, cursor);
-  return { classified, cursor };
+  return { classified, cursor, truncated };
 }
 
 export type PollLoopDeps = {
@@ -67,6 +118,8 @@ export type PollLoopDeps = {
   onAdmitted: (messages: ClassifiedMessage[]) => Promise<void> | void;
   /** Reports a cycle that threw. The loop continues regardless. */
   onError?: (error: unknown) => void;
+  /** Reports that the page ceiling was hit with unread mail still behind it. */
+  onTruncated?: (params: { mailbox: string; limit: number }) => void;
   /** Injected so tests do not wait in real time. */
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
 };
@@ -101,11 +154,17 @@ export async function runPollLoop(
   const sleep = deps.sleep ?? defaultSleep;
   while (!signal.aborted) {
     try {
-      const { classified } = await runPollCycle(deps, options, store);
+      const { classified, cursor, truncated } = await runPollCycle(deps, options, store);
+      if (truncated) {
+        deps.onTruncated?.({ mailbox: options.mailbox, limit: options.maxLimit ?? DEFAULT_MAX_LIMIT });
+      }
       const admitted = classified.filter((entry) => entry.decision.admission !== "drop");
       if (admitted.length > 0) {
+        // Deliver first. If this throws, the cursor is left untouched and the batch is
+        // retried next cycle rather than silently skipped.
         await deps.onAdmitted(admitted);
       }
+      await store.register(options.cursorKey, cursor);
     } catch (error) {
       deps.onError?.(error);
     }

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -1,0 +1,117 @@
+/**
+ * The poll loop that drives inbound mail.
+ *
+ * This is what replaces the retired Mail.app rule. Polling instead of being pushed keeps
+ * the filter inside the channel, where policy belongs, rather than upstream in a mail rule
+ * that decided what the agent was even allowed to see.
+ *
+ * The cursor lives in the plugin keyed store (SQLite-backed), not a sidecar file, so it
+ * survives gateway restarts without adding a parallel state path.
+ */
+
+import {
+  classifyMessage,
+  selectNewMessages,
+  type ClassifiedMessage,
+  type ClassifyOptions,
+  type InboundDeps,
+  type PollCursor,
+} from "./inbound.ts";
+
+/** The subset of the plugin keyed store this needs. Narrow so tests can fake it. */
+export type CursorStore = {
+  lookup(key: string): Promise<PollCursor | undefined>;
+  register(key: string, value: PollCursor): Promise<void>;
+};
+
+export type PollOptions = {
+  mailbox: string;
+  limit: number;
+  /** Store key, so several accounts can poll independently. */
+  cursorKey: string;
+  classify: ClassifyOptions;
+};
+
+export type PollCycleResult = {
+  classified: ClassifiedMessage[];
+  cursor: PollCursor;
+};
+
+/**
+ * Runs one poll cycle: list, filter to unseen, classify each, persist the cursor.
+ *
+ * The cursor is written **after** classification, not before. A crash mid-cycle therefore
+ * reprocesses messages rather than losing them. For mail that is the right trade: a
+ * duplicate is visible and recoverable, a silently dropped message is neither.
+ */
+export async function runPollCycle(
+  deps: InboundDeps,
+  options: PollOptions,
+  store: CursorStore,
+): Promise<PollCycleResult> {
+  const previous = (await store.lookup(options.cursorKey)) ?? {};
+  const messages = await deps.listMessages({ mailbox: options.mailbox, limit: options.limit });
+  const { fresh, cursor } = selectNewMessages(messages, previous);
+
+  const classified: ClassifiedMessage[] = [];
+  for (const message of fresh) {
+    classified.push(await classifyMessage(message, deps, options.classify));
+  }
+
+  await store.register(options.cursorKey, cursor);
+  return { classified, cursor };
+}
+
+export type PollLoopDeps = {
+  /** Called with the messages a cycle admitted. Dropped messages never reach it. */
+  onAdmitted: (messages: ClassifiedMessage[]) => Promise<void> | void;
+  /** Reports a cycle that threw. The loop continues regardless. */
+  onError?: (error: unknown) => void;
+  /** Injected so tests do not wait in real time. */
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+};
+
+function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    // Unblock immediately on shutdown instead of holding the gateway for a full interval.
+    signal.addEventListener("abort", () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+
+/**
+ * Polls until aborted.
+ *
+ * Cycles never overlap: the next interval starts after the previous cycle settles, so a
+ * slow mailbox cannot stack concurrent scans that would race on the same cursor.
+ *
+ * A failing cycle is reported and skipped rather than ending the loop. Mail is a
+ * background source; one bad poll should not silently stop the channel until someone
+ * notices no mail has arrived for a day.
+ */
+export async function runPollLoop(
+  deps: InboundDeps & PollLoopDeps,
+  options: PollOptions & { intervalMs: number },
+  store: CursorStore,
+  signal: AbortSignal,
+): Promise<void> {
+  const sleep = deps.sleep ?? defaultSleep;
+  while (!signal.aborted) {
+    try {
+      const { classified } = await runPollCycle(deps, options, store);
+      const admitted = classified.filter((entry) => entry.decision.admission !== "drop");
+      if (admitted.length > 0) {
+        await deps.onAdmitted(admitted);
+      }
+    } catch (error) {
+      deps.onError?.(error);
+    }
+    if (signal.aborted) {
+      return;
+    }
+    await sleep(options.intervalMs, signal);
+  }
+}


### PR DESCRIPTION
The loop that drives inbound mail. This is what replaces the retired Mail.app `From Contacts` rule.

Polling instead of being pushed keeps the filter **inside the channel**, where policy belongs, rather than upstream in a mail rule that decided what the agent was allowed to see at all. That was the structural problem with the old rule, not just its lack of authentication.

## Decisions worth reviewing

**The cursor is written after classification, not before.** A crash mid-cycle therefore reprocesses rather than loses. For mail that is the right trade: a duplicate is visible and recoverable, a silently dropped message is neither.

**Cycles never overlap.** The next interval starts after the previous cycle settles, so a slow mailbox cannot stack concurrent scans racing on the same cursor. Tested by asserting max in-flight is 1.

**A failing cycle is reported and skipped, not fatal.** Mail is a background source; one bad poll should not quietly stop the channel until someone notices no mail has arrived for a day. Tested: throw on cycle 1, still delivers on cycle 2.

**Cursor storage is the SQLite-backed plugin keyed store** (`runtime.state.openKeyedStore`), not a sidecar file, per the repo's storage policy. The store is injected as a two-method interface so the loop is testable without a gateway.

**Abort is honored mid-sleep**, so shutdown does not wait out a full interval.

## Evidence

**Live, against the real mailbox:**

```
cycle 0: admitted 4
   observe  hello@email.bluebottlecoffee.com
   observe  omar@shahine.com
   observe  noreply@email.apple.com
cycle 1: (nothing admitted)

persisted cursor: {"lastDateReceived":"2026-07-10T20:05:31.000Z","seenAtWatermark":[...]}
```

Cycle 1 admitting nothing is the cursor doing its job across cycles.

**Gates:** 69 tests (8 new), `tsc -p tsconfig.json` clean, `npm run build` succeeds.

## Known Gaps

`onAdmitted` is a callback; nothing yet connects it to `startAccount`/`stopAccount` on the gateway adapter, so the loop does not start on its own. That wiring plus dispatch into the agent is the next step, and it is the point at which inbound mail actually reaches Lobster again.

**Not merging without your approval.**