### PR TITLE
feat(openclaw): start the poll loop from the channel lifecycle

### DIFF
--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -18,6 +18,10 @@ import {
 } from "openclaw/plugin-sdk/channel-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import type { ClassifiedMessage, PollCursor } from "./inbound.ts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
+import { runPollLoop, type CursorStore } from "./poll.ts";
+import { createMailCliDeps } from "./runtime.ts";
 
 /** Account shape this channel resolves from config. */
 export type ResolvedAppleMailAccount = {
@@ -35,10 +39,44 @@ export type ResolvedAppleMailAccount = {
     egressAllowlist?: string[];
     /** Seconds between Envelope Index polls. */
     pollIntervalSeconds?: number;
+    /** Mailbox to poll. Not always INBOX: mail is often archived on arrival. */
+    mailbox?: string;
+    /** Messages per listing page before widening to reach the cursor. */
+    pageSize?: number;
+    /** Path to trusted-senders.json. */
+    trustedSendersPath?: string;
   };
 };
 
 const CHANNEL_ID = "apple-mail";
+const DEFAULT_POLL_SECONDS = 60;
+const DEFAULT_MAILBOX = "INBOX";
+const DEFAULT_PAGE = 25;
+
+/**
+ * Where admitted mail goes.
+ *
+ * Left injectable rather than reaching into `ctx.channelRuntime`: that surface is typed
+ * `{ runtimeContexts, [key: string]: unknown }`, so calling its reply dispatcher means
+ * casting through `unknown`. Wiring agent dispatch is the next step and is deliberately
+ * not guessed at here.
+ */
+export type AdmittedHandler = (messages: ClassifiedMessage[]) => Promise<void> | void;
+
+let admittedHandler: AdmittedHandler | undefined;
+
+/**
+ * Captured at registration.
+ *
+ * The keyed store lives on `PluginRuntime`, not on the `RuntimeEnv` handed to
+ * `startAccount`, so it has to be taken here via the entry's `setRuntime` hook.
+ */
+let pluginRuntime: PluginRuntime | undefined;
+
+/** Overrides the default handler. Used by the gateway wiring and by tests. */
+export function setAdmittedHandler(handler: AdmittedHandler | undefined): void {
+  admittedHandler = handler;
+}
 
 /** Reads one account's config block out of `channels.apple-mail`. */
 function resolveAccount(cfg: OpenClawConfig, accountId?: string | null): ResolvedAppleMailAccount {
@@ -102,12 +140,96 @@ const security = {
   },
 };
 
+/**
+ * Starts one account's poll loop and stops it on shutdown.
+ *
+ * `startAccount` returns once the loop is running rather than awaiting it, because the
+ * loop only ends on abort and the gateway needs startup to complete. The promise is kept
+ * so `stopAccount` can wait for the current cycle to settle instead of tearing down
+ * mid-classification.
+ */
+const loops = new Map<string, Promise<void>>();
+
+const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> = {
+  startAccount: async (ctx) => {
+    const config = ctx.account.config;
+    const state = pluginRuntime?.state;
+    if (!state) {
+      // Without durable cursor storage the loop would re-read the mailbox from scratch on
+      // every restart. Refuse to start rather than run in a state that looks fine and
+      // silently reprocesses.
+      ctx.log?.warn?.("apple-mail: plugin runtime unavailable; not starting the poll loop");
+      return;
+    }
+    const store = state.openKeyedStore<PollCursor>({
+      namespace: `${CHANNEL_ID}:cursor`,
+      maxEntries: 64,
+    }) as CursorStore;
+
+    const deps = createMailCliDeps({
+      account: config.account,
+      trustedSendersPath: config.trustedSendersPath,
+    });
+
+    const selfAddresses = config.selfAddresses ?? [];
+    const allowFrom = (config.allowFrom ?? []).map((entry) => String(entry).toLowerCase());
+
+    const loop = runPollLoop(
+      {
+        ...deps,
+        onAdmitted: async (messages) => {
+          if (!admittedHandler) {
+            // Never silently swallow admitted mail: if nothing is wired to receive it,
+            // say so once per batch rather than letting it vanish.
+            ctx.log?.warn?.(
+              `apple-mail: ${messages.length} message(s) admitted with no handler configured`,
+            );
+            return;
+          }
+          await admittedHandler(messages);
+        },
+        onError: (error) => ctx.log?.warn?.(`apple-mail poll failed: ${String(error)}`),
+        onTruncated: ({ mailbox, limit }) =>
+          ctx.log?.warn?.(
+            `apple-mail: ${mailbox} had more than ${limit} unread messages; some were not read this cycle`,
+          ),
+      },
+      {
+        mailbox: config.mailbox ?? DEFAULT_MAILBOX,
+        limit: config.pageSize ?? DEFAULT_PAGE,
+        cursorKey: `${CHANNEL_ID}:${ctx.accountId}`,
+        intervalMs: (config.pollIntervalSeconds ?? DEFAULT_POLL_SECONDS) * 1000,
+        classify: {
+          allowlisted: false,
+          minIdentifierAuthentication: config.minIdentifierAuthentication ?? "asserted",
+          selfAddressed: false,
+        },
+      },
+      store,
+      ctx.abortSignal,
+    );
+
+    loops.set(ctx.accountId, loop);
+    void allowFrom;
+    void selfAddresses;
+  },
+
+  stopAccount: async (ctx) => {
+    // The abort signal ends the loop; this just waits for the in-flight cycle.
+    await loops.get(ctx.accountId)?.catch(() => {});
+    loops.delete(ctx.accountId);
+  },
+};
+
 export const appleMailChannelPlugin = createChatChannelPlugin<ResolvedAppleMailAccount>({
-  base,
+  base: { ...base, gateway },
   security,
 });
 
 export const appleMailChannelEntry = defineChannelPluginEntry({
+  setRuntime: (runtime) => {
+    pluginRuntime = runtime;
+  },
   id: CHANNEL_ID,
   name: "Apple Mail",
   description:

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -171,8 +171,6 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
       trustedSendersPath: config.trustedSendersPath,
     });
 
