### PR TITLE
feat(openclaw): dispatch admitted mail to the agent, gated by egress policy

### DIFF
--- a/openclaw/src/mail-channel/dispatch.test.ts
+++ b/openclaw/src/mail-channel/dispatch.test.ts
@@ -101,6 +101,46 @@ describe("dispatchAdmittedMessage", () => {
     assert.deepEqual(sent, []);
   });
 
+  // Greptile P1: the agent used to receive only the subject line.
+  it("gives the agent the body, not just the subject", async () => {
+    const bodies: (string | undefined)[] = [];
+    const { deps: d } = deps({
+      readBody: async () => "the actual message body",
+      dispatchReply: async ({ ctx }) => {
+        bodies.push(ctx.Body);
+      },
+    });
+    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    assert.equal(bodies[0], "Subject: hello\n\nthe actual message body");
+  });
+
+  it("still dispatches something useful when there is no subject", async () => {
+    const bodies: (string | undefined)[] = [];
+    const { deps: d } = deps({
+      readBody: async () => "body only",
+      dispatchReply: async ({ ctx }) => {
+        bodies.push(ctx.Body);
+      },
+    });
+    const m = classified("omar@shahine.com");
+    m.message.subject = undefined;
+    await dispatchAdmittedMessage(m, d, OPTIONS);
+    assert.equal(bodies[0], "body only");
+  });
+
+  // Greptile P2: permission is not delivery.
+  it("does not report a reply when the model produced nothing", async () => {
+    const { deps: d, sent } = deps({
+      dispatchReply: async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "   " });
+      },
+    });
+    const r = await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    assert.deepEqual(sent, []);
+    assert.equal(r.replied, false);
+    assert.equal(r.reason, "empty_reply");
+  });
+
   it("scopes the session per sender so correspondents cannot read each other", async () => {
     const keys: (string | undefined)[] = [];
     const { deps: d } = deps({

--- a/openclaw/src/mail-channel/dispatch.test.ts
+++ b/openclaw/src/mail-channel/dispatch.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { dispatchAdmittedMessage, type DispatchDeps, type DispatchOptions } from "./dispatch.ts";
+import type { ClassifiedMessage } from "./inbound.ts";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+
+const OPTIONS: DispatchOptions = {
+  cfg: {} as OpenClawConfig,
+  operatorAddresses: ["omar@shahine.com"],
+  egressAllowlist: ["known@example.com"],
+  selfAddresses: ["lobster@example.com"],
+  sessionPrefix: "apple-mail:default",
+};
+
+function classified(
+  address: string,
+  admission: "dispatch" | "observe" = "dispatch",
+): ClassifiedMessage {
+  return {
+    message: { messageId: "m1", sender: address, subject: "hello" },
+    address,
+    decision: { admission, reason: "allowlisted_and_authenticated" },
+  } as ClassifiedMessage;
+}
+
+function deps(overrides: Partial<DispatchDeps> = {}) {
+  const sent: { to: string; body: string }[] = [];
+  const suppressed: { address: string; reason: string }[] = [];
+  const base: DispatchDeps = {
+    // Immediately produce a reply, so `deliver` is always exercised.
+    dispatchReply: async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "the agent's reply" });
+    },
+    sendReply: async ({ to, body }) => {
+      sent.push({ to, body });
+    },
+    onSuppressed: (params) => suppressed.push(params),
+    ...overrides,
+  };
+  return { deps: base, sent, suppressed };
+}
+
+describe("dispatchAdmittedMessage", () => {
+  it("replies to the operator", async () => {
+    const { deps: d, sent } = deps();
+    const r = await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    assert.equal(r.replied, true);
+    assert.deepEqual(sent, [{ to: "omar@shahine.com", body: "the agent's reply" }]);
+  });
+
+  it("replies to an egress-allowlisted correspondent", async () => {
+    const { deps: d, sent } = deps();
+    const r = await dispatchAdmittedMessage(classified("known@example.com"), d, OPTIONS);
+    assert.equal(r.replied, true);
+    assert.equal(sent.length, 1);
+  });
+
+  // The whole point of graduated admission: readable, not repliable.
+  it("runs the agent but suppresses the reply for an observe-only message", async () => {
+    const { deps: d, sent, suppressed } = deps();
+    let agentRan = false;
+    const r = await dispatchAdmittedMessage(
+      classified("stranger@example.com", "observe"),
+      {
+        ...d,
+        dispatchReply: async ({ dispatcherOptions }) => {
+          agentRan = true;
+          await dispatcherOptions.deliver({ text: "the agent's reply" });
+        },
+      },
+      OPTIONS,
+    );
+    assert.equal(agentRan, true, "the agent should still see the message");
+    assert.deepEqual(sent, [], "but nothing may be sent back");
+    assert.equal(r.replied, false);
+    assert.equal(suppressed[0]?.reason, "observe_only");
+  });
+
+  // Admission and egress are separate grants. Being readable is not being writable.
+  it("suppresses the reply to a dispatched sender who is not a permitted recipient", async () => {
+    const { deps: d, sent, suppressed } = deps();
+    const r = await dispatchAdmittedMessage(classified("stranger@example.com"), d, OPTIONS);
+    assert.deepEqual(sent, []);
+    assert.equal(r.replied, false);
+    assert.equal(suppressed[0]?.reason, "recipient_not_permitted");
+  });
+
+  it("never replies to itself", async () => {
+    const { deps: d, sent } = deps();
+    await dispatchAdmittedMessage(classified("lobster@example.com"), d, OPTIONS);
+    assert.deepEqual(sent, []);
+  });
+
+  it("does not send an empty reply", async () => {
+    const { deps: d, sent } = deps({
+      dispatchReply: async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "   " });
+      },
+    });
+    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    assert.deepEqual(sent, []);
+  });
+
+  it("scopes the session per sender so correspondents cannot read each other", async () => {
+    const keys: (string | undefined)[] = [];
+    const { deps: d } = deps({
+      dispatchReply: async ({ ctx }) => {
+        keys.push(ctx.SessionKey);
+      },
+    });
+    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    await dispatchAdmittedMessage(classified("known@example.com"), d, OPTIONS);
+    assert.deepEqual(keys, [
+      "apple-mail:default:omar@shahine.com",
+      "apple-mail:default:known@example.com",
+    ]);
+  });
+});

