### PR TITLE
feat(mail-cli): launch Mail.app when a command actually needs it

### DIFF
--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -336,13 +336,82 @@ func validateDestDir(_ url: URL) throws {
     }
 }
 
-func ensureMailRunning() throws {
-    let running = NSWorkspace.shared.runningApplications.contains {
+func mailIsRunning() -> Bool {
+    NSWorkspace.shared.runningApplications.contains {
         $0.bundleIdentifier == "com.apple.mail"
     }
-    guard running else {
-        throw CLIError.appNotRunning("Mail.app is not running. Please open Mail.app first.")
+}
+
+/// Ensures Mail.app is running, launching it if it is not.
+///
+/// This used to only check and throw, which made the name a lie and left every JXA-backed
+/// command failing on a host where Mail.app does not stay open. Reads no longer reach here
+/// (the SQLite/emlx path is tried first), so by the time this runs the caller genuinely
+/// needs Mail.app and launching is useful rather than a surprise GUI launch.
+///
+/// Launched without activating, so it does not steal focus on a machine in use.
+func ensureMailRunning() throws {
+    if mailIsRunning() {
+        return
     }
+
+    guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.mail") else {
+        throw CLIError.appNotRunning("Mail.app is not installed or could not be located.")
+    }
+
+    let config = NSWorkspace.OpenConfiguration()
+    config.activates = false
+
+    let group = DispatchGroup()
+    group.enter()
+    var launched: NSRunningApplication?
+    var launchError: Error?
+    NSWorkspace.shared.openApplication(at: url, configuration: config) { app, error in
+        launched = app
+        launchError = error
+        group.leave()
+    }
+    _ = group.wait(timeout: .now() + 30)
+
+    if let launchError {
+        throw CLIError.appNotRunning("Failed to launch Mail.app: \(launchError.localizedDescription)")
+    }
+    guard let app = launched else {
+        throw CLIError.appNotRunning("Mail.app did not launch.")
+    }
+
+    // Readiness is polled by asking Mail a trivial question over Apple Events, because
+    // that is the capability every caller here actually needs.
+    //
+    // The two obvious proxies both fail in a short-lived CLI: NSWorkspace.runningApplications
+    // is a per-process snapshot refreshed by notifications, and isFinishedLaunching is
+    // KVO-backed, so neither updates without a running app's event loop. Both reported
+    // failure for launches that had in fact succeeded.
+    _ = app
+    let deadline = Date().addingTimeInterval(30)
+    while Date() < deadline {
+        if mailAnswersAppleEvents() {
+            return
+        }
+        Thread.sleep(forTimeInterval: 0.5)
+    }
+    throw CLIError.appNotRunning("Mail.app launched but did not answer Apple Events within 30s.")
+}
+
+/// Cheapest possible round-trip that proves Mail is scriptable, not merely running.
+func mailAnswersAppleEvents() -> Bool {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+    proc.arguments = ["-l", "JavaScript", "-e", "Application('Mail').name()"]
+    proc.standardOutput = Pipe()
+    proc.standardError = Pipe()
+    do {
+        try proc.run()
+    } catch {
+        return false
+    }
+    proc.waitUntilExit()
+    return proc.terminationStatus == 0
 }
 
 func runJXA(_ script: String) throws -> Any {

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -350,9 +350,18 @@ func mailIsRunning() -> Bool {
 /// needs Mail.app and launching is useful rather than a surprise GUI launch.
 ///
 /// Launched without activating, so it does not steal focus on a machine in use.
-func ensureMailRunning() throws {
+/// - Parameter launch: opt in to starting Mail.app when it is not running.
+///
+/// Defaults to false so this stays a pure check, which is what every read path relies on:
+/// several commands catch the throw and fall back to SQLite, and a launching default turns
+/// those fallbacks into dead code and every read into a GUI launch. Only operations that
+/// cannot be served any other way (sending, replying) opt in.
+func ensureMailRunning(launch: Bool = false) throws {
     if mailIsRunning() {
         return
+    }
+    guard launch else {
+        throw CLIError.appNotRunning("Mail.app is not running. Please open Mail.app first.")
     }
 
     guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.mail") else {
@@ -410,7 +419,20 @@ func mailAnswersAppleEvents() -> Bool {
     } catch {
         return false
     }
-    proc.waitUntilExit()
+
+    // Bounded wait. An Apple Events call can stall indefinitely behind an automation
+    // consent dialog, and waitUntilExit() would then block past the caller's deadline and
+    // hang the whole command rather than timing out.
+    let group = DispatchGroup()
+    group.enter()
+    DispatchQueue.global().async {
+        proc.waitUntilExit()
+        group.leave()
+    }
+    if group.wait(timeout: .now() + 5) == .timedOut {
+        proc.terminate()
+        return false
+    }
     return proc.terminationStatus == 0
 }
 
@@ -1671,7 +1693,7 @@ struct SendMessage: AsyncParsableCommand {
     var attachment: [String] = []
 
     func run() async throws {
-        try ensureMailRunning()
+        try ensureMailRunning(launch: true)
         let config = pimOptions.loadConfig()
         try checkMailEnabled(config: config)
 
@@ -1765,7 +1787,7 @@ struct ReplyMessage: AsyncParsableCommand {
     var attachment: [String] = []
 
     func run() async throws {
-        try ensureMailRunning()
+        try ensureMailRunning(launch: true)
         let config = pimOptions.loadConfig()
         try checkMailEnabled(config: config)
 


### PR DESCRIPTION
## What Problem This Solves

`ensureMailRunning` only ever **checked and threw** — the name promised something it never did. Every JXA-backed command failed on a host where Mail.app does not stay open, which is this one.

Replying is the case that mattered. The channel could read a mailbox it could not reply from: reads use `--engine sqlite` and work with Mail closed, but `mail-cli reply` goes through JXA.

## Why launching here is safe

Reads no longer reach this function. The SQLite/emlx path is tried first, so by the time `ensureMailRunning` runs, the caller genuinely needs Apple Events. Launching is then the useful behavior rather than a surprise GUI launch. It launches **without activating**, so it does not steal focus on a machine in use.

## The readiness check took three attempts

Two obvious proxies both reported failure for launches that had **actually succeeded**:

| proxy | why it failed |
| --- | --- |
| `NSWorkspace.runningApplications` | per-process snapshot refreshed by notifications; a short-lived CLI never sees the change |
| `NSRunningApplication.isFinishedLaunching` | KVO-backed, did not settle even with the run loop spun |

Both would have shipped a function that launches Mail correctly and then reports a timeout. It now probes by asking Mail a trivial question over Apple Events, which is the capability callers actually need rather than a proxy for it.

## Evidence

Live, on this machine:

| scenario | result |
| --- | --- |
| Mail **down**, `--engine jxa` | launches Mail, returns a real message |
| Mail **up**, `--engine jxa` | no-op, instant |
| Mail **down**, `--engine sqlite` | returns `verified`, **does not launch Mail** |

That last row is the important one: the whole point of the SQLite path is that it has no GUI dependency, and this change must not quietly reintroduce one.

**Not merging without your approval.**