-    const selfAddresses = config.selfAddresses ?? [];
-    const allowFrom = (config.allowFrom ?? []).map((entry) => String(entry).toLowerCase());
 
     const loop = runPollLoop(
       {
@@ -200,9 +198,9 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
         cursorKey: `${CHANNEL_ID}:${ctx.accountId}`,
         intervalMs: (config.pollIntervalSeconds ?? DEFAULT_POLL_SECONDS) * 1000,
         classify: {
-          allowlisted: false,
           minIdentifierAuthentication: config.minIdentifierAuthentication ?? "asserted",
-          selfAddressed: false,
+          allowFrom: (config.allowFrom ?? []).map((entry) => String(entry)),
+          selfAddresses: config.selfAddresses ?? [],
         },
       },
       store,
@@ -210,8 +208,6 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
     );
 
     loops.set(ctx.accountId, loop);
-    void allowFrom;
-    void selfAddresses;
   },
 
   stopAccount: async (ctx) => {

--- a/openclaw/src/mail-channel/inbound.test.ts
+++ b/openclaw/src/mail-channel/inbound.test.ts
@@ -107,9 +107,8 @@ describe("selectNewMessages", () => {
 describe("classifyMessage", () => {
   it("dispatches an authenticated allowlisted sender", async () => {
     const r = await classifyMessage(msg(), deps(), {
-      allowlisted: true,
+      allowFrom: ["omar@shahine.com"],
       minIdentifierAuthentication: "verified",
-      selfAddressed: false,
     });
     assert.equal(r.decision.admission, "dispatch");
     assert.equal(r.address, "omar@shahine.com");
@@ -124,7 +123,7 @@ describe("classifyMessage", () => {
     const r = await classifyMessage(
       msg({ sender: "Apple <noreply@email.apple.com>" }),
       deps({ authCheck: async () => stranger }),
-      { allowlisted: false, minIdentifierAuthentication: "verified", selfAddressed: false },
+      { minIdentifierAuthentication: "verified" },
     );
     assert.equal(r.decision.admission, "observe");
   });
@@ -132,9 +131,8 @@ describe("classifyMessage", () => {
   it("drops a spoofed sender whose provenance never held", async () => {
     const forged: MailAuthCheckResult = { verdict: "unknown", sender: "omar@shahine.com" };
     const r = await classifyMessage(msg(), deps({ authCheck: async () => forged }), {
-      allowlisted: true,
+      allowFrom: ["omar@shahine.com"],
       minIdentifierAuthentication: "verified",
-      selfAddressed: false,
     });
     assert.equal(r.decision.admission, "drop");
     assert.equal(r.decision.reason, "identifier_authentication_too_weak");
@@ -150,9 +148,35 @@ describe("classifyMessage", () => {
           return {};
         },
       }),
-      { allowlisted: true, minIdentifierAuthentication: "verified", selfAddressed: false },
+      { allowFrom: ["omar@shahine.com"], minIdentifierAuthentication: "verified" },
     );
     assert.equal(called, false);
+  });
+
+  it("derives allowlist membership from the configured list", async () => {
+    // Greptile P1: startAccount passed constant false, so trusted senders were strangers.
+    const r = await classifyMessage(msg(), deps(), {
+      allowFrom: ["OMAR@Shahine.com"],
+      minIdentifierAuthentication: "verified",
+    });
+    assert.equal(r.decision.admission, "dispatch");
+    assert.equal(r.decision.reason, "allowlisted_and_authenticated");
+  });
+
+  it("treats a sender absent from the list as not allowlisted", async () => {
+    const r = await classifyMessage(msg(), deps(), {
+      allowFrom: ["someone-else@example.com"],
+      minIdentifierAuthentication: "verified",
+    });
+    assert.notEqual(r.decision.reason, "allowlisted_and_authenticated");
+  });
+
+  it("activates the loop guard from configured self addresses", async () => {
+    const r = await classifyMessage(msg(), deps(), {
+      selfAddresses: ["Omar@Shahine.com"],
+      minIdentifierAuthentication: "verified",
+    });
+    assert.deepEqual(r.decision, { admission: "drop", reason: "self_addressed" });
   });
 
   it("admits a thread reply from an addressed participant", async () => {
@@ -163,9 +187,7 @@ describe("classifyMessage", () => {
         readThreadHeaders: async () => ({ inReplyTo: "<agent-1@lobster.local>" }),
       }),
       {
-        allowlisted: false,
         minIdentifierAuthentication: "verified",
-        selfAddressed: false,
         threadRecords: [
           {
             sentMessageIds: ["<agent-1@lobster.local>"],
@@ -186,9 +208,7 @@ describe("classifyMessage", () => {
         readThreadHeaders: async () => ({ inReplyTo: "<agent-1@lobster.local>" }),
       }),
       {
-        allowlisted: false,
         minIdentifierAuthentication: "verified",
-        selfAddressed: false,
         threadRecords: [
           {
             sentMessageIds: ["<agent-1@lobster.local>"],

--- a/openclaw/src/mail-channel/inbound.ts
+++ b/openclaw/src/mail-channel/inbound.ts
@@ -137,10 +137,15 @@ export type ClassifiedMessage = {
   decision: IngressDecision;
 };
 
-export type ClassifyOptions = Pick<
-  IngressInput,
-  "allowlisted" | "minIdentifierAuthentication" | "selfAddressed"
-> & {
+export type ClassifyOptions = Pick<IngressInput, "minIdentifierAuthentication"> & {
+  /**
+   * Configured inbound allowlist. Membership is derived per message rather than passed
+   * as a boolean: the caller does not know the sender address until this function has
+   * parsed it, so asking the caller to precompute it invites passing a constant.
+   */
+  allowFrom?: readonly string[];
+  /** Addresses the agent sends as, for the loop guard. */
+  selfAddresses?: readonly string[];
   /** Threads the agent originated, for the reply rule. */
   threadRecords?: Iterable<AgentThreadRecord>;
 };
@@ -157,6 +162,12 @@ export async function classifyMessage(
   options: ClassifyOptions,
 ): Promise<ClassifiedMessage> {
   const address = senderAddress(message.sender);
+  const allowlisted = (options.allowFrom ?? []).some(
+    (entry) => entry.trim().toLowerCase() === address,
+  );
+  const selfAddressed = (options.selfAddresses ?? []).some(
+    (entry) => entry.trim().toLowerCase() === address,
+  );
   const auth = await deps.authCheck(message.messageId);
   const strengths = mailAuthToIdentifierStrengths(auth);
 
@@ -176,9 +187,9 @@ export async function classifyMessage(
     decision: decideIngress({
       strengths,
       senderAddress: address,
-      allowlisted: options.allowlisted,
+      allowlisted,
       minIdentifierAuthentication: options.minIdentifierAuthentication,
-      selfAddressed: options.selfAddressed,
+      selfAddressed,
       threadPermitted,
     }),
   };

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -1,0 +1,210 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { runPollCycle, runPollLoop, type CursorStore, type PollOptions } from "./poll.ts";
+import type { InboundDeps, MailboxMessage, PollCursor } from "./inbound.ts";
+import type { MailAuthCheckResult } from "../mail-auth/strength.ts";
+
+const VERIFIED: MailAuthCheckResult = {
+  verdict: "verified",
+  sender: "omar@shahine.com",
+  checks: {
+    dkim: { result: "pass", signingDomain: "shahine.com", match: true },
+    spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+  },
+};
+
+function memoryStore(): CursorStore & { values: Map<string, PollCursor> } {
+  const values = new Map<string, PollCursor>();
+  return {
+    values,
+    lookup: async (key) => values.get(key),
+    register: async (key, value) => {
+      values.set(key, value);
+    },
+  };
+}
+
+function msg(id: string, date = "2026-07-28T10:00:00.000Z"): MailboxMessage {
+  return { messageId: id, sender: "Omar <omar@shahine.com>", dateReceived: date };
+}
+
+const OPTIONS: PollOptions = {
+  mailbox: "INBOX",
+  limit: 25,
+  cursorKey: "apple-mail:default",
+  classify: {
+    allowlisted: true,
+    minIdentifierAuthentication: "verified",
+    selfAddressed: false,
+  },
+};
+
+function deps(messages: MailboxMessage[][]): InboundDeps & { calls: number } {
+  let calls = 0;
+  return {
+    get calls() {
+      return calls;
+    },
+    listMessages: async () => messages[Math.min(calls++, messages.length - 1)] ?? [],
+    authCheck: async () => VERIFIED,
+  } as InboundDeps & { calls: number };
+}
+
+describe("runPollCycle", () => {
+  it("classifies fresh messages and persists the cursor", async () => {
+    const store = memoryStore();
+    const r = await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
+    assert.equal(r.classified.length, 1);
+    assert.equal(r.classified[0]?.decision.admission, "dispatch");
+    assert.ok(store.values.has(OPTIONS.cursorKey));
+  });
+
+  it("does not reprocess across cycles using the persisted cursor", async () => {
+    const store = memoryStore();
+    const d = deps([[msg("a")], [msg("a")]]);
+    await runPollCycle(d, OPTIONS, store);
+    const second = await runPollCycle(d, OPTIONS, store);
+    assert.deepEqual(second.classified, []);
+  });
+
+  it("keeps separate cursors per key, so accounts do not shadow each other", async () => {
+    const store = memoryStore();
+    await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
+    const other = await runPollCycle(deps([[msg("a")]]), { ...OPTIONS, cursorKey: "other" }, store);
+    assert.equal(other.classified.length, 1);
+  });
+});
+
+describe("runPollLoop", () => {
+  /** Runs the loop for a fixed number of cycles, then aborts. */
+  function boundedSignal(cycles: number) {
+    const controller = new AbortController();
+    let seen = 0;
+    const sleep = async () => {
+      seen += 1;
+      if (seen >= cycles) {
+        controller.abort();
+      }
+    };
+    return { signal: controller.signal, sleep };
+  }
+
+  it("hands admitted messages to the consumer and withholds dropped ones", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(1);
+    const admitted: string[] = [];
+    const unauthenticated: MailAuthCheckResult = { verdict: "unknown", sender: "x@example.com" };
+    await runPollLoop(
+      {
+        listMessages: async () => [msg("a"), msg("b")],
+        authCheck: async (id) => (id === "a" ? VERIFIED : unauthenticated),
+        onAdmitted: (messages) => {
+          admitted.push(...messages.map((m) => m.message.messageId));
+        },
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.deepEqual(admitted, ["a"]);
+  });
+
+  it("does not call the consumer when a cycle admits nothing", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(1);
+    let called = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => [],
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {
+          called += 1;
+        },
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(called, 0);
+  });
+
+  // A background source must not go quiet forever because one poll threw.
+  it("survives a failing cycle and keeps polling", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(3);
+    const errors: unknown[] = [];
+    let attempt = 0;
+    const admitted: string[] = [];
+    await runPollLoop(
+      {
+        listMessages: async () => {
+          attempt += 1;
+          if (attempt === 1) {
+            throw new Error("mailbox unavailable");
+          }
+          return [msg("a")];
+        },
+        authCheck: async () => VERIFIED,
+        onAdmitted: (messages) => {
+          admitted.push(...messages.map((m) => m.message.messageId));
+        },
+        onError: (error) => errors.push(error),
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(errors.length, 1);
+    assert.deepEqual(admitted, ["a"]);
+  });
+
+  it("stops immediately when already aborted", async () => {
+    const store = memoryStore();
+    const controller = new AbortController();
+    controller.abort();
+    let listed = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => {
+          listed += 1;
+          return [];
+        },
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {},
+        sleep: async () => {},
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      controller.signal,
+    );
+    assert.equal(listed, 0);
+  });
+
+  it("does not overlap cycles", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(3);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          inFlight -= 1;
+          return [];
+        },
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {},
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(maxInFlight, 1);
+  });
+});

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -33,9 +33,8 @@ const OPTIONS: PollOptions = {
   limit: 25,
   cursorKey: "apple-mail:default",
   classify: {
-    allowlisted: true,
+    allowFrom: ["omar@shahine.com"],
     minIdentifierAuthentication: "verified",
-    selfAddressed: false,
   },
 };
 
@@ -256,6 +255,75 @@ describe("runPollLoop", () => {
       signal,
     );
     assert.deepEqual(delivered, ["a"]);
+  });
+
+  // Greptile P1: reporting truncation was not enough; the cursor still advanced past the
+  // mail still sitting behind the ceiling.
+  it("does not advance the cursor on a truncated cycle", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
+    const before = store.values.get(OPTIONS.cursorKey);
+    const { signal, sleep } = boundedSignal(1);
+    let truncations = 0;
+    await runPollLoop(
+      {
+        listMessages: async ({ limit }) =>
+          Array.from({ length: limit }, (_, i) => msg(`x${i}`, "2026-07-28T11:00:00.000Z")),
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {},
+        onTruncated: () => {
+          truncations += 1;
+        },
+        sleep,
+      },
+      { ...OPTIONS, limit: 2, maxLimit: 8, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(truncations, 1);
+    assert.deepEqual(store.values.get(OPTIONS.cursorKey), before);
+  });
+
+  // A truncated cycle must still sleep. An earlier version used `continue`, which skipped
+  // the sleep and spun a tight infinite loop; the only symptom was a hanging test run.
+  it("holds the cursor on truncation without spinning the loop", async () => {
+    const store = memoryStore();
+    // Seed a prior cursor: truncation is only possible once there is a watermark to fall
+    // short of. A cold start deliberately takes the page as-is.
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
+    const seeded = store.values.get(OPTIONS.cursorKey);
+    const controller = new AbortController();
+    let sleeps = 0;
+    let cycles = 0;
+    await runPollLoop(
+      {
+        listMessages: async ({ limit }) => {
+          cycles += 1;
+          if (cycles > 20) {
+            throw new Error("loop spun without sleeping");
+          }
+          // Always a full page newer than the cursor: permanently truncated.
+          return Array.from({ length: limit }, (_, i) => msg(`t${i}`, "2026-07-28T11:00:00.000Z"));
+        },
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {},
+        sleep: async () => {
+          sleeps += 1;
+          if (sleeps >= 2) {
+            controller.abort();
+          }
+        },
+      },
+      { ...OPTIONS, limit: 2, maxLimit: 8, intervalMs: 1 },
+      store,
+      controller.signal,
+    );
+    assert.equal(sleeps, 2, "each truncated cycle must reach the sleep");
+    assert.deepEqual(
+      store.values.get(OPTIONS.cursorKey),
+      seeded,
+      "cursor must not advance past a truncated page",
+    );
   });
 
   it("stops immediately when already aborted", async () => {

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -51,27 +51,76 @@ function deps(messages: MailboxMessage[][]): InboundDeps & { calls: number } {
 }
 
 describe("runPollCycle", () => {
-  it("classifies fresh messages and persists the cursor", async () => {
+  it("classifies fresh messages and returns a cursor without persisting it", async () => {
     const store = memoryStore();
     const r = await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
     assert.equal(r.classified.length, 1);
     assert.equal(r.classified[0]?.decision.admission, "dispatch");
-    assert.ok(store.values.has(OPTIONS.cursorKey));
+    // Persisting is the loop's job, gated on delivery.
+    assert.equal(store.values.has(OPTIONS.cursorKey), false);
   });
 
-  it("does not reprocess across cycles using the persisted cursor", async () => {
+  it("does not reprocess across cycles once the cursor is stored", async () => {
     const store = memoryStore();
     const d = deps([[msg("a")], [msg("a")]]);
-    await runPollCycle(d, OPTIONS, store);
+    const first = await runPollCycle(d, OPTIONS, store);
+    await store.register(OPTIONS.cursorKey, first.cursor);
     const second = await runPollCycle(d, OPTIONS, store);
     assert.deepEqual(second.classified, []);
   });
 
   it("keeps separate cursors per key, so accounts do not shadow each other", async () => {
     const store = memoryStore();
-    await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
+    const first = await runPollCycle(deps([[msg("a")]]), OPTIONS, store);
+    await store.register(OPTIONS.cursorKey, first.cursor);
     const other = await runPollCycle(deps([[msg("a")]]), { ...OPTIONS, cursorKey: "other" }, store);
     assert.equal(other.classified.length, 1);
+  });
+
+  // Greptile P1: newest-first paging stops short of the cursor when a burst arrives, and
+  // advancing the watermark from that subset would skip the rest permanently.
+  it("widens the page to reach back past the cursor", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
+    const burst = Array.from({ length: 7 }, (_, i) =>
+      msg(`b${i}`, `2026-07-28T10:0${i}:00.000Z`),
+    );
+    let lastLimit = 0;
+    const d: InboundDeps = {
+      listMessages: async ({ limit }) => {
+        lastLimit = limit;
+        return burst.slice(-limit);
+      },
+      authCheck: async () => VERIFIED,
+    };
+    const r = await runPollCycle(d, { ...OPTIONS, limit: 2, maxLimit: 64 }, store);
+    assert.ok(lastLimit > 2, "should have widened past the initial limit");
+    assert.equal(r.classified.length, 7);
+    assert.equal(r.truncated, false);
+  });
+
+  it("flags truncation instead of silently skipping when the ceiling is hit", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
+    const d: InboundDeps = {
+      // Always returns a full page newer than the cursor: the ceiling is reached.
+      listMessages: async ({ limit }) =>
+        Array.from({ length: limit }, (_, i) => msg(`x${i}`, `2026-07-28T11:00:00.000Z`)),
+      authCheck: async () => VERIFIED,
+    };
+    const r = await runPollCycle(d, { ...OPTIONS, limit: 2, maxLimit: 8 }, store);
+    assert.equal(r.truncated, true);
+  });
+
+  it("takes the page as-is on a cold cursor rather than scanning history", async () => {
+    const store = memoryStore();
+    const d: InboundDeps = {
+      listMessages: async ({ limit }) => Array.from({ length: limit }, (_, i) => msg(`c${i}`)),
+      authCheck: async () => VERIFIED,
+    };
+    const r = await runPollCycle(d, { ...OPTIONS, limit: 3, maxLimit: 64 }, store);
+    assert.equal(r.classified.length, 3);
+    assert.equal(r.truncated, false);
   });
 });
 
@@ -159,6 +208,54 @@ describe("runPollLoop", () => {
     );
     assert.equal(errors.length, 1);
     assert.deepEqual(admitted, ["a"]);
+  });
+
+  // Greptile P1: the cursor used to advance inside the cycle, so a delivery failure
+  // permanently skipped that batch.
+  it("does not advance the cursor when delivery fails", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(1);
+    await runPollLoop(
+      {
+        listMessages: async () => [msg("a")],
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => {
+          throw new Error("dispatch failed");
+        },
+        onError: () => {},
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.equal(store.values.has(OPTIONS.cursorKey), false);
+  });
+
+  it("redelivers the batch on the next cycle after a delivery failure", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(2);
+    const delivered: string[] = [];
+    let attempt = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => [msg("a")],
+        authCheck: async () => VERIFIED,
+        onAdmitted: (messages) => {
+          attempt += 1;
+          if (attempt === 1) {
+            throw new Error("dispatch failed");
+          }
+          delivered.push(...messages.map((m) => m.message.messageId));
+        },
+        onError: () => {},
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.deepEqual(delivered, ["a"]);
   });
 
   it("stops immediately when already aborted", async () => {

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -15,6 +15,7 @@ import {
   type ClassifiedMessage,
   type ClassifyOptions,
   type InboundDeps,
+  type MailboxMessage,
   type PollCursor,
 } from "./inbound.ts";
 
@@ -27,6 +28,11 @@ export type CursorStore = {
 export type PollOptions = {
   mailbox: string;
   limit: number;
+  /**
+   * Ceiling when widening the page to reach back to the cursor. Bounds a burst of mail
+   * from turning one cycle into an unbounded scan of the mailbox.
+   */
+  maxLimit?: number;
   /** Store key, so several accounts can poll independently. */
   cursorKey: string;
   classify: ClassifyOptions;
@@ -34,15 +40,61 @@ export type PollOptions = {
 
 export type PollCycleResult = {
   classified: ClassifiedMessage[];
+  /** Cursor to persist once delivery succeeds. Deliberately not persisted here. */
   cursor: PollCursor;
+  /** True when the page ceiling was hit with mail still unread behind it. */
+  truncated: boolean;
 };
 
+const DEFAULT_MAX_LIMIT = 500;
+
 /**
- * Runs one poll cycle: list, filter to unseen, classify each, persist the cursor.
+ * Lists far enough back to reach the previous cursor.
  *
- * The cursor is written **after** classification, not before. A crash mid-cycle therefore
- * reprocesses messages rather than losing them. For mail that is the right trade: a
- * duplicate is visible and recoverable, a silently dropped message is neither.
+ * Listing is newest-first with a limit, so if more than `limit` messages arrive between
+ * cycles the page stops short of the cursor and everything behind it would be skipped
+ * forever once the watermark advanced. This widens the page until it reaches back past the
+ * cursor, the page is no longer full, or the ceiling is hit.
+ *
+ * With no cursor yet the page is taken as-is: a first run starts from now rather than
+ * ingesting the entire mailbox history.
+ */
+async function listBackToCursor(
+  deps: InboundDeps,
+  options: PollOptions,
+  previousWatermark: string | undefined,
+): Promise<{ messages: MailboxMessage[]; truncated: boolean }> {
+  const ceiling = options.maxLimit ?? DEFAULT_MAX_LIMIT;
+  let limit = options.limit;
+  let messages = await deps.listMessages({ mailbox: options.mailbox, limit });
+
+  if (!previousWatermark) {
+    return { messages, truncated: false };
+  }
+
+  while (messages.length >= limit && limit < ceiling) {
+    const dates = messages.map((m) => m.dateReceived).filter(Boolean) as string[];
+    const oldest = dates.sort()[0];
+    if (oldest && oldest <= previousWatermark) {
+      // The page now spans the cursor, so nothing is hiding behind it.
+      return { messages, truncated: false };
+    }
+    limit = Math.min(limit * 4, ceiling);
+    messages = await deps.listMessages({ mailbox: options.mailbox, limit });
+  }
+
+  const dates = messages.map((m) => m.dateReceived).filter(Boolean) as string[];
+  const oldest = dates.sort()[0];
+  const stillShort = messages.length >= limit && !!oldest && oldest > previousWatermark;
+  return { messages, truncated: stillShort };
+}
+
+/**
+ * Runs one poll cycle: list, filter to unseen, classify each.
+ *
+ * The cursor is returned, **not persisted**. Advancing it is the caller's job and must
+ * happen only after the batch has actually been delivered, because a cursor that moves
+ * ahead of delivery turns any delivery failure into permanently skipped mail.
  */
 export async function runPollCycle(
   deps: InboundDeps,
@@ -50,7 +102,7 @@ export async function runPollCycle(
   store: CursorStore,
 ): Promise<PollCycleResult> {
   const previous = (await store.lookup(options.cursorKey)) ?? {};
-  const messages = await deps.listMessages({ mailbox: options.mailbox, limit: options.limit });
+  const { messages, truncated } = await listBackToCursor(deps, options, previous.lastDateReceived);
   const { fresh, cursor } = selectNewMessages(messages, previous);
 
   const classified: ClassifiedMessage[] = [];
@@ -58,8 +110,7 @@ export async function runPollCycle(
     classified.push(await classifyMessage(message, deps, options.classify));
   }
 
-  await store.register(options.cursorKey, cursor);
-  return { classified, cursor };
+  return { classified, cursor, truncated };
 }
 
 export type PollLoopDeps = {
@@ -67,6 +118,8 @@ export type PollLoopDeps = {
   onAdmitted: (messages: ClassifiedMessage[]) => Promise<void> | void;
   /** Reports a cycle that threw. The loop continues regardless. */
   onError?: (error: unknown) => void;
+  /** Reports that the page ceiling was hit with unread mail still behind it. */
+  onTruncated?: (params: { mailbox: string; limit: number }) => void;
   /** Injected so tests do not wait in real time. */
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
 };
@@ -101,11 +154,17 @@ export async function runPollLoop(
   const sleep = deps.sleep ?? defaultSleep;
   while (!signal.aborted) {
     try {
-      const { classified } = await runPollCycle(deps, options, store);
+      const { classified, cursor, truncated } = await runPollCycle(deps, options, store);
+      if (truncated) {
+        deps.onTruncated?.({ mailbox: options.mailbox, limit: options.maxLimit ?? DEFAULT_MAX_LIMIT });
+      }
       const admitted = classified.filter((entry) => entry.decision.admission !== "drop");
       if (admitted.length > 0) {
+        // Deliver first. If this throws, the cursor is left untouched and the batch is
+        // retried next cycle rather than silently skipped.
         await deps.onAdmitted(admitted);
       }
+      await store.register(options.cursorKey, cursor);
     } catch (error) {
       deps.onError?.(error);
     }

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -164,7 +164,16 @@ export async function runPollLoop(
         // retried next cycle rather than silently skipped.
         await deps.onAdmitted(admitted);
       }
-      await store.register(options.cursorKey, cursor);
+      // Reporting truncation is not enough. The cursor derives from a newest-first
+      // partial page, so persisting it would bury the older mail still behind the
+      // ceiling. Holding it reprocesses this page next cycle, which is duplicates
+      // instead of loss, and truncation keeps being reported until the backlog drains
+      // or the operator raises maxLimit.
+      //
+      // Deliberately not `continue`: that would skip the sleep below and spin the loop.
+      if (!truncated) {
+        await store.register(options.cursorKey, cursor);
+      }
     } catch (error) {
       deps.onError?.(error);
     }

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -1,0 +1,117 @@
+/**
+ * The poll loop that drives inbound mail.
+ *
+ * This is what replaces the retired Mail.app rule. Polling instead of being pushed keeps
+ * the filter inside the channel, where policy belongs, rather than upstream in a mail rule
+ * that decided what the agent was even allowed to see.
+ *
+ * The cursor lives in the plugin keyed store (SQLite-backed), not a sidecar file, so it
+ * survives gateway restarts without adding a parallel state path.
+ */
+
+import {
+  classifyMessage,
+  selectNewMessages,
+  type ClassifiedMessage,
+  type ClassifyOptions,
+  type InboundDeps,
+  type PollCursor,
+} from "./inbound.ts";
+
+/** The subset of the plugin keyed store this needs. Narrow so tests can fake it. */
+export type CursorStore = {
+  lookup(key: string): Promise<PollCursor | undefined>;
+  register(key: string, value: PollCursor): Promise<void>;
+};
+
+export type PollOptions = {
+  mailbox: string;
+  limit: number;
+  /** Store key, so several accounts can poll independently. */
+  cursorKey: string;
+  classify: ClassifyOptions;
+};
+
+export type PollCycleResult = {
+  classified: ClassifiedMessage[];
+  cursor: PollCursor;
+};
+
+/**
+ * Runs one poll cycle: list, filter to unseen, classify each, persist the cursor.
+ *
+ * The cursor is written **after** classification, not before. A crash mid-cycle therefore
+ * reprocesses messages rather than losing them. For mail that is the right trade: a
+ * duplicate is visible and recoverable, a silently dropped message is neither.
+ */
+export async function runPollCycle(
+  deps: InboundDeps,
+  options: PollOptions,
+  store: CursorStore,
+): Promise<PollCycleResult> {
+  const previous = (await store.lookup(options.cursorKey)) ?? {};
+  const messages = await deps.listMessages({ mailbox: options.mailbox, limit: options.limit });
+  const { fresh, cursor } = selectNewMessages(messages, previous);
+
+  const classified: ClassifiedMessage[] = [];
+  for (const message of fresh) {
+    classified.push(await classifyMessage(message, deps, options.classify));
+  }
+
+  await store.register(options.cursorKey, cursor);
+  return { classified, cursor };
+}
+
+export type PollLoopDeps = {
+  /** Called with the messages a cycle admitted. Dropped messages never reach it. */
+  onAdmitted: (messages: ClassifiedMessage[]) => Promise<void> | void;
+  /** Reports a cycle that threw. The loop continues regardless. */
+  onError?: (error: unknown) => void;
+  /** Injected so tests do not wait in real time. */
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+};
+
+function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    // Unblock immediately on shutdown instead of holding the gateway for a full interval.
+    signal.addEventListener("abort", () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+
+/**
+ * Polls until aborted.
+ *
+ * Cycles never overlap: the next interval starts after the previous cycle settles, so a
+ * slow mailbox cannot stack concurrent scans that would race on the same cursor.
+ *
+ * A failing cycle is reported and skipped rather than ending the loop. Mail is a
+ * background source; one bad poll should not silently stop the channel until someone
+ * notices no mail has arrived for a day.
+ */
+export async function runPollLoop(
+  deps: InboundDeps & PollLoopDeps,
+  options: PollOptions & { intervalMs: number },
+  store: CursorStore,
+  signal: AbortSignal,
+): Promise<void> {
+  const sleep = deps.sleep ?? defaultSleep;
+  while (!signal.aborted) {
+    try {
+      const { classified } = await runPollCycle(deps, options, store);
+      const admitted = classified.filter((entry) => entry.decision.admission !== "drop");
+      if (admitted.length > 0) {
+        await deps.onAdmitted(admitted);
+      }
+    } catch (error) {
+      deps.onError?.(error);
+    }
+    if (signal.aborted) {
+      return;
+    }
+    await sleep(options.intervalMs, signal);
+  }
+}

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -1,0 +1,126 @@
+/**
+ * Real `mail-cli`-backed implementations of the inbound dependencies.
+ *
+ * Everything here shells out; everything above it is pure. That split is why the policy,
+ * cursor, and loop can be tested exhaustively without a mailbox.
+ *
+ * All calls use `--engine sqlite`, which reads the Envelope Index and the emlx files on
+ * disk. That is what lets the channel run without Mail.app being open, which matters
+ * because Mail.app does not stay running unattended.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import type { MailAuthCheckResult } from "../mail-auth/strength.ts";
+import type { InboundDeps, MailboxMessage, MessageThreadHeaders } from "./inbound.ts";
+
+const run = promisify(execFile);
+
+export type MailCliOptions = {
+  /** Directory holding the Swift CLIs. Falls back to whatever is on PATH. */
+  binDir?: string;
+  /** Path to trusted-senders.json, which carries expectedDkimDomains and authserv-ids. */
+  trustedSendersPath?: string;
+  /** Mail.app account name, passed as a lookup hint. */
+  account?: string;
+  /** Per-call timeout. A hung CLI must not stall the poll loop forever. */
+  timeoutMs?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+function binary(options: MailCliOptions): string {
+  return options.binDir ? path.join(options.binDir, "mail-cli") : "mail-cli";
+}
+
+async function runJson<T>(options: MailCliOptions, args: string[]): Promise<T> {
+  const { stdout } = await run(binary(options), args, {
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return JSON.parse(stdout) as T;
+}
+
+/** Builds the inbound dependency set backed by the real CLI. */
+export function createMailCliDeps(options: MailCliOptions): InboundDeps {
+  const accountArgs = options.account ? ["--account", options.account] : [];
+  const trustedArgs = options.trustedSendersPath
+    ? ["--trusted-senders", options.trustedSendersPath]
+    : [];
+
+  return {
+    listMessages: async ({ mailbox, limit }) => {
+      const result = await runJson<{ messages?: MailboxMessage[] }>(options, [
+        "messages",
+        "--mailbox",
+        mailbox,
+        "--limit",
+        String(limit),
+        ...accountArgs,
+        "--engine",
+        "sqlite",
+        "--format",
+        "json",
+      ]);
+      return result.messages ?? [];
+    },
+
+    authCheck: async (messageId) =>
+      runJson<MailAuthCheckResult>(options, [
+        "auth-check",
+        "--id",
+        messageId,
+        ...trustedArgs,
+        ...accountArgs,
+        "--engine",
+        "sqlite",
+      ]),
+
+    readThreadHeaders: async (messageId) => {
+      const result = await runJson<{ message?: { allHeaders?: unknown } }>(options, [
+        "get",
+        "--id",
+        messageId,
+        ...accountArgs,
+        "--engine",
+        "sqlite",
+        "--format",
+        "json",
+      ]);
+      return parseThreadHeaders(result.message?.allHeaders);
+    },
+  };
+}
+
+/**
+ * Pulls `In-Reply-To` and `References` out of raw headers.
+ *
+ * These are sender-controlled and are treated as *claims* by `decideThreadReply`, which
+ * checks them against what the agent recorded sending. Nothing here grants anything.
+ */
+export function parseThreadHeaders(allHeaders: unknown): MessageThreadHeaders {
+  const text =
+    typeof allHeaders === "string"
+      ? allHeaders
+      : allHeaders && typeof allHeaders === "object"
+        ? Object.entries(allHeaders as Record<string, unknown>)
+            .map(([key, value]) => `${key}: ${String(value)}`)
+            .join("\n")
+        : "";
+  if (!text) {
+    return {};
+  }
+  // Unfold continuation lines before matching; both headers commonly wrap.
+  const unfolded = text.replace(/\r?\n[ \t]+/g, " ");
+  const inReplyTo = /^in-reply-to:\s*(.+)$/im.exec(unfolded)?.[1]?.trim();
+  const referencesRaw = /^references:\s*(.+)$/im.exec(unfolded)?.[1];
+  const references = referencesRaw
+    ?.split(/\s+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return {
+    ...(inReplyTo ? { inReplyTo } : {}),
+    ...(references && references.length > 0 ? { references } : {}),
+  };
+}


### PR DESCRIPTION
The loop existed but nothing called it. This adds the gateway adapter and the `mail-cli`-backed dependencies.

## Decisions worth reviewing

**`startAccount` returns once the loop is running** rather than awaiting it, since the loop only ends on abort and gateway startup has to complete. The promise is retained so `stopAccount` waits for the in-flight cycle to settle instead of tearing down mid-classification.

**The keyed store is captured at registration, not from `ctx`.** `ChannelGatewayContext.runtime` is `RuntimeEnv`, which has no `.state`; `openKeyedStore` lives on `PluginRuntime`. The compiler caught this — my first attempt used `ctx.runtime.state` and did not typecheck.

**It refuses to start without durable cursor storage.** Running with an in-memory cursor would re-read the mailbox from scratch on every restart: it looks healthy and silently reprocesses. Failing loudly is better than a channel that appears to work.

**All CLI calls use `--engine sqlite`**, so the channel runs without Mail.app open — which matters because Mail.app does not stay running unattended on this host.

**Thread headers are unfolded before parsing**, since `In-Reply-To` and `References` commonly wrap across lines. They stay *claims*: `decideThreadReply` checks them against what the agent recorded sending.

## Evidence

74 tests, `tsc -p tsconfig.json` clean, build clean.

Live round-trip against the real mailbox:

```
folded References: {"inReplyTo":"<b@x>","references":["<a@x>","<b@x>"]}
listMessages: 2 messages
authCheck   : untrusted
threadHdrs  : {}
```

## Known Gap, stated plainly

**Mail still does not reach the agent.** `onAdmitted` currently logs a warning when no handler is set, and no handler is set yet.

I did not wire agent dispatch because `ChannelRuntimeSurface` is typed `{ runtimeContexts, [key: string]: unknown }`, so calling its reply dispatcher means casting through `unknown`. Given that three of this session's findings came from claiming more verification than I had, guessing at an untyped surface is the wrong move. The handler is an explicit injectable seam (`setAdmittedHandler`) and dispatch is the next piece.

So this PR makes the loop *run*; it does not yet restore the inbound trigger.

**Not merging without your approval.**