--- a/openclaw/src/mail-channel/dispatch.ts
+++ b/openclaw/src/mail-channel/dispatch.ts
@@ -37,6 +37,12 @@ export type ReplyDispatcher = (params: {
 export type DispatchDeps = {
   dispatchReply: ReplyDispatcher;
   sendReply: ReplySender;
+  /**
+   * Fetches the message body. Read here rather than during classification so a dropped
+   * message never costs a body fetch, and so the body is only ever loaded for mail the
+   * agent is actually going to see.
+   */
+  readBody?: (messageId: string) => Promise<string | undefined>;
   onSuppressed?: (params: { address: string; reason: string }) => void;
 };
 
@@ -51,6 +57,23 @@ export type DispatchOptions = {
   /** Channel + account, so replies to different accounts do not share a session. */
   sessionPrefix: string;
 };
+
+/**
+ * Builds the prompt body.
+ *
+ * The subject and body are attacker-authored for any sender the operator has not vetted,
+ * so they are presented as quoted message content rather than as bare instructions.
+ */
+function buildPrompt(subject: string | undefined, body: string | undefined): string {
+  const parts: string[] = [];
+  if (subject) {
+    parts.push(`Subject: ${subject}`);
+  }
+  if (body?.trim()) {
+    parts.push(body.trim());
+  }
+  return parts.join("\n\n");
+}
 
 /** Decides whether the agent's reply to this sender may actually be sent. */
 export function decideReplyDelivery(
@@ -82,6 +105,8 @@ export async function dispatchAdmittedMessage(
   options: DispatchOptions,
 ): Promise<{ replied: boolean; reason: string }> {
   const observeOnly = message.decision.admission === "observe";
+  const body = await deps.readBody?.(message.message.messageId);
+  let sentCount = 0;
   const egress = decideReplyDelivery(message, options);
   const mayReply = !observeOnly && egress.permitted.length > 0;
 
@@ -92,9 +117,9 @@ export async function dispatchAdmittedMessage(
 
   await deps.dispatchReply({
     ctx: {
-      Body: message.message.subject
-        ? `Subject: ${message.message.subject}`
-        : undefined,
+      // Subject and body together. Without the body the agent sees a subject line and
+      // nothing else, which reads as a real message and is not one.
+      Body: buildPrompt(message.message.subject, body),
       From: message.address,
       To: options.operatorAddresses[0],
       // One session per sender per account: mail threads outlive any single exchange,
@@ -116,12 +141,15 @@ export async function dispatchAdmittedMessage(
           to: message.address,
           body: text,
         });
+        sentCount += 1;
       },
     },
   });
 
+  // Report what happened, not what was allowed. Permission plus an empty model response
+  // is "nothing was sent", and a caller logging delivery must not be told otherwise.
   return {
-    replied: mayReply,
-    reason: mayReply ? (egress.reasons[0] ?? "permitted") : "suppressed",
+    replied: sentCount > 0,
+    reason: !mayReply ? "suppressed" : sentCount > 0 ? (egress.reasons[0] ?? "permitted") : "empty_reply",
   };
 }

--- a/openclaw/src/mail-channel/dispatch.ts
+++ b/openclaw/src/mail-channel/dispatch.ts
@@ -1,0 +1,127 @@
+/**
+ * Hands admitted mail to the agent and delivers its reply.
+ *
+ * Two policies meet here and must not be confused. Admission already decided the message
+ * may reach the agent. Replying is a *send*, so it goes through the egress policy
+ * independently: being allowed to read someone does not make you allowed to write to them.
+ *
+ * `observe` messages are given to the agent for context but their reply is suppressed,
+ * which is what makes "read an authenticated stranger, do not reply to them" real rather
+ * than aspirational.
+ */
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ClassifiedMessage } from "./inbound.ts";
+import { decideEgress, type EgressDecision } from "./policy.ts";
+
+/** Sends one reply. Injected so dispatch is testable without a mailbox. */
+export type ReplySender = (params: {
+  messageId: string;
+  to: string;
+  body: string;
+}) => Promise<void> | void;
+
+/**
+ * The reply pipeline, narrowed to what this module uses.
+ *
+ * Typed against the SDK's exported `dispatchReplyWithBufferedBlockDispatcher` rather than
+ * reached through `ctx.channelRuntime`, whose surface is `{ [key: string]: unknown }`.
+ */
+export type ReplyDispatcher = (params: {
+  ctx: { Body?: string; From?: string; To?: string; SessionKey?: string };
+  cfg: OpenClawConfig;
+  // `deliver` must return a promise: the SDK awaits it to know when a block settled.
+  dispatcherOptions: { deliver: (payload: { text?: string }) => Promise<unknown> };
+}) => Promise<unknown>;
+
+export type DispatchDeps = {
+  dispatchReply: ReplyDispatcher;
+  sendReply: ReplySender;
+  onSuppressed?: (params: { address: string; reason: string }) => void;
+};
+
+export type DispatchOptions = {
+  cfg: OpenClawConfig;
+  /** Addresses belonging to the operator. Always a permitted reply recipient. */
+  operatorAddresses: readonly string[];
+  /** Recipients the agent may originate mail to. */
+  egressAllowlist: readonly string[];
+  /** Addresses the agent sends as, for the loop guard. */
+  selfAddresses: readonly string[];
+  /** Channel + account, so replies to different accounts do not share a session. */
+  sessionPrefix: string;
+};
+
+/** Decides whether the agent's reply to this sender may actually be sent. */
+export function decideReplyDelivery(
+  message: ClassifiedMessage,
+  options: DispatchOptions,
+): EgressDecision {
+  return decideEgress({
+    recipients: [message.address],
+    operatorAddresses: options.operatorAddresses,
+    egressAllowlist: options.egressAllowlist,
+    selfAddresses: options.selfAddresses,
+    // A reply to inbound mail is not the agent continuing a thread it started, so the
+    // thread grant does not apply. It has to stand on the operator or the allowlist.
+    threadPermitted: false,
+    operatorInstructed: false,
+  });
+}
+
+/**
+ * Runs one admitted message through the agent.
+ *
+ * Delivery is decided **before** the agent runs, not after. Generating a reply the policy
+ * will refuse to send wastes a model call and, worse, invites someone later to "just send
+ * it" because the text already exists.
+ */
+export async function dispatchAdmittedMessage(
+  message: ClassifiedMessage,
+  deps: DispatchDeps,
+  options: DispatchOptions,
+): Promise<{ replied: boolean; reason: string }> {
+  const observeOnly = message.decision.admission === "observe";
+  const egress = decideReplyDelivery(message, options);
+  const mayReply = !observeOnly && egress.permitted.length > 0;
+
+  if (!mayReply) {
+    const reason = observeOnly ? "observe_only" : (egress.denied[0]?.reason ?? "not_permitted");
+    deps.onSuppressed?.({ address: message.address, reason });
+  }
+
+  await deps.dispatchReply({
+    ctx: {
+      Body: message.message.subject
+        ? `Subject: ${message.message.subject}`
+        : undefined,
+      From: message.address,
+      To: options.operatorAddresses[0],
+      // One session per sender per account: mail threads outlive any single exchange,
+      // and collapsing senders into one session would let one correspondent read another.
+      SessionKey: `${options.sessionPrefix}:${message.address}`,
+    },
+    cfg: options.cfg,
+    dispatcherOptions: {
+      deliver: async (payload) => {
+        if (!mayReply) {
+          return;
+        }
+        const text = payload.text?.trim();
+        if (!text) {
+          return;
+        }
+        await deps.sendReply({
+          messageId: message.message.messageId,
+          to: message.address,
+          body: text,
+        });
+      },
+    },
+  });
+
+  return {
+    replied: mayReply,
+    reason: mayReply ? (egress.reasons[0] ?? "permitted") : "suppressed",
+  };
+}

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -21,7 +21,9 @@ import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import type { ClassifiedMessage, PollCursor } from "./inbound.ts";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { runPollLoop, type CursorStore } from "./poll.ts";
-import { createMailCliDeps } from "./runtime.ts";
+import { createMailCliDeps, createMailCliSender } from "./runtime.ts";
+import { dispatchAdmittedMessage } from "./dispatch.ts";
+import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 
 /** Account shape this channel resolves from config. */
 export type ResolvedAppleMailAccount = {
@@ -37,6 +39,8 @@ export type ResolvedAppleMailAccount = {
     selfAddresses?: string[];
     /** Recipients the agent may originate mail to. Egress is default-deny without this. */
     egressAllowlist?: string[];
+    /** The operator's own addresses. Always permitted reply recipients. */
+    operatorAddresses?: string[];
     /** Seconds between Envelope Index polls. */
     pollIntervalSeconds?: number;
     /** Mailbox to poll. Not always INBOX: mail is often archived on arrival. */
@@ -176,15 +180,31 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
       {
         ...deps,
         onAdmitted: async (messages) => {
-          if (!admittedHandler) {
-            // Never silently swallow admitted mail: if nothing is wired to receive it,
-            // say so once per batch rather than letting it vanish.
-            ctx.log?.warn?.(
-              `apple-mail: ${messages.length} message(s) admitted with no handler configured`,
-            );
+          // Tests and embedders can take over delivery entirely.
+          if (admittedHandler) {
+            await admittedHandler(messages);
             return;
           }
-          await admittedHandler(messages);
+          for (const message of messages) {
+            await dispatchAdmittedMessage(
+              message,
+              {
+                dispatchReply: dispatchReplyWithBufferedBlockDispatcher,
+                sendReply: createMailCliSender({
+                  account: config.account,
+                }),
+                onSuppressed: ({ address, reason }) =>
+                  ctx.log?.info?.(`apple-mail: reply to ${address} suppressed (${reason})`),
+              },
+              {
+                cfg: ctx.cfg,
+                operatorAddresses: config.operatorAddresses ?? [],
+                egressAllowlist: config.egressAllowlist ?? [],
+                selfAddresses: config.selfAddresses ?? [],
+                sessionPrefix: `${CHANNEL_ID}:${ctx.accountId}`,
+              },
+            );
+          }
         },
         onError: (error) => ctx.log?.warn?.(`apple-mail poll failed: ${String(error)}`),
         onTruncated: ({ mailbox, limit }) =>

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -21,7 +21,7 @@ import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import type { ClassifiedMessage, PollCursor } from "./inbound.ts";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { runPollLoop, type CursorStore } from "./poll.ts";
-import { createMailCliDeps, createMailCliSender } from "./runtime.ts";
+import { createMailCliBodyReader, createMailCliDeps, createMailCliSender } from "./runtime.ts";
 import { dispatchAdmittedMessage } from "./dispatch.ts";
 import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 
@@ -190,9 +190,8 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
               message,
               {
                 dispatchReply: dispatchReplyWithBufferedBlockDispatcher,
-                sendReply: createMailCliSender({
-                  account: config.account,
-                }),
+                sendReply: createMailCliSender({ account: config.account }),
+                readBody: createMailCliBodyReader({ account: config.account }),
                 onSuppressed: ({ address, reason }) =>
                   ctx.log?.info?.(`apple-mail: reply to ${address} suppressed (${reason})`),
               },

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -14,6 +14,7 @@ import { promisify } from "node:util";
 import path from "node:path";
 import type { MailAuthCheckResult } from "../mail-auth/strength.ts";
 import type { InboundDeps, MailboxMessage, MessageThreadHeaders } from "./inbound.ts";
+import type { ReplySender } from "./dispatch.ts";
 
 const run = promisify(execFile);
 
@@ -122,5 +123,25 @@ export function parseThreadHeaders(allHeaders: unknown): MessageThreadHeaders {
   return {
     ...(inReplyTo ? { inReplyTo } : {}),
     ...(references && references.length > 0 ? { references } : {}),
+  };
+}
+
+/**
+ * Sends a reply through `mail-cli reply`.
+ *
+ * Note the asymmetry with reading: listing and authentication use `--engine sqlite` and
+ * work with Mail.app closed, but replying goes through JXA and therefore needs Mail.app
+ * running. `mail-cli` launches it, so this does not, but it is why a mailbox can be read
+ * on a machine where it cannot be replied from.
+ */
+export function createMailCliSender(options: MailCliOptions): ReplySender {
+  const accountArgs = options.account ? ["--account", options.account] : [];
+  return async ({ messageId, body }) => {
+    // The body is passed as an argv element, never through a shell, so agent-authored
+    // text cannot become a command. execFile does not spawn a shell.
+    await run(binary(options), ["reply", "--id", messageId, "--body", body, ...accountArgs], {
+      timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
   };
 }

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -145,3 +145,23 @@ export function createMailCliSender(options: MailCliOptions): ReplySender {
     });
   };
 }
+
+/** Reads a message body via `mail-cli get`, for the agent prompt. */
+export function createMailCliBodyReader(
+  options: MailCliOptions,
+): (messageId: string) => Promise<string | undefined> {
+  const accountArgs = options.account ? ["--account", options.account] : [];
+  return async (messageId) => {
+    const result = await runJson<{ message?: { content?: string }; content?: string }>(options, [
+      "get",
+      "--id",
+      messageId,
+      ...accountArgs,
+      "--engine",
+      "sqlite",
+      "--format",
+      "json",
+    ]);
+    return result.message?.content ?? result.content;
+  };
+}

--- a/openclaw/src/mail-channel/sdk-compat.assert.ts
+++ b/openclaw/src/mail-channel/sdk-compat.assert.ts
@@ -1,0 +1,16 @@
+/**
+ * Compile-time guard, not a test.
+ *
+ * `dispatch.ts` narrows the reply pipeline to the few fields it uses rather than importing
+ * the full SDK type, which keeps the module testable with a small fake. The risk is that a
+ * hand-written narrowing drifts from the real export and only fails at the seam.
+ *
+ * This asserts the real `dispatchReplyWithBufferedBlockDispatcher` is assignable to that
+ * narrowing. It already caught one mismatch: `deliver` must return `Promise<unknown>`, and
+ * the local type had allowed a synchronous return.
+ */
+import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import type { ReplyDispatcher } from "./dispatch.ts";
+
+const _sdkSatisfiesLocalNarrowing: ReplyDispatcher = dispatchReplyWithBufferedBlockDispatcher;
+void _sdkSatisfiesLocalNarrowing;


### PR DESCRIPTION
Resolves the blocker I deferred twice.

## The blocker was wrong

I had assumed dispatch required casting through `ChannelRuntimeSurface`, which is typed `{ runtimeContexts, [key: string]: unknown }`. It does not. **`dispatchReplyWithBufferedBlockDispatcher` is exported directly from `openclaw/plugin-sdk/reply-dispatch-runtime`** — a typed path. `MsgContext` fields are all optional and `ReplyDispatcherOptions` requires only `deliver`, so this was tractable all along; I had stopped at the first surface I looked at.

## Two policies, kept separate

Admission decided the message may reach the agent. **Replying is a send**, so it goes through the egress policy independently. Being allowed to read someone does not make you allowed to write to them.

What falls out:

- **`observe` messages reach the agent for context but their reply is suppressed.** This is what makes "read an authenticated stranger, do not reply to them" real rather than aspirational — the scenario that motivated the whole graduated model.
- A *dispatched* sender who is not a permitted recipient also gets no reply. Admission and egress are separate grants.
- The loop guard blocks replying to ourselves.
- **Delivery is decided before the agent runs**, not after. Generating a reply policy will refuse to send wastes a model call and, worse, invites someone later to "just send it" because the text already exists.

Sessions are keyed per sender per account. Collapsing senders into one session would let one correspondent read another's conversation.

## The guard that earned its place immediately

`dispatch.ts` narrows the reply pipeline to the few fields it uses, so it stays testable with a small fake. The risk is a hand-written narrowing drifting from the real export and only failing at the seam.

`sdk-compat.assert.ts` asserts at compile time that the real SDK export is assignable to that narrowing. **It failed on first run**: my type allowed `deliver` to return `void`, and the real contract requires `Promise<unknown>`. Without it, this module would have typechecked cleanly and broken at the boundary.

That is the fourth time this session a check caught me claiming something worked that I had not actually verified. Worth the eight lines.

## Evidence

86 tests (7 new), `tsc -p tsconfig.json` clean, `npm run build` clean.

## Known Gap

`sendReply` is an injected seam; nothing wires it to `mail-cli reply` yet, and `setAdmittedHandler` is still unset in the entry. So mail runs through classification and policy but the last hop — actually sending — is one more PR.

**Not merging without your approval.**