### PR TITLE
fix(mail): close the sender-authentication bypass at the default minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,14 +266,12 @@ The `auth_check` action verifies email sender identity by parsing DKIM and SPF r
       "name": "Alice",
       "emails": ["alice@example.com"],
       "expectedDkimDomains": ["example.com", "messagingengine.com"],
-      "requireDkim": true,
       "requireSpf": true
     },
     {
       "name": "Bob (relaxed SPF)",
       "emails": ["bob@company.com"],
       "expectedDkimDomains": ["company.com"],
-      "requireDkim": true,
       "requireSpf": false
     }
   ]
@@ -287,8 +285,19 @@ The `auth_check` action verifies email sender identity by parsing DKIM and SPF r
 | `name` | string | required | Display name for the verdict |
 | `emails` | string[] | required | Email addresses to match (case-insensitive) |
 | `expectedDkimDomains` | string[] | `[]` | DKIM signing domains to accept (matches exact or subdomain) |
-| `requireDkim` | boolean | `true` | Require DKIM pass + domain match for "verified" verdict |
 | `requireSpf` | boolean | `true` | Require SPF pass for "verified" verdict |
+
+`expectedDkimDomains` is what makes `verified` reachable: a DKIM signature from a domain you
+listed for that sender is the only evidence that binds a *mailbox* to a signer. An enrolled
+sender with no signing domains listed can never be verified, and `auth-check` says so in its
+warnings.
+
+There is deliberately no `requireDkim`. SPF authenticates an envelope *domain*, so on any
+shared domain (gmail.com, a company domain, a hosting provider) every user of it passes
+aligned SPF and would authenticate as every other. Waiving DKIM would leave nothing
+per-sender behind a `verified` verdict. `requireSpf: false` is still supported, because
+relaying breaks SPF while DKIM survives it, and DKIM already carried the mailbox claim.
+Existing config files carrying `requireDkim` still load; the key is ignored.
 
 **Verdicts:**
 

--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -64,7 +64,24 @@ because DMARC alignment authenticates a **domain**, never a mailbox.
 | Full address | The above, **and** the signing domain is one the operator listed for that specific sender |
 
 That last row is the only thing that carries a claim from "this domain sent it" to "this
-person sent it", and it requires an explicit operator assertion. Nothing infers it.
+person sent it", and it requires an explicit operator assertion. Nothing infers it. In
+particular an aligned SPF pass alone never gets there: SPF authenticates an envelope
+*domain*, so on any shared domain every user of it passes aligned SPF and would authenticate
+as every other.
+
+The three levels have to stay honest about the bottom of the scale, which is the part that
+is easy to get wrong:
+
+| Level | Means | An address gets it when |
+| --- | --- | --- |
+| `verified` | our boundary proved this exact mailbox | an expected signer signed it |
+| `asserted` | our boundary proved the domain, and nothing narrower | the domain authenticated but no operator assertion names the mailbox |
+| `mutable` | nobody vouched for it; it is a string the sender typed | authentication produced nothing |
+
+A `From` header on a message that failed authentication belongs in `mutable`. Scoring it
+`asserted` gives the address identifier a floor, which silently turns the lowest configurable
+minimum into no minimum at all, and every scenario below that says `drop` stops dropping.
+That was a real defect here, not a hypothetical.
 
 ### Provenance
 
@@ -87,21 +104,25 @@ not act or reply. `drop` means it never reaches the agent.
 | # | Scenario | Domain | Address | Outcome |
 | --- | --- | --- | --- | --- |
 | I1 | Operator, authenticated, enrolled | `verified` | `verified` | `dispatch` |
-| I2 | Operator's address, authentication failed | `asserted` | `asserted` | `drop` |
-| I3 | Operator's address, no trusted `authserv-id` configured | `asserted` | `asserted` | `drop`, with a config warning |
+| I2 | Operator's address, authentication failed | `mutable` | `mutable` | `drop` |
+| I3 | Operator's address, no trusted `authserv-id` configured | `mutable` | `mutable` | `drop`, with a config warning |
 | I4 | Enrolled non-operator (family, colleague) | `verified` | `verified` | `dispatch`, subject to sender policy |
+| I4a | Allowlisted, domain authenticated, **not** enrolled | `verified` | `asserted` | `dispatch` at the default minimum, `observe` under `verified` |
 | I5 | Authenticated stranger | `verified` | `asserted` | `observe` |
-| I6 | Unauthenticated stranger | `asserted` | `asserted` | `drop` |
-| I7 | Spoofed operator, forged `Authentication-Results` | `asserted` | `asserted` | `drop`, forged header never read |
-| I8 | Spoofed operator, valid SPF for the attacker's own domain | `asserted` | `asserted` | `drop`, unaligned pass does not count |
-| I9 | Reply inside a thread the agent started, from an addressed participant | inherits | inherits | `dispatch` (see E1) |
+| I6 | Unauthenticated stranger | `mutable` | `mutable` | `drop` |
+| I7 | Spoofed operator, forged `Authentication-Results` | `mutable` | `mutable` | `drop`, forged header never read |
+| I8 | Spoofed operator, valid SPF for the attacker's own domain | `mutable` | `mutable` | `drop`, unaligned pass does not count |
+| I9 | Reply inside a thread the agent started, from an addressed participant | inherits | inherits | `dispatch`, or `observe` if the address is under the minimum (see E1) |
 | I10 | Reply inside a thread the agent did not start | per I1-I6 | | as if new |
 | I10a | Claimed thread membership from a non-participant | per I1-I6 | | thread claim ignored, treated as new |
 | I11 | Bulk or marketing mail, authenticated | `verified` | `asserted` | `observe` |
-| I12 | Forwarded mail | usually `asserted` | `asserted` | `observe` at best |
+| I12 | Forwarded mail, alignment broken in transit | usually `mutable` | `mutable` | `drop` unless the forwarding address is enrolled |
 | I13 | Mail from the agent's own address | n/a | n/a | `drop`, loop guard |
 | I14 | Mail in Junk | n/a | n/a | not polled |
 | I15 | Mail with attachments | per above | | admission unchanged; attachments separately gated |
+
+Every row is executed against the real policy in `openclaw/src/mail-channel/scenarios.test.ts`,
+at both configured minimums, so this table and the code cannot drift apart again.
 
 ### The scenarios worth explaining
 
@@ -123,6 +144,23 @@ message; nothing proved this human should be able to direct an agent. Reading it
 Acting on it is not acceptable. A binary allow/deny model cannot express this, which is why
 the older "sender is in my address book" rule could not either: it never fired for
 strangers at all, so an authenticated stranger and a spoofed one were equally invisible.
+
+**I4a is the configuration everyone actually has.** Two lists must agree for an address to
+reach `verified`: `allowFrom` says who may drive the agent, and `trusted-senders.json` says
+what proves they are who they claim. Adding someone to the first and forgetting the second
+is the normal state of a half-configured install, and it is not an attack.
+
+So a grant that fails to apply must leave the sender exactly where an ungranted one lands,
+never below it. An allowlisted sender whose mailbox is not enrolled is the I5 case, an
+authenticated stranger, and is treated as one. The earlier design dropped them instead,
+which meant adding an address to `allowFrom` *reduced* what the channel did with their mail:
+a silent inversion landing precisely on the addresses the operator cared enough to
+configure. The same reasoning applies to thread permission (I9).
+
+Under `minIdentifierAuthentication: "verified"` this is still a real restriction. The
+message is readable and not actionable, which is the honest answer, and the channel reports
+every `allowFrom` entry with no enrollment behind it when the account starts, so the gap is
+visible rather than inferred from an agent that reads mail and never answers.
 
 **I7 and I8 are the two live attacks.** Both were real defects in this codebase before the
 current design. I7 is a forged `Authentication-Results` header that a naive parser reads as
@@ -298,7 +336,11 @@ what the agent is even allowed to see.
 - **Thread membership asserted by the sender.** `References` and `In-Reply-To` are claims,
   not credentials. Membership is checked against what the agent recorded sending.
 - **Authenticating a mailbox from a domain proof.** Requires an explicit per-sender
-  assertion; nothing derives it.
+  assertion; nothing derives it. There is deliberately no way to reach `verified` on an
+  aligned SPF pass alone, because on a shared domain every user of it passes aligned SPF and
+  would authenticate as every other.
+- **A grant that lowers admission.** Being on `allowFrom`, or inside a thread the agent
+  started, can only ever admit a sender further than they would get without it (I4a, I9).
 
 ## Configuration summary
 
@@ -306,9 +348,23 @@ what the agent is even allowed to see.
 | --- | --- | --- |
 | Trusted `authserv-id`, per account | Which authentication results are believed | none, fails closed |
 | Per-sender expected signing domains | Whether an address can reach `verified` | none, so no address is verified |
-| Minimum identifier strength | The bar for admission | `asserted`, matching existing behavior |
+| Minimum identifier strength | The bar for admission | `asserted`: the sender's domain must have authenticated |
 | Egress recipient allowlist | Who the agent may originate mail to | empty, default-deny |
 | Attachment allowed roots | Outbound attachments | empty, default-deny |
+
+The two minimums are different postures, not strictness dials on the same one:
+
+- **`asserted`** requires the transport to have proved the sender's *domain*. It admits an
+  allowlisted sender whose mailbox is not separately enrolled, and rejects every message
+  that authenticated nothing. This is the useful default.
+- **`verified`** additionally requires an operator assertion binding that mailbox to its
+  signers. It is the right posture once enrollment is complete, and until then it leaves
+  allowlisted senders readable but not actioned (I4a).
+
+`asserted` is a real bar only because an unauthenticated `From` address scores `mutable`.
+If it scored `asserted`, this row would be decorative and I2, I7, and I8 would all dispatch.
+The channel reports any `allowFrom` entry with no enrollment behind it at startup, so the
+gap between the two files is visible rather than inferred.
 
 Every default is closed. An install that configures nothing reads nothing and sends nothing,
 which is the correct resting state for a system whose failure mode is an agent acting on a

--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -220,15 +220,43 @@ narrow exception to it.
 
 So the claim is checked against the agent's own record, on both ends:
 
-1. The claimed parent must be a `Message-ID` **the agent itself generated**. A thread root
-   the agent never sent is not an agent-originated thread, whatever the headers say.
-2. The sender must be an address **the agent actually addressed** in that thread. Forging
+1. The claimed parent must be a `Message-ID` **the agent recorded** for that thread.
+2. The sender must be an address **the agent actually addressed** in it. Forging
    `In-Reply-To` gains nothing unless you were already a participant, and a participant
    already had permission.
 
-Both conditions come from state the agent wrote down when it sent the message. Neither is
-read from the inbound message. That is the same discipline the rest of this document applies
-to authentication: the evidence must come from a side the sender does not control.
+Both come from state the agent wrote down when it sent. Neither is read from the inbound
+message.
+
+### Two kinds of anchor, and why the weaker one is still sound
+
+Condition 1 would ideally match only Message-IDs the agent *generated*: unguessable, and
+absent from inbound mail until the agent sends. `mail-cli smtp-send` mints its own and
+returns it, so that anchor is available on that path. Mail.app does not — it assigns a
+Message-ID internally and reports nothing back — so a reply sent through `mail-cli reply`
+can only record the **inbound** Message-ID it was replying to.
+
+Inbound anchors are not secret. The original sender knows one, and so does anyone Cc'd or
+forwarded a copy. Recording them anyway is safe, but the reason is worth stating plainly
+rather than glossing:
+
+> An anchor selects a thread. It does not grant entry to one.
+
+Knowing an anchor buys an attacker nothing on its own, because condition 2 still requires
+them to be an address the agent addressed, and admission independently requires that address
+to meet `minIdentifierAuthentication` — thread permission waives the allowlist, never
+authentication (I9). To use a stolen anchor you must authenticate as a participant, at which
+point you are that participant.
+
+The two are kept as separate fields and the decision reports which one matched, so an audit
+can tell a thread proven by the agent's own Message-ID from one resolved through an anchor
+the sender could also have known. Moving a deployment to `smtp-send` upgrades its threads to
+the strong anchor with no policy change.
+
+A consequence worth knowing: a correspondent whose client sets `In-Reply-To` but writes no
+`References` chain names only the agent's own reply, which the Mail.app path never learned.
+That reply is denied. Full `References` chains are near-universal, but this is a real
+false-negative and the reason the strong anchor is worth having.
 
 Two further properties the rule must preserve:
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -40,6 +40,59 @@ Requires macOS 13+ and Swift 5.9+ (Xcode 15+).
 | `configDir` | Override the PIM config root (default `~/.config/apple-pim/`). |
 | `mailAttachmentsConfig` | Path to the mail attachment policy JSON. |
 
+### Apple Mail channel
+
+The plugin also registers an inbound mail **channel** (`apple-mail`). It polls the local
+Mail.app store, authenticates each sender, and admits messages by authentication strength.
+It is inert until `channels.apple-mail` exists in `openclaw.json`.
+
+```jsonc
+{
+  "channels": {
+    "apple-mail": {
+      "dmPolicy": "allowlist",
+      // Who may drive the agent.
+      "allowFrom": ["omar@shahine.com", "lora@shahine.com"],
+      // Minimum strength an identifier needs before it authorizes a sender.
+      // "asserted" is the compatible default; "verified" is the strict posture and
+      // requires an expectedDkimDomains entry for each address below.
+      "minIdentifierAuthentication": "verified",
+      // Carries expectedDkimDomains (address -> legitimate signing domains) and
+      // trustedAuthservIds (which Authentication-Results headers are believed).
+      "trustedSendersPath": "~/.config/lobster/trusted-senders.json",
+      // Addresses the agent sends as. Required: this is the inbound and outbound loop guard.
+      "selfAddresses": ["lobster@example.com"],
+      // Always-permitted reply recipients.
+      "operatorAddresses": ["omar@shahine.com"],
+      // Recipients the agent may originate mail to. Egress is default-deny without this.
+      "egressAllowlist": [],
+      // Not always INBOX: mail is often archived on arrival.
+      "mailbox": "INBOX",
+      "pollIntervalSeconds": 60
+    }
+  }
+}
+```
+
+Two lists, two jobs, and they are deliberately not the same file:
+
+- **`allowFrom`** answers *who may drive the agent*. Policy.
+- **`trustedSendersPath`** answers *what proves they are who they claim*. Only addresses with
+  an `expectedDkimDomains` entry can ever reach `verified`, because that entry is the
+  operator assertion binding an address to its legitimate signers. DMARC alignment proves a
+  **domain**, never a mailbox.
+
+They will list overlapping addresses. That duplication is intended, but it is a drift risk
+worth knowing about: adding someone to `allowFrom` without enrolling them caps them at
+`asserted`, so under `minIdentifierAuthentication: "verified"` they are silently not admitted.
+
+Scenario-by-scenario behavior, inbound and outbound, is in
+[`docs/mail-channel-scenarios.md`](../docs/mail-channel-scenarios.md).
+
+**Reading does not need Mail.app; replying does.** Polling and authentication read the
+Envelope Index and the `.emlx` files directly, so they work with Mail.app closed. `reply`
+goes through Apple Events and launches Mail.app on demand.
+
 ### Mail attachment safety
 
 Mail send/reply attachments are **default-denied**. To allow them, point

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -102,8 +102,11 @@ Scenario-by-scenario behavior, inbound and outbound, is in
 [`docs/mail-channel-scenarios.md`](../docs/mail-channel-scenarios.md).
 
 **Reading does not need Mail.app; replying does.** Polling and authentication read the
-Envelope Index and the `.emlx` files directly, so they work with Mail.app closed. `reply`
-goes through Apple Events and launches Mail.app on demand.
+Envelope Index and the `.emlx` files directly, so they work with Mail.app closed, but the
+process needs **Full Disk Access** to read them at all. `reply` goes through Apple Events,
+needs **Automation** access to Mail.app, and launches Mail.app on demand. Without those
+permissions the channel does not fall back to a degraded mode: polls and replies simply
+fail.
 
 ### Mail attachment safety
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -54,8 +54,9 @@ It is inert until `channels.apple-mail` exists in `openclaw.json`.
       // Who may drive the agent.
       "allowFrom": ["omar@shahine.com", "lora@shahine.com"],
       // Minimum strength an identifier needs before it authorizes a sender.
-      // "asserted" is the compatible default; "verified" is the strict posture and
-      // requires an expectedDkimDomains entry for each address below.
+      // "asserted" (default) requires the sender's domain to have authenticated.
+      // "verified" additionally requires an expectedDkimDomains entry for each address
+      // below; until one exists, that sender is readable but never actioned.
       "minIdentifierAuthentication": "verified",
       // Carries expectedDkimDomains (address -> legitimate signing domains) and
       // trustedAuthservIds (which Authentication-Results headers are believed).
@@ -82,9 +83,20 @@ Two lists, two jobs, and they are deliberately not the same file:
   operator assertion binding an address to its legitimate signers. DMARC alignment proves a
   **domain**, never a mailbox.
 
-They will list overlapping addresses. That duplication is intended, but it is a drift risk
-worth knowing about: adding someone to `allowFrom` without enrolling them caps them at
-`asserted`, so under `minIdentifierAuthentication: "verified"` they are silently not admitted.
+They will list overlapping addresses. That duplication is intended, and the drift between
+them is checked rather than merely documented: adding someone to `allowFrom` without
+enrolling them caps that address at `asserted`, so under `minIdentifierAuthentication:
+"verified"` their mail is readable but never actioned. The channel reports every such entry
+at startup:
+
+```
+apple-mail [allowlisted_not_enrolled]: lora@shahine.com is in channels.apple-mail.allowFrom
+but has no expectedDkimDomains entry in ~/.config/lobster/trusted-senders.json. ...
+```
+
+It also warns when `selfAddresses` is empty (the loop guard cannot fire), when no
+`trustedAuthservIds` covers the account (nothing authenticates, everything drops), and when
+an enrolled sender names no signing domains (that address can never reach `verified`).
 
 Scenario-by-scenario behavior, inbound and outbound, is in
 [`docs/mail-channel-scenarios.md`](../docs/mail-channel-scenarios.md).

--- a/openclaw/skills/apple-pim/SKILL.md
+++ b/openclaw/skills/apple-pim/SKILL.md
@@ -123,7 +123,6 @@ The `auth_check` action verifies sender identity by parsing Authentication-Resul
       "name": "Alice",
       "emails": ["alice@example.com"],
       "expectedDkimDomains": ["example.com"],
-      "requireDkim": true,
       "requireSpf": true
     }
   ]

--- a/openclaw/src/mail-auth/strength.test.ts
+++ b/openclaw/src/mail-auth/strength.test.ts
@@ -62,13 +62,13 @@ describe("mailAuthToIdentifierStrengths", () => {
       warnings: ["No trustedAuthservIds configured for account key 'iCloud'"],
     });
     assert.deepEqual(mailAuthToIdentifierStrengths(forged), {
-      address: "asserted",
-      domain: "asserted",
+      address: "mutable",
+      domain: "mutable",
       displayName: "mutable",
     });
   });
 
-  it("an unaligned SPF pass does not verify the domain", () => {
+  it("an unaligned SPF pass authenticates nothing about this sender", () => {
     const unaligned = result({
       verdict: "suspicious",
       checks: {
@@ -76,8 +76,8 @@ describe("mailAuthToIdentifierStrengths", () => {
         spf: { result: "pass", mailFrom: "bounce@attacker.example", aligned: false, match: false },
       },
     });
-    assert.equal(mailAuthToIdentifierStrengths(unaligned).domain, "asserted");
-    assert.equal(mailAuthToIdentifierStrengths(unaligned).address, "asserted");
+    assert.equal(mailAuthToIdentifierStrengths(unaligned).domain, "mutable");
+    assert.equal(mailAuthToIdentifierStrengths(unaligned).address, "mutable");
   });
 
   // A DKIM pass authenticates header.d, not the From domain. An unaligned signature means
@@ -91,8 +91,8 @@ describe("mailAuthToIdentifierStrengths", () => {
       },
     });
     assert.deepEqual(mailAuthToIdentifierStrengths(unalignedSigner), {
-      address: "asserted",
-      domain: "asserted",
+      address: "mutable",
+      domain: "mutable",
       displayName: "mutable",
     });
   });
@@ -145,7 +145,7 @@ describe("mailAuthToIdentifierStrengths", () => {
     assert.equal(strengths.domain, "verified");
   });
 
-  it("keeps an unauthenticated stranger fully asserted", () => {
+  it("keeps an unauthenticated stranger fully mutable", () => {
     const stranger = result({
       verdict: "untrusted",
       sender: "spoofed@example.com",
@@ -155,18 +155,54 @@ describe("mailAuthToIdentifierStrengths", () => {
       },
     });
     assert.deepEqual(mailAuthToIdentifierStrengths(stranger), {
-      address: "asserted",
-      domain: "asserted",
+      address: "mutable",
+      domain: "mutable",
       displayName: "mutable",
     });
   });
 
   it("treats missing checks as unproven rather than absent-therefore-fine", () => {
     assert.deepEqual(mailAuthToIdentifierStrengths({ verdict: "suspicious" }), {
-      address: "asserted",
-      domain: "asserted",
+      address: "mutable",
+      domain: "mutable",
       displayName: "mutable",
     });
+  });
+
+  // Mailbox providers sign with their own domain, so the operator's expectedDkimDomains
+  // entry routinely names a signer that does not align with the sender's domain. That
+  // assertion is narrower than alignment, so it has to carry the domain claim too;
+  // otherwise a correctly enrolled sender would come back verified-address / mutable-domain,
+  // which `weakest()` would then collapse back to mutable.
+  it("carries the domain claim when the operator named an unaligned expected signer", () => {
+    const providerSigned = result({
+      verdict: "verified",
+      sender: "omar@shahine.com",
+      checks: {
+        dkim: { result: "pass", signingDomain: "fastmail.com", match: true },
+        spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+      },
+    });
+    assert.deepEqual(mailAuthToIdentifierStrengths(providerSigned), {
+      address: "verified",
+      domain: "verified",
+      displayName: "mutable",
+    });
+  });
+
+  // The bug this mapping exists to prevent. `address` used to have a floor of `asserted`,
+  // so `mutable` was unreachable for it and the default `asserted` minimum was not a bar.
+  it("reaches mutable on the address, so the default minimum is a real bar", () => {
+    const unauthenticated: MailAuthCheckResult[] = [
+      { verdict: "unknown", sender: "omar@shahine.com" },
+      { verdict: "suspicious", sender: "omar@shahine.com" },
+      { verdict: "untrusted", sender: "omar@shahine.com" },
+    ];
+    for (const r of unauthenticated) {
+      const strengths = mailAuthToIdentifierStrengths(r);
+      assert.equal(strengths.address, "mutable", `verdict ${r.verdict}`);
+      assert.equal(meetsMinimum(strengths.address, "asserted"), false, `verdict ${r.verdict}`);
+    }
   });
 });
 
@@ -183,8 +219,32 @@ describe("policy composition", () => {
     assert.equal(meetsMinimum(weakest("verified", subject), "verified"), true);
   });
 
-  it("today's default minimum admits anything non-mutable, preserving current behavior", () => {
-    const subject = mailAuthToIdentifierStrengths(result({ verdict: "suspicious" })).address;
-    assert.equal(meetsMinimum(weakest("verified", subject), "asserted"), true);
+  // The default minimum is `asserted`, and it has to reject a message that authenticated
+  // nothing even when the allowlist entry itself is a fully verified address.
+  it("the default minimum rejects a message that proved nothing, however strong the entry", () => {
+    const subject = mailAuthToIdentifierStrengths(
+      result({
+        verdict: "suspicious",
+        checks: { dkim: { result: "fail" }, spf: { result: "fail", match: false } },
+      }),
+    ).address;
+    assert.equal(meetsMinimum(weakest("verified", subject), "asserted"), false);
+  });
+
+  // I5: the domain authenticated but no operator assertion binds the mailbox. Readable at
+  // the default minimum, and still short of the strict posture.
+  it("an authenticated stranger clears asserted but not verified", () => {
+    const stranger = mailAuthToIdentifierStrengths(
+      result({
+        verdict: "untrusted",
+        sender: "noreply@email.apple.com",
+        checks: {
+          dkim: { result: "pass", signingDomain: "email.apple.com", match: false },
+          spf: { result: "pass", mailFrom: "bounce@email.apple.com", aligned: true, match: true },
+        },
+      }),
+    ).address;
+    assert.equal(meetsMinimum(stranger, "asserted"), true);
+    assert.equal(meetsMinimum(stranger, "verified"), false);
   });
 });

--- a/openclaw/src/mail-auth/strength.ts
+++ b/openclaw/src/mail-auth/strength.ts
@@ -58,7 +58,7 @@ export type MailAuthCheckResult = {
 export type MailIdentifierStrengths = {
   /** Full sender address. Needs an operator assertion binding address to signing domain. */
   address: IdentifierAuthentication;
-  /** Sender domain. Needs only a passing check from a trusted boundary. */
+  /** Sender domain. Needs only a passing *aligned* check from a trusted boundary. */
   domain: IdentifierAuthentication;
   /** Display name. Sender-chosen, so never above `mutable`. */
   displayName: IdentifierAuthentication;
@@ -67,7 +67,8 @@ export type MailIdentifierStrengths = {
 /**
  * `unknown` means auth-check could not establish provenance at all: no trusted
  * authserv-id configured for the account, or no Authentication-Results from one. Nothing
- * in the message may be promoted, because the only evidence available is sender-writable.
+ * in the message may be promoted, because the only evidence available is sender-writable,
+ * which is the definition of `mutable`.
  */
 function provenanceEstablished(result: MailAuthCheckResult): boolean {
   return result.verdict !== "unknown";
@@ -102,10 +103,17 @@ function domainsAlign(a: string | undefined, b: string | undefined): boolean {
  * The address and the domain are deliberately scored differently, which is the whole
  * reason RFC 0027 is per-identifier rather than one per-message trust score:
  *
- * - A passing DKIM signature, or an aligned SPF pass, proves something about the *domain*.
- * - Only a DKIM signature from a domain the operator listed in that sender's
- *   `expectedDkimDomains` says anything about the *mailbox*, which is what auth-check's
- *   own `verified` verdict already requires.
+ * - An *aligned* passing DKIM signature, or an aligned SPF pass, proves the *domain*.
+ * - Only auth-check's `verified` verdict, which requires a DKIM signature from a domain the
+ *   operator listed in that sender's `expectedDkimDomains`, says anything about the
+ *   *mailbox*.
+ *
+ * A `From` address with neither behind it scores `mutable`: a string the sender typed, with
+ * no evidence from our side of the boundary. Scoring it `asserted` was the original defect
+ * in this module. `asserted` has to mean "a trusted boundary stamped something about this",
+ * because otherwise the address identifier has a floor of `asserted`, the default
+ * `asserted` minimum is not a bar at all, and every allowlisted address is admitted on the
+ * strength of its own `From` header. That is the I2/I7/I8 bypass in the scenario doc.
  */
 export function mailAuthToIdentifierStrengths(
   result: MailAuthCheckResult,
@@ -113,7 +121,7 @@ export function mailAuthToIdentifierStrengths(
   const displayName: IdentifierAuthentication = "mutable";
 
   if (!provenanceEstablished(result)) {
-    return { address: "asserted", domain: "asserted", displayName };
+    return { address: "mutable", domain: "mutable", displayName };
   }
 
   // A DKIM pass authenticates the *signing* domain (header.d), which is not automatically
@@ -124,14 +132,24 @@ export function mailAuthToIdentifierStrengths(
     dkimPassed && domainsAlign(result.checks?.dkim?.signingDomain, senderDomain(result.sender));
   // `match` on spf already folds in alignment; `aligned` is kept for diagnostics.
   const spfPassedAligned = result.checks?.spf?.match === true;
+  const domainAuthenticated = dkimAligned || spfPassedAligned;
 
+  // auth-check returns `verified` only when a DKIM signature matched the sender's configured
+  // expectedDkimDomains. That operator assertion is what carries the claim from domain to
+  // mailbox; without it the address can be no stronger than its domain.
+  const operatorAssertedMailbox = result.verdict === "verified";
+
+  const address: IdentifierAuthentication = operatorAssertedMailbox
+    ? "verified"
+    : domainAuthenticated
+      ? "asserted"
+      : "mutable";
+
+  // An expected signer need not align: mailbox providers routinely sign with their own
+  // domain (fastmail.com for a shahine.com address). Naming that signer for that sender is
+  // a narrower operator statement than alignment, so it carries the domain claim as well.
   const domain: IdentifierAuthentication =
-    dkimAligned || spfPassedAligned ? "verified" : "asserted";
-
-  // auth-check only returns `verified` when a DKIM signature matched the sender's
-  // configured expectedDkimDomains (and SPF, unless that sender sets requireSpf=false).
-  // That operator assertion is what carries the claim from domain to mailbox.
-  const address: IdentifierAuthentication = result.verdict === "verified" ? "verified" : "asserted";
+    domainAuthenticated || operatorAssertedMailbox ? "verified" : "mutable";
 
   return { address, domain, displayName };
 }

--- a/openclaw/src/mail-channel/config-check.test.ts
+++ b/openclaw/src/mail-channel/config-check.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { checkChannelConfig, type ConfigCheckInput } from "./config-check.ts";
+
+function input(overrides: Partial<ConfigCheckInput> = {}): ConfigCheckInput {
+  return {
+    allowFrom: ["omar@shahine.com"],
+    selfAddresses: ["lobster@example.com"],
+    minIdentifierAuthentication: "verified",
+    trustedSendersPath: "~/.config/lobster/trusted-senders.json",
+    trustedSenders: [
+      { name: "Omar", emails: ["omar@shahine.com"], expectedDkimDomains: ["shahine.com"] },
+    ],
+    trustedAuthservIds: { "*": ["mx.icloud.com"] },
+    ...overrides,
+  };
+}
+
+const codes = (i: ConfigCheckInput) => checkChannelConfig(i).map((f) => f.code);
+
+describe("checkChannelConfig", () => {
+  it("says nothing when both files agree", () => {
+    assert.deepEqual(checkChannelConfig(input()), []);
+  });
+
+  it("reports an empty selfAddresses, because the loop guard cannot fire without it", () => {
+    assert.ok(codes(input({ selfAddresses: [] })).includes("loop_guard_disabled"));
+  });
+
+  // The whole reason this module exists: the strict posture makes a missing enrollment
+  // change behavior, and nothing else in the system says so.
+  it("reports an allowFrom entry with no enrollment behind it", () => {
+    const found = checkChannelConfig(input({ allowFrom: ["omar@shahine.com", "lora@shahine.com"] }));
+    assert.deepEqual(
+      found.map((f) => f.code),
+      ["allowlisted_not_enrolled"],
+    );
+    assert.match(found[0]!.message, /lora@shahine\.com/);
+    assert.match(found[0]!.message, /readable\s+but never actioned/);
+  });
+
+  it("reports an enrollment that names no signers, which can never verify", () => {
+    const found = codes(
+      input({
+        allowFrom: [],
+        trustedSenders: [{ name: "Omar", emails: ["omar@shahine.com"], expectedDkimDomains: [] }],
+      }),
+    );
+    assert.deepEqual(found, ["enrolled_without_expected_signers"]);
+  });
+
+  it("treats an enrollment with only blank signers as naming none", () => {
+    const found = codes(
+      input({
+        trustedSenders: [
+          { name: "Omar", emails: ["omar@shahine.com"], expectedDkimDomains: ["  "] },
+        ],
+      }),
+    );
+    assert.ok(found.includes("enrolled_without_expected_signers"));
+    // ...and the address is therefore still uncovered.
+    assert.ok(found.includes("allowlisted_not_enrolled"));
+  });
+
+  it("matches allowFrom against enrollment case-insensitively", () => {
+    assert.deepEqual(checkChannelConfig(input({ allowFrom: ["Omar@Shahine.COM"] })), []);
+  });
+
+  it("reports a missing authserv-id pin, which drops everything", () => {
+    assert.ok(codes(input({ trustedAuthservIds: {} })).includes("no_trusted_authserv_id"));
+    assert.ok(codes(input({ trustedAuthservIds: undefined })).includes("no_trusted_authserv_id"));
+  });
+
+  // mail-cli keys the set off the message's own account, so any populated key counts.
+  // Warning on a name mismatch here would fire on working installs: real files key by
+  // Mail.app display name *and* by account UUID, and startup cannot know which will hit.
+  it("accepts any populated authserv-id key, wildcard or not", () => {
+    const maps: Record<string, readonly string[]>[] = [
+      { "*": ["mx.icloud.com"] },
+      { iCloud: ["mx.icloud.com"] },
+      { "168231BA-20A5-4B91-B54D-8D9906C76D25": ["mx.icloud.com"] },
+      { Fastmail: ["mx.fastmail.com"] },
+    ];
+    for (const map of maps) {
+      assert.deepEqual(checkChannelConfig(input({ trustedAuthservIds: map })), [], JSON.stringify(map));
+    }
+  });
+
+  it("treats a map of only blank ids as unconfigured", () => {
+    assert.ok(codes(input({ trustedAuthservIds: { iCloud: ["  "] } })).includes("no_trusted_authserv_id"));
+  });
+
+  // An unreadable file means nothing authenticates at all, which subsumes every enrollment
+  // finding below it. Reporting one line beats reporting one per allowlist entry.
+  it("stops at an unreadable trusted-senders file", () => {
+    assert.deepEqual(codes(input({ trustedSenders: undefined, allowFrom: ["a@b.com", "c@d.com"] })), [
+      "trusted_senders_unreadable",
+    ]);
+  });
+
+  // At the default minimum an authenticated domain is enough for an allowlisted sender, so
+  // the enrollment gap changes nothing and reporting it would be noise.
+  it("stays quiet about enrollment gaps at the default minimum", () => {
+    const found = codes(
+      input({ minIdentifierAuthentication: "asserted", allowFrom: ["nobody@example.com"] }),
+    );
+    assert.deepEqual(found, []);
+  });
+
+  it("still reports the loop guard and authserv-id pin at the default minimum", () => {
+    const found = codes(
+      input({ minIdentifierAuthentication: "asserted", selfAddresses: [], trustedAuthservIds: {} }),
+    );
+    assert.deepEqual(found, ["loop_guard_disabled", "no_trusted_authserv_id"]);
+  });
+});

--- a/openclaw/src/mail-channel/config-check.ts
+++ b/openclaw/src/mail-channel/config-check.ts
@@ -1,0 +1,143 @@
+/**
+ * Startup configuration checks for the Apple Mail channel.
+ *
+ * Every control here fails closed, which is the right direction and the worst one to debug:
+ * a control that silently does not apply looks exactly like one that passes. The specific
+ * trap is that admission needs two files to agree. `allowFrom` in `openclaw.json` says who
+ * may drive the agent; `trusted-senders.json` says what proves they are who they claim.
+ * Configure the first and forget the second and, under the strict posture, that sender is
+ * readable but never actionable, with nothing in the logs pointing at the missing half.
+ *
+ * So these run once at account start and say it out loud. Pure, so the rules are testable
+ * without a mailbox; the caller supplies the parsed file.
+ */
+
+import type { IdentifierAuthentication } from "../mail-auth/strength.ts";
+
+export type ConfigFinding = {
+  /** Stable code, so a caller can suppress one check without pattern-matching prose. */
+  code:
+    | "loop_guard_disabled"
+    | "trusted_senders_unreadable"
+    | "no_trusted_authserv_id"
+    | "allowlisted_not_enrolled"
+    | "enrolled_without_expected_signers";
+  message: string;
+};
+
+/** One `trustedSenders` entry, narrowed to what these checks read. */
+export type TrustedSenderEntry = {
+  name?: string;
+  emails?: readonly string[];
+  expectedDkimDomains?: readonly string[];
+};
+
+export type ConfigCheckInput = {
+  allowFrom: readonly string[];
+  selfAddresses: readonly string[];
+  minIdentifierAuthentication: IdentifierAuthentication;
+  trustedSendersPath?: string;
+  /** Parsed `trustedSenders`, or undefined when the file could not be read or parsed. */
+  trustedSenders?: readonly TrustedSenderEntry[];
+  /** Parsed `trustedAuthservIds`, keyed by Mail.app account name, with `*` as the wildcard. */
+  trustedAuthservIds?: Readonly<Record<string, readonly string[]>>;
+};
+
+function normalize(values: readonly string[] | undefined): Set<string> {
+  return new Set((values ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean));
+}
+
+/**
+ * Returns everything wrong with this account's configuration, most severe first.
+ *
+ * Empty means the two files agree and the channel will behave the way the scenario doc
+ * describes.
+ */
+export function checkChannelConfig(input: ConfigCheckInput): ConfigFinding[] {
+  const findings: ConfigFinding[] = [];
+  const path = input.trustedSendersPath ?? "trusted-senders.json";
+
+  // I13. Without this the agent can answer its own mail, and the loop is only bounded by
+  // however long it takes someone to notice.
+  if (normalize(input.selfAddresses).size === 0) {
+    findings.push({
+      code: "loop_guard_disabled",
+      message:
+        "channels.apple-mail.selfAddresses is empty, so the loop guard cannot fire and the " +
+        "agent may process its own replies. Set it to every address this account sends as.",
+    });
+  }
+
+  if (!input.trustedSenders) {
+    findings.push({
+      code: "trusted_senders_unreadable",
+      message:
+        `${path} could not be read, so no sender can authenticate and every message will ` +
+        "be dropped. This is the fail-closed state, not a working install.",
+    });
+    return findings;
+  }
+
+  // I3. auth-check refuses to read Authentication-Results from an unpinned authserv-id,
+  // because a sender can write that header themselves.
+  //
+  // Scoped no further than "is anything configured". mail-cli picks the set from the
+  // *message's* own account (`msg.mailbox().account().name()`, or the account UUID when the
+  // display name does not resolve), so startup cannot know which key a future message will
+  // land on, and guessing from the channel's `account` option would warn about working
+  // installs. A diagnostic that cries wolf is worse than none.
+  const configuredIds = Object.values(input.trustedAuthservIds ?? {}).flatMap((ids) =>
+    (ids ?? []).filter((id) => id.trim().length > 0),
+  );
+  if (configuredIds.length === 0) {
+    findings.push({
+      code: "no_trusted_authserv_id",
+      message:
+        `${path} configures no trustedAuthservIds at all, so no Authentication-Results ` +
+        "header is believed and every message is dropped. Run `mail-cli auth-check` on a " +
+        "known-good message; it reports the authserv-ids observed, keyed by account name.",
+    });
+  }
+
+  // Only the strict posture turns a missing enrollment into a behavior change. At the
+  // default minimum an authenticated domain is enough to dispatch an allowlisted sender,
+  // so reporting the gap there would be noise about a control nothing is relying on.
+  if (input.minIdentifierAuthentication !== "verified") {
+    return findings;
+  }
+
+  const enrolledWithSigners = new Set<string>();
+  for (const sender of input.trustedSenders) {
+    const hasSigners = (sender.expectedDkimDomains ?? []).some((d) => d.trim().length > 0);
+    const emails = normalize(sender.emails);
+    if (hasSigners) {
+      for (const email of emails) {
+        enrolledWithSigners.add(email);
+      }
+      continue;
+    }
+    if (emails.size > 0) {
+      findings.push({
+        code: "enrolled_without_expected_signers",
+        message:
+          `${path} enrolls ${sender.name ?? [...emails].join(", ")} with no ` +
+          "expectedDkimDomains, so no signature can match and the address can never reach " +
+          "`verified`. Add the signing domain; `mail-cli auth-check` reports the observed one.",
+      });
+    }
+  }
+
+  for (const entry of normalize(input.allowFrom)) {
+    if (!enrolledWithSigners.has(entry)) {
+      findings.push({
+        code: "allowlisted_not_enrolled",
+        message:
+          `${entry} is in channels.apple-mail.allowFrom but has no expectedDkimDomains entry ` +
+          `in ${path}. Under minIdentifierAuthentication "verified" their mail is readable ` +
+          "but never actioned, because nothing binds that address to a signer.",
+      });
+    }
+  }
+
+  return findings;
+}

--- a/openclaw/src/mail-channel/dispatch.test.ts
+++ b/openclaw/src/mail-channel/dispatch.test.ts
@@ -156,3 +156,64 @@ describe("dispatchAdmittedMessage", () => {
     ]);
   });
 });
+
+// The thread rule is only as good as the record behind it, and the record must follow
+// delivery: writing it on permission would grant thread standing for a message that a
+// suppressed or empty reply never actually sent.
+describe("thread recording", () => {
+  it("records the thread after a reply is sent", async () => {
+    const recorded: unknown[] = [];
+    const { deps: d } = deps({
+      sendReply: async () => ({ sentMessageId: "<agent-1@lobster.example>" }),
+      recordThread: async (reply) => {
+        recorded.push(reply);
+      },
+    });
+    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    assert.deepEqual(recorded, [
+      {
+        inboundMessageId: "m1",
+        sentMessageId: "<agent-1@lobster.example>",
+        recipients: ["omar@shahine.com"],
+      },
+    ]);
+  });
+
+  it("records nothing when the reply was suppressed", async () => {
+    const recorded: unknown[] = [];
+    const { deps: d } = deps({
+      recordThread: async (reply) => {
+        recorded.push(reply);
+      },
+    });
+    await dispatchAdmittedMessage(classified("stranger@example.com", "observe"), d, OPTIONS);
+    assert.deepEqual(recorded, []);
+  });
+
+  it("records nothing when the model produced an empty reply", async () => {
+    const recorded: unknown[] = [];
+    const { deps: d } = deps({
+      dispatchReply: async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "   " });
+      },
+      recordThread: async (reply) => {
+        recorded.push(reply);
+      },
+    });
+    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    assert.deepEqual(recorded, []);
+  });
+
+  // Mail.app assigns its own Message-ID and reports nothing back, which is the common path.
+  it("still records the inbound anchor when the transport reports no id", async () => {
+    const recorded: { sentMessageId?: string }[] = [];
+    const { deps: d } = deps({
+      recordThread: async (reply) => {
+        recorded.push(reply);
+      },
+    });
+    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]?.sentMessageId, undefined);
+  });
+});

--- a/openclaw/src/mail-channel/dispatch.ts
+++ b/openclaw/src/mail-channel/dispatch.ts
@@ -19,7 +19,12 @@ export type ReplySender = (params: {
   messageId: string;
   to: string;
   body: string;
-}) => Promise<void> | void;
+  /**
+   * Message-ID the reply carried, when the transport reports one. `mail-cli smtp-send`
+   * mints and returns it; Mail.app assigns one internally and reports nothing, so this is
+   * optional rather than a lie.
+   */
+}) => Promise<{ sentMessageId?: string } | void> | { sentMessageId?: string } | void;
 
 /**
  * The reply pipeline, narrowed to what this module uses.
@@ -44,6 +49,18 @@ export type DispatchDeps = {
    */
   readBody?: (messageId: string) => Promise<string | undefined>;
   onSuppressed?: (params: { address: string; reason: string }) => void;
+  /**
+   * Records that the agent replied in this thread, which is what lets a later reply from
+   * this correspondent be permitted under the thread rule.
+   *
+   * Called only after a reply was actually sent. Recording on permission rather than on
+   * delivery would grant thread standing for a message that never left.
+   */
+  recordThread?: (reply: {
+    inboundMessageId: string;
+    sentMessageId?: string;
+    recipients: readonly string[];
+  }) => Promise<void> | void;
 };
 
 export type DispatchOptions = {
@@ -136,12 +153,19 @@ export async function dispatchAdmittedMessage(
         if (!text) {
           return;
         }
-        await deps.sendReply({
+        const sent = await deps.sendReply({
           messageId: message.message.messageId,
           to: message.address,
           body: text,
         });
         sentCount += 1;
+        // After delivery, never before: thread standing has to follow a message that
+        // actually left, or a suppressed reply would still widen permission.
+        await deps.recordThread?.({
+          inboundMessageId: message.message.messageId,
+          sentMessageId: sent?.sentMessageId,
+          recipients: [message.address],
+        });
       },
     },
   });

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -28,6 +28,7 @@ import {
   readTrustedSenders,
 } from "./runtime.ts";
 import { checkChannelConfig } from "./config-check.ts";
+import { ThreadRecords, type ThreadRecordStore } from "./thread-store.ts";
 import { dispatchAdmittedMessage } from "./dispatch.ts";
 import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 
@@ -181,6 +182,17 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
       trustedSendersPath: config.trustedSendersPath,
     });
 
+    // Threads the agent has replied in. Hydrated once; admission reads it per message, so it
+    // is held in memory rather than round-tripped to the store inside the poll loop.
+    const threads = new ThreadRecords(
+      state.openKeyedStore({
+        namespace: `${CHANNEL_ID}:threads`,
+        maxEntries: 64,
+      }) as ThreadRecordStore,
+      `${CHANNEL_ID}:${ctx.accountId}`,
+    );
+    await threads.hydrate();
+
     const minIdentifierAuthentication = config.minIdentifierAuthentication ?? "asserted";
     const allowFrom = (config.allowFrom ?? []).map((entry) => String(entry));
 
@@ -217,6 +229,18 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
                 readBody: createMailCliBodyReader({ account: config.account }),
                 onSuppressed: ({ address, reason }) =>
                   ctx.log?.info?.(`apple-mail: reply to ${address} suppressed (${reason})`),
+                // The reply has already been sent by this point, so a store failure must not
+                // surface as a failed dispatch. It fails closed instead: the thread goes
+                // unrecorded and a later answer is denied, which is worth a warning.
+                recordThread: async (reply) => {
+                  try {
+                    await threads.record(reply);
+                  } catch (error) {
+                    ctx.log?.warn?.(
+                      `apple-mail: reply sent but thread not recorded (${String(error)}); a later reply in this thread will not be permitted`,
+                    );
+                  }
+                },
               },
               {
                 cfg: ctx.cfg,
@@ -243,6 +267,11 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
           minIdentifierAuthentication,
           allowFrom,
           selfAddresses: config.selfAddresses ?? [],
+          // A live view, not a snapshot: a reply sent this cycle has to be visible to the
+          // next one, or the correspondent's answer arrives before the thread is recorded.
+          get threadRecords() {
+            return threads.all();
+          },
         },
       },
       store,

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -21,7 +21,13 @@ import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import type { ClassifiedMessage, PollCursor } from "./inbound.ts";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { runPollLoop, type CursorStore } from "./poll.ts";
-import { createMailCliBodyReader, createMailCliDeps, createMailCliSender } from "./runtime.ts";
+import {
+  createMailCliBodyReader,
+  createMailCliDeps,
+  createMailCliSender,
+  readTrustedSenders,
+} from "./runtime.ts";
+import { checkChannelConfig } from "./config-check.ts";
 import { dispatchAdmittedMessage } from "./dispatch.ts";
 import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 
@@ -175,6 +181,23 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
       trustedSendersPath: config.trustedSendersPath,
     });
 
+    const minIdentifierAuthentication = config.minIdentifierAuthentication ?? "asserted";
+    const allowFrom = (config.allowFrom ?? []).map((entry) => String(entry));
+
+    // Admission needs `openclaw.json` and `trusted-senders.json` to agree, and every way
+    // they can disagree fails closed and therefore silently. Say so at startup, once, rather
+    // than leaving the operator to infer it from an agent that reads mail and never answers.
+    const findings = checkChannelConfig({
+      allowFrom,
+      selfAddresses: config.selfAddresses ?? [],
+      minIdentifierAuthentication,
+      trustedSendersPath: config.trustedSendersPath,
+      ...(await readTrustedSenders(config.trustedSendersPath)),
+    });
+    for (const finding of findings) {
+      ctx.log?.warn?.(`apple-mail [${finding.code}]: ${finding.message}`);
+    }
+
 
     const loop = runPollLoop(
       {
@@ -217,8 +240,8 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
         cursorKey: `${CHANNEL_ID}:${ctx.accountId}`,
         intervalMs: (config.pollIntervalSeconds ?? DEFAULT_POLL_SECONDS) * 1000,
         classify: {
-          minIdentifierAuthentication: config.minIdentifierAuthentication ?? "asserted",
-          allowFrom: (config.allowFrom ?? []).map((entry) => String(entry)),
+          minIdentifierAuthentication,
+          allowFrom,
           selfAddresses: config.selfAddresses ?? [],
         },
       },

--- a/openclaw/src/mail-channel/policy.ts
+++ b/openclaw/src/mail-channel/policy.ts
@@ -69,10 +69,8 @@ export function decideIngress(input: IngressInput): IngressDecision {
   // decideThreadReply matches on the sender address, and an unauthenticated address is a
   // claim: anyone who learns a participant's address and an agent Message-ID could
   // otherwise spoof their way into a dispatch.
-  if (input.threadPermitted) {
-    return addressStrongEnough
-      ? { admission: "dispatch", reason: "thread_originated_by_agent" }
-      : { admission: "drop", reason: "identifier_authentication_too_weak" };
+  if (input.threadPermitted && addressStrongEnough) {
+    return { admission: "dispatch", reason: "thread_originated_by_agent" };
   }
 
   // I1, I4.
@@ -80,16 +78,30 @@ export function decideIngress(input: IngressInput): IngressDecision {
     return { admission: "dispatch", reason: "allowlisted_and_authenticated" };
   }
 
-  // I2. An allowlisted sender whose message did not authenticate is dropped, not escalated.
-  // The operator is not exempt: making an exception for the most valuable identity in the
-  // system would invert the model the rest of this file rests on.
-  if (input.allowlisted) {
-    return { admission: "drop", reason: "identifier_authentication_too_weak" };
+  // I5, I11, I4a. The transport proved a domain; nothing proved this human may direct an
+  // agent.
+  //
+  // Deliberately ahead of the allowlist rejection below. A grant that fails to apply has to
+  // leave the sender where they were, never below it: an allowlisted sender whose mailbox
+  // is not enrolled is the same authenticated-stranger case as I5, not a spoof, and
+  // dropping them here would mean adding someone to `allowFrom` *reduced* what the channel
+  // does with their mail. That inversion is silent, and it lands on exactly the addresses
+  // the operator cared enough to configure.
+  if (input.strengths.domain === "verified") {
+    return {
+      admission: "observe",
+      reason:
+        input.allowlisted || input.threadPermitted
+          ? "identifier_authentication_too_weak"
+          : "authenticated_but_not_allowlisted",
+    };
   }
 
-  // I5, I11. The transport proved a domain; nothing proved this human may direct an agent.
-  if (input.strengths.domain === "verified") {
-    return { admission: "observe", reason: "authenticated_but_not_allowlisted" };
+  // I2. An allowlisted sender whose message authenticated nothing is dropped, not escalated.
+  // The operator is not exempt: making an exception for the most valuable identity in the
+  // system would invert the model the rest of this file rests on.
+  if (input.allowlisted || input.threadPermitted) {
+    return { admission: "drop", reason: "identifier_authentication_too_weak" };
   }
 
   // I6, I7, I8.

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -11,10 +11,13 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { readFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import type { MailAuthCheckResult } from "../mail-auth/strength.ts";
 import type { InboundDeps, MailboxMessage, MessageThreadHeaders } from "./inbound.ts";
 import type { ReplySender } from "./dispatch.ts";
+import type { ConfigCheckInput } from "./config-check.ts";
 
 const run = promisify(execFile);
 
@@ -41,6 +44,40 @@ async function runJson<T>(options: MailCliOptions, args: string[]): Promise<T> {
     maxBuffer: 32 * 1024 * 1024,
   });
   return JSON.parse(stdout) as T;
+}
+
+/** Mirrors mail-cli's own default, so both sides read the same file when none is configured. */
+const DEFAULT_TRUSTED_SENDERS = "~/.config/apple-pim/trusted-senders.json";
+
+/** Expands a leading `~`, which mail-cli does natively and Node does not. */
+export function expandHome(input: string): string {
+  return input.startsWith("~/") ? path.join(os.homedir(), input.slice(2)) : input;
+}
+
+/**
+ * Reads `trusted-senders.json` for the startup configuration checks.
+ *
+ * Returns the pieces `checkChannelConfig` reads, leaving `trustedSenders` undefined when the
+ * file is missing or unparseable. That is not smoothed over: an absent file means nothing
+ * can authenticate, which is a finding rather than a default.
+ */
+export async function readTrustedSenders(
+  trustedSendersPath?: string,
+): Promise<Pick<ConfigCheckInput, "trustedSenders" | "trustedAuthservIds">> {
+  const resolved = expandHome(trustedSendersPath ?? DEFAULT_TRUSTED_SENDERS);
+  try {
+    const parsed = JSON.parse(await readFile(resolved, "utf8")) as {
+      trustedSenders?: ConfigCheckInput["trustedSenders"];
+      trustedAuthservIds?: ConfigCheckInput["trustedAuthservIds"];
+    };
+    return {
+      // A file whose `trustedSenders` is not an array is as unusable as a missing one.
+      trustedSenders: Array.isArray(parsed.trustedSenders) ? parsed.trustedSenders : undefined,
+      trustedAuthservIds: parsed.trustedAuthservIds,
+    };
+  } catch {
+    return { trustedSenders: undefined, trustedAuthservIds: undefined };
+  }
 }
 
 /** Builds the inbound dependency set backed by the real CLI. */

--- a/openclaw/src/mail-channel/scenarios.test.ts
+++ b/openclaw/src/mail-channel/scenarios.test.ts
@@ -1,0 +1,345 @@
+/**
+ * The ingress table from docs/mail-channel-scenarios.md, executed.
+ *
+ * The doc is the specification, and it drifted from the code once already: the scenario
+ * rows said `drop` for I2/I7/I8 while the documented default minimum (`asserted`) admitted
+ * every one of them, because the address identifier had a floor of `asserted` and so the
+ * default was not a bar at all. Nothing caught it, because the unit tests either fixed the
+ * minimum at `verified` or asserted the strengths without running them through admission.
+ *
+ * So each row runs the real `mail-cli auth-check` shape through the real strength mapping
+ * and the real policy, at **both** configured postures. A row that changes behavior in the
+ * code without changing here is a drift, and a row whose two postures disagree is a place
+ * the operator's choice of minimum actually matters, which is worth stating explicitly.
+ */
+
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  mailAuthToIdentifierStrengths,
+  type MailAuthCheckResult,
+  type MailIdentifierStrengths,
+} from "../mail-auth/strength.ts";
+import { decideIngress, type Admission } from "./policy.ts";
+
+const OPERATOR = "omar@shahine.com";
+
+type Row = {
+  id: string;
+  what: string;
+  auth: MailAuthCheckResult;
+  allowlisted?: boolean;
+  selfAddressed?: boolean;
+  threadPermitted?: boolean;
+  strengths: Pick<MailIdentifierStrengths, "address" | "domain">;
+  /** Admission at the default `asserted` minimum. */
+  atDefault: Admission;
+  /** Admission at the strict `verified` minimum. */
+  atStrict: Admission;
+};
+
+/** An Authentication-Results header from a trusted authserv-id, DKIM aligned and expected. */
+const GENUINE: MailAuthCheckResult["checks"] = {
+  dkim: { result: "pass", signingDomain: "shahine.com", match: true },
+  spf: { result: "pass", mailFrom: OPERATOR, aligned: true, match: true },
+};
+
+/** Aligned pass, but no expectedDkimDomains entry binds the mailbox to that signer. */
+function alignedButUnenrolled(domain: string): MailAuthCheckResult["checks"] {
+  return {
+    dkim: { result: "pass", signingDomain: domain, match: false },
+    spf: { result: "pass", mailFrom: `bounce@${domain}`, aligned: true, match: true },
+  };
+}
+
+const ROWS: Row[] = [
+  {
+    id: "I1",
+    what: "operator, authenticated, enrolled",
+    auth: { verdict: "verified", sender: OPERATOR, checks: GENUINE },
+    allowlisted: true,
+    strengths: { address: "verified", domain: "verified" },
+    atDefault: "dispatch",
+    atStrict: "dispatch",
+  },
+  {
+    id: "I2",
+    what: "operator's address, authentication failed",
+    auth: {
+      verdict: "suspicious",
+      sender: OPERATOR,
+      checks: { dkim: { result: "fail" }, spf: { result: "fail", match: false } },
+    },
+    allowlisted: true,
+    strengths: { address: "mutable", domain: "mutable" },
+    // The operator is not special. A failed authentication is dropped, not escalated.
+    atDefault: "drop",
+    atStrict: "drop",
+  },
+  {
+    id: "I3",
+    what: "operator's address, no trusted authserv-id configured",
+    // auth-check fails closed and returns no checks at all: every header is sender-writable.
+    auth: { verdict: "unknown", sender: OPERATOR },
+    allowlisted: true,
+    strengths: { address: "mutable", domain: "mutable" },
+    atDefault: "drop",
+    atStrict: "drop",
+  },
+  {
+    id: "I4",
+    what: "enrolled non-operator (family, colleague)",
+    auth: {
+      verdict: "verified",
+      sender: "lora@shahine.com",
+      checks: { ...GENUINE, spf: { result: "pass", mailFrom: "lora@shahine.com", match: true } },
+    },
+    allowlisted: true,
+    strengths: { address: "verified", domain: "verified" },
+    atDefault: "dispatch",
+    atStrict: "dispatch",
+  },
+  {
+    id: "I4a",
+    what: "allowlisted, domain authenticated, not enrolled in trusted-senders.json",
+    auth: {
+      verdict: "untrusted",
+      sender: "lora@shahine.com",
+      checks: alignedButUnenrolled("shahine.com"),
+    },
+    allowlisted: true,
+    strengths: { address: "asserted", domain: "verified" },
+    // The drift case: on `allowFrom` but with no expectedDkimDomains entry to bind the
+    // mailbox. Under the strict posture it lands exactly where I5 does, readable but not
+    // actionable, because it must never be admitted *less* than the same message would be
+    // without the allowlist entry.
+    atDefault: "dispatch",
+    atStrict: "observe",
+  },
+  {
+    id: "I5",
+    what: "authenticated stranger",
+    auth: {
+      verdict: "untrusted",
+      sender: "noreply@email.apple.com",
+      checks: alignedButUnenrolled("email.apple.com"),
+    },
+    strengths: { address: "asserted", domain: "verified" },
+    atDefault: "observe",
+    atStrict: "observe",
+  },
+  {
+    id: "I6",
+    what: "unauthenticated stranger",
+    auth: {
+      verdict: "untrusted",
+      sender: "stranger@example.com",
+      checks: { dkim: { result: "none" }, spf: { result: "fail", match: false } },
+    },
+    strengths: { address: "mutable", domain: "mutable" },
+    atDefault: "drop",
+    atStrict: "drop",
+  },
+  {
+    id: "I7",
+    what: "spoofed operator, forged Authentication-Results",
+    // The forged header carries an authserv-id we do not trust, so auth-check never reads
+    // it and reports no checks. The forgery buys the attacker nothing.
+    auth: { verdict: "suspicious", sender: OPERATOR },
+    allowlisted: true,
+    strengths: { address: "mutable", domain: "mutable" },
+    atDefault: "drop",
+    atStrict: "drop",
+  },
+  {
+    id: "I8",
+    what: "spoofed operator, valid SPF for the attacker's own domain",
+    auth: {
+      verdict: "suspicious",
+      sender: OPERATOR,
+      checks: {
+        dkim: { result: "none" },
+        // Passes for attacker.example, which is not the From domain. Unaligned proves nothing.
+        spf: { result: "pass", mailFrom: "bounce@attacker.example", aligned: false, match: false },
+      },
+    },
+    allowlisted: true,
+    strengths: { address: "mutable", domain: "mutable" },
+    atDefault: "drop",
+    atStrict: "drop",
+  },
+  {
+    id: "I9",
+    what: "reply inside a thread the agent started, from an addressed participant",
+    auth: {
+      verdict: "untrusted",
+      sender: "correspondent@example.com",
+      checks: alignedButUnenrolled("example.com"),
+    },
+    threadPermitted: true,
+    strengths: { address: "asserted", domain: "verified" },
+    // Thread permission waives the allowlist, never authentication. Under the strict
+    // posture a thread the agent itself started cannot be *acted on* unless the participant
+    // is separately enrolled; the reply is still readable, because the grant failing to
+    // apply must not put them below an ordinary authenticated stranger.
+    atDefault: "dispatch",
+    atStrict: "observe",
+  },
+  {
+    id: "I10a",
+    what: "claimed thread membership from a non-participant",
+    // decideThreadReply already rejected the claim, so it arrives as ordinary new mail.
+    auth: {
+      verdict: "untrusted",
+      sender: "stranger@example.com",
+      checks: { dkim: { result: "none" }, spf: { result: "none", match: false } },
+    },
+    threadPermitted: false,
+    strengths: { address: "mutable", domain: "mutable" },
+    atDefault: "drop",
+    atStrict: "drop",
+  },
+  {
+    id: "I11",
+    what: "bulk or marketing mail, authenticated",
+    auth: {
+      verdict: "untrusted",
+      sender: "news@marketing.example",
+      checks: alignedButUnenrolled("marketing.example"),
+    },
+    strengths: { address: "asserted", domain: "verified" },
+    atDefault: "observe",
+    atStrict: "observe",
+  },
+  {
+    id: "I12",
+    what: "forwarded mail, alignment broken in transit",
+    auth: {
+      verdict: "untrusted",
+      sender: OPERATOR,
+      checks: {
+        dkim: { result: "pass", signingDomain: "forwarder.example", match: false },
+        spf: { result: "fail", mailFrom: "bounce@forwarder.example", aligned: false, match: false },
+      },
+    },
+    strengths: { address: "mutable", domain: "mutable" },
+    atDefault: "drop",
+    atStrict: "drop",
+  },
+  {
+    id: "I13",
+    what: "mail from the agent's own address",
+    auth: { verdict: "verified", sender: "lobster@example.com", checks: GENUINE },
+    allowlisted: true,
+    selfAddressed: true,
+    strengths: { address: "verified", domain: "verified" },
+    // The loop guard runs before any grant, so even a perfectly authenticated message drops.
+    atDefault: "drop",
+    atStrict: "drop",
+  },
+];
+
+describe("scenario doc: ingress table", () => {
+  for (const row of ROWS) {
+    it(`${row.id}: ${row.what}`, () => {
+      const strengths = mailAuthToIdentifierStrengths(row.auth);
+      assert.equal(strengths.address, row.strengths.address, "address strength");
+      assert.equal(strengths.domain, row.strengths.domain, "domain strength");
+
+      const input = {
+        strengths,
+        senderAddress: row.auth.sender ?? "",
+        allowlisted: row.allowlisted ?? false,
+        selfAddressed: row.selfAddressed ?? false,
+        threadPermitted: row.threadPermitted ?? false,
+      };
+      assert.equal(
+        decideIngress({ ...input, minIdentifierAuthentication: "asserted" }).admission,
+        row.atDefault,
+        "at the default `asserted` minimum",
+      );
+      assert.equal(
+        decideIngress({ ...input, minIdentifierAuthentication: "verified" }).admission,
+        row.atStrict,
+        "at the strict `verified` minimum",
+      );
+    });
+  }
+});
+
+describe("scenario doc: invariants across the table", () => {
+  const RANK: Record<Admission, number> = { drop: 0, observe: 1, dispatch: 2 };
+
+  // The inversion that made `allowFrom` actively harmful: at the strict minimum an
+  // allowlisted-but-unenrolled sender dropped, while the identical message from a sender
+  // *not* on the allowlist was admitted to `observe`. Enrolling someone must never reduce
+  // what the channel does with their mail.
+  it("adding a sender to allowFrom never lowers their admission", () => {
+    for (const row of ROWS) {
+      if (row.selfAddressed) {
+        continue;
+      }
+      const strengths = mailAuthToIdentifierStrengths(row.auth);
+      for (const minimum of ["asserted", "verified"] as const) {
+        const base = {
+          strengths,
+          senderAddress: row.auth.sender ?? "",
+          selfAddressed: false,
+          threadPermitted: row.threadPermitted ?? false,
+          minIdentifierAuthentication: minimum,
+        };
+        const off = decideIngress({ ...base, allowlisted: false }).admission;
+        const on = decideIngress({ ...base, allowlisted: true }).admission;
+        assert.ok(
+          RANK[on] >= RANK[off],
+          `${row.id} at ${minimum}: allowlisted=${on} is weaker than allowlisted=false=${off}`,
+        );
+      }
+    }
+  });
+
+  // Same argument for the other grant. Thread permission is a grant, and a grant that
+  // cannot be exercised must leave the sender exactly where an ungranted one lands.
+  it("thread permission never lowers admission", () => {
+    for (const row of ROWS) {
+      if (row.selfAddressed) {
+        continue;
+      }
+      const strengths = mailAuthToIdentifierStrengths(row.auth);
+      for (const minimum of ["asserted", "verified"] as const) {
+        const base = {
+          strengths,
+          senderAddress: row.auth.sender ?? "",
+          selfAddressed: false,
+          allowlisted: row.allowlisted ?? false,
+          minIdentifierAuthentication: minimum,
+        };
+        const off = decideIngress({ ...base, threadPermitted: false }).admission;
+        const on = decideIngress({ ...base, threadPermitted: true }).admission;
+        assert.ok(
+          RANK[on] >= RANK[off],
+          `${row.id} at ${minimum}: threadPermitted=${on} is weaker than ungranted=${off}`,
+        );
+      }
+    }
+  });
+
+  // The strict posture may only ever be at least as closed as the default. If a row is
+  // admitted more freely under `verified`, the minimum is being read backwards somewhere.
+  it("the strict minimum is never more permissive than the default", () => {
+    for (const row of ROWS) {
+      assert.ok(
+        RANK[row.atStrict] <= RANK[row.atDefault],
+        `${row.id}: strict=${row.atStrict} is more permissive than default=${row.atDefault}`,
+      );
+    }
+  });
+
+  // A `From` header nobody vouched for must not clear the lowest configurable bar.
+  it("no unauthenticated row reaches dispatch at any minimum", () => {
+    for (const row of ROWS.filter((r) => r.strengths.domain === "mutable")) {
+      assert.equal(row.atDefault, "drop", `${row.id} at the default minimum`);
+      assert.equal(row.atStrict, "drop", `${row.id} at the strict minimum`);
+    }
+  });
+});

--- a/openclaw/src/mail-channel/thread-store.test.ts
+++ b/openclaw/src/mail-channel/thread-store.test.ts
@@ -1,0 +1,183 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { foldReply, MAX_THREADS, ThreadRecords, type ThreadRecordStore } from "./thread-store.ts";
+import { decideThreadReply, type AgentThreadRecord } from "./thread.ts";
+
+function fakeStore() {
+  const data = new Map<string, AgentThreadRecord[]>();
+  const store: ThreadRecordStore = {
+    lookup: async (key) => data.get(key),
+    register: async (key, value) => {
+      data.set(key, value);
+    },
+  };
+  return { store, data };
+}
+
+describe("foldReply", () => {
+  it("records the inbound anchor and the recipient", () => {
+    const [record] = foldReply([], {
+      inboundMessageId: "<m1@example.com>",
+      recipients: ["Omar@Shahine.com"],
+    });
+    assert.deepEqual(record?.inboundAnchorIds, ["m1@example.com"]);
+    assert.deepEqual(record?.addressedRecipients, ["omar@shahine.com"]);
+    // Mail.app reports no id, so there is nothing to claim here and it does not pretend.
+    assert.deepEqual(record?.sentMessageIds, []);
+  });
+
+  it("keeps the agent's own Message-ID when the transport reports one", () => {
+    const [record] = foldReply([], {
+      inboundMessageId: "m1@example.com",
+      sentMessageId: "<agent-1@lobster.example>",
+      recipients: ["omar@shahine.com"],
+    });
+    assert.deepEqual(record?.sentMessageIds, ["agent-1@lobster.example"]);
+  });
+
+  // Without this a long exchange writes one record per turn and evicts every other thread.
+  it("merges a second reply in the same thread instead of appending", () => {
+    let records = foldReply([], {
+      inboundMessageId: "m1@example.com",
+      sentMessageId: "agent-1@lobster.example",
+      recipients: ["omar@shahine.com"],
+    });
+    records = foldReply(records, {
+      inboundMessageId: "m1@example.com",
+      sentMessageId: "agent-2@lobster.example",
+      recipients: ["lora@shahine.com"],
+    });
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0]?.sentMessageIds, [
+      "agent-1@lobster.example",
+      "agent-2@lobster.example",
+    ]);
+    assert.deepEqual(records[0]?.addressedRecipients, ["omar@shahine.com", "lora@shahine.com"]);
+  });
+
+  it("recognizes the same thread through the agent's own id when the anchor differs", () => {
+    const first = foldReply([], {
+      inboundMessageId: "m1@example.com",
+      sentMessageId: "agent-1@lobster.example",
+      recipients: ["omar@shahine.com"],
+    });
+    // Next turn: a new inbound message, but the same agent id already on record.
+    const merged = foldReply(first, {
+      inboundMessageId: "m2@example.com",
+      sentMessageId: "agent-1@lobster.example",
+      recipients: ["omar@shahine.com"],
+    });
+    assert.equal(merged.length, 1);
+    assert.deepEqual(merged[0]?.inboundAnchorIds, ["m1@example.com", "m2@example.com"]);
+  });
+
+  it("starts a separate record for an unrelated thread", () => {
+    const records = foldReply(
+      foldReply([], { inboundMessageId: "m1@example.com", recipients: ["a@example.com"] }),
+      { inboundMessageId: "m2@example.com", recipients: ["b@example.com"] },
+    );
+    assert.equal(records.length, 2);
+  });
+
+  it("bounds the set, dropping the least recently active thread", () => {
+    let records: AgentThreadRecord[] = [];
+    for (let i = 0; i < MAX_THREADS + 5; i += 1) {
+      records = foldReply(records, {
+        inboundMessageId: `m${i}@example.com`,
+        recipients: ["a@example.com"],
+      });
+    }
+    assert.equal(records.length, MAX_THREADS);
+    assert.deepEqual(records[0]?.inboundAnchorIds, ["m5@example.com"]);
+  });
+
+  it("normalizes brackets and case on both sides", () => {
+    const [record] = foldReply([], {
+      inboundMessageId: "  <M1@Example.COM>  ",
+      recipients: ["  Omar@Shahine.com "],
+    });
+    assert.deepEqual(record?.inboundAnchorIds, ["m1@example.com"]);
+    assert.deepEqual(record?.addressedRecipients, ["omar@shahine.com"]);
+  });
+});
+
+describe("ThreadRecords", () => {
+  it("starts empty, which denies every claim", async () => {
+    const { store } = fakeStore();
+    const records = new ThreadRecords(store, "apple-mail:default");
+    await records.hydrate();
+    assert.deepEqual(records.all(), []);
+    assert.equal(
+      decideThreadReply({ inReplyTo: "anything@example.com", senderAddress: "a@b.com" }, records.all())
+        .permitted,
+      false,
+    );
+  });
+
+  it("survives a restart", async () => {
+    const { store } = fakeStore();
+    const first = new ThreadRecords(store, "apple-mail:default");
+    await first.hydrate();
+    await first.record({ inboundMessageId: "m1@example.com", recipients: ["omar@shahine.com"] });
+
+    const second = new ThreadRecords(store, "apple-mail:default");
+    await second.hydrate();
+    assert.equal(
+      decideThreadReply(
+        { references: ["<m1@example.com>"], senderAddress: "omar@shahine.com" },
+        second.all(),
+      ).permitted,
+      true,
+    );
+  });
+
+  it("keeps accounts apart", async () => {
+    const { store } = fakeStore();
+    const a = new ThreadRecords(store, "apple-mail:work");
+    await a.hydrate();
+    await a.record({ inboundMessageId: "m1@example.com", recipients: ["omar@shahine.com"] });
+
+    const b = new ThreadRecords(store, "apple-mail:personal");
+    await b.hydrate();
+    assert.deepEqual(b.all(), []);
+  });
+});
+
+// The end-to-end shape of the rule: reply to someone, and their answer becomes permitted.
+// This is what the record set exists to make true, and what an empty one made impossible.
+describe("the loop the store closes", () => {
+  it("permits a correspondent's answer only after the agent replied to them", async () => {
+    const { store } = fakeStore();
+    const records = new ThreadRecords(store, "apple-mail:default");
+    await records.hydrate();
+
+    const answer = { references: ["m1@example.com"], senderAddress: "correspondent@example.com" };
+    assert.equal(decideThreadReply(answer, records.all()).permitted, false, "before replying");
+
+    await records.record({
+      inboundMessageId: "m1@example.com",
+      recipients: ["correspondent@example.com"],
+    });
+    const after = decideThreadReply(answer, records.all());
+    assert.equal(after.permitted, true, "after replying");
+    assert.equal(after.matchedAnchor, "inbound_anchor");
+  });
+
+  it("does not extend that permission to a bystander who learned the anchor", async () => {
+    const { store } = fakeStore();
+    const records = new ThreadRecords(store, "apple-mail:default");
+    await records.hydrate();
+    await records.record({
+      inboundMessageId: "m1@example.com",
+      recipients: ["correspondent@example.com"],
+    });
+
+    // Same claimed thread, different sender. Anchors select a thread; they do not grant entry.
+    const decision = decideThreadReply(
+      { references: ["m1@example.com"], senderAddress: "bystander@example.com" },
+      records.all(),
+    );
+    assert.equal(decision.permitted, false);
+    assert.equal(decision.reason, "sender_not_addressed_in_thread");
+  });
+});

--- a/openclaw/src/mail-channel/thread-store.ts
+++ b/openclaw/src/mail-channel/thread-store.ts
@@ -1,0 +1,118 @@
+/**
+ * Durable record of threads the agent has replied in.
+ *
+ * `decideThreadReply` can only permit what the agent wrote down, so without this the thread
+ * rule is inert: every claim resolves against an empty record set and is denied. This is the
+ * half that was missing.
+ *
+ * Held as one bounded array under a single key rather than a key per thread, because the
+ * plugin keyed store is a lookup/register KV with no enumeration, and admission needs *all*
+ * records to evaluate a References chain that may span several threads.
+ */
+
+import type { AgentThreadRecord } from "./thread.ts";
+
+/** The subset of the plugin keyed store this needs. Narrow so tests can fake it. */
+export type ThreadRecordStore = {
+  lookup(key: string): Promise<AgentThreadRecord[] | undefined>;
+  register(key: string, value: AgentThreadRecord[]): Promise<void>;
+};
+
+/**
+ * Threads retained. Old threads go quiet, and an unbounded array under one key is a slow
+ * leak in a value rewritten on every reply. Dropping the oldest costs a stale correspondent
+ * one denied reply, which is the safe direction.
+ */
+export const MAX_THREADS = 200;
+
+export type RecordedReply = {
+  /** Message-ID of the inbound message being replied to. */
+  inboundMessageId: string;
+  /** Message-ID the agent's own reply carried, when the send path reported one. */
+  sentMessageId?: string;
+  /** Everyone the reply was addressed to. */
+  recipients: readonly string[];
+};
+
+function normalizeId(raw: string): string {
+  return raw.trim().replace(/^<|>$/g, "").toLowerCase();
+}
+
+/**
+ * Folds one reply into the record set.
+ *
+ * Pure, so the merge semantics are testable without a store. Replying twice in the same
+ * thread merges into the existing record instead of appending a second one; otherwise a long
+ * exchange would evict every other thread from the bound above.
+ */
+export function foldReply(
+  records: readonly AgentThreadRecord[],
+  reply: RecordedReply,
+): AgentThreadRecord[] {
+  const anchor = normalizeId(reply.inboundMessageId);
+  const sent = reply.sentMessageId ? normalizeId(reply.sentMessageId) : undefined;
+  const recipients = reply.recipients.map((r) => r.trim().toLowerCase()).filter(Boolean);
+
+  // A thread is the same thread when it already carries this anchor or this sent id, which
+  // is how a multi-turn exchange collapses onto one record.
+  const index = records.findIndex(
+    (record) =>
+      (record.inboundAnchorIds ?? []).some((id) => normalizeId(id) === anchor) ||
+      (sent !== undefined && (record.sentMessageIds ?? []).some((id) => normalizeId(id) === sent)),
+  );
+
+  const existing = index >= 0 ? records[index]! : undefined;
+  const merged: AgentThreadRecord = {
+    sentMessageIds: [
+      ...new Set([...(existing?.sentMessageIds ?? []), ...(sent ? [sent] : [])]),
+    ],
+    inboundAnchorIds: [...new Set([...(existing?.inboundAnchorIds ?? []), anchor])],
+    addressedRecipients: [...new Set([...(existing?.addressedRecipients ?? []), ...recipients])],
+  };
+
+  const rest = index >= 0 ? records.filter((_, i) => i !== index) : [...records];
+  // Newest last, so the trim below drops the least recently active thread.
+  return [...rest, merged].slice(-MAX_THREADS);
+}
+
+/**
+ * Process-local view over the durable store.
+ *
+ * Admission consults the records on every classified message, so they are held in memory and
+ * the store is written only when a reply adds something. Reading them back per message would
+ * be a database round trip inside the poll loop for a value only this process changes.
+ */
+export class ThreadRecords {
+  // Explicit fields, not constructor parameter properties: Node runs this repo's TypeScript
+  // in strip-only mode, which cannot erase them.
+  readonly #store: ThreadRecordStore;
+  readonly #key: string;
+  #records: AgentThreadRecord[] = [];
+
+  constructor(store: ThreadRecordStore, key: string) {
+    this.#store = store;
+    this.#key = key;
+  }
+
+  /** Loads the durable set. Call once, at account start. */
+  async hydrate(): Promise<void> {
+    this.#records = [...((await this.#store.lookup(this.#key)) ?? [])];
+  }
+
+  /** Everything admission should match claims against. */
+  all(): readonly AgentThreadRecord[] {
+    return this.#records;
+  }
+
+  /**
+   * Records a reply and persists it.
+   *
+   * Throws if the store does. The caller decides what that means: the mail has already gone
+   * out by this point, so failing the dispatch would misreport a delivered message, while
+   * dropping the record silently costs the correspondent a denied reply later.
+   */
+  async record(reply: RecordedReply): Promise<void> {
+    this.#records = foldReply(this.#records, reply);
+    await this.#store.register(this.#key, this.#records);
+  }
+}

--- a/openclaw/src/mail-channel/thread.test.ts
+++ b/openclaw/src/mail-channel/thread.test.ts
@@ -107,3 +107,62 @@ describe("thread reply permission", () => {
     assert.equal(d.reason, "sender_not_addressed_in_thread");
   });
 });
+
+// Two anchor kinds, deliberately not blurred together. Both are safe only because the
+// sender must also be an address the agent addressed, and decideIngress independently
+// requires that address to authenticate.
+describe("anchor kinds", () => {
+  const record = {
+    sentMessageIds: ["agent-1@lobster.example"],
+    inboundAnchorIds: ["m1@example.com"],
+    addressedRecipients: ["omar@shahine.com"],
+  };
+
+  it("reports an agent-generated match as the strong anchor", () => {
+    const d = decideThreadReply(
+      { inReplyTo: "<agent-1@lobster.example>", senderAddress: "omar@shahine.com" },
+      [record],
+    );
+    assert.equal(d.permitted, true);
+    assert.equal(d.matchedAnchor, "agent_generated");
+  });
+
+  it("reports an inbound-anchor match as the weaker one", () => {
+    const d = decideThreadReply(
+      { references: ["m1@example.com"], senderAddress: "omar@shahine.com" },
+      [record],
+    );
+    assert.equal(d.permitted, true);
+    assert.equal(d.matchedAnchor, "inbound_anchor");
+  });
+
+  it("prefers the agent-generated anchor when the chain names both", () => {
+    const d = decideThreadReply(
+      {
+        references: ["m1@example.com", "agent-1@lobster.example"],
+        senderAddress: "omar@shahine.com",
+      },
+      [record],
+    );
+    assert.equal(d.matchedAnchor, "agent_generated");
+  });
+
+  it("works on a record carrying only an inbound anchor", () => {
+    const d = decideThreadReply(
+      { references: ["m1@example.com"], senderAddress: "omar@shahine.com" },
+      [{ inboundAnchorIds: ["m1@example.com"], addressedRecipients: ["omar@shahine.com"] }],
+    );
+    assert.equal(d.permitted, true);
+  });
+
+  it("denies a sender who was never addressed, whichever anchor they name", () => {
+    for (const claim of [
+      { inReplyTo: "agent-1@lobster.example" },
+      { references: ["m1@example.com"] },
+    ]) {
+      const d = decideThreadReply({ ...claim, senderAddress: "attacker@example.com" }, [record]);
+      assert.equal(d.permitted, false, JSON.stringify(claim));
+      assert.equal(d.reason, "sender_not_addressed_in_thread");
+    }
+  });
+});

--- a/openclaw/src/mail-channel/thread.ts
+++ b/openclaw/src/mail-channel/thread.ts
@@ -16,10 +16,29 @@
  * See docs/mail-channel-scenarios.md scenarios I9, I10, I10a and E1, E2.
  */
 
-/** One thread the agent originated, as recorded at send time. */
+/** One thread the agent participated in, as recorded at send time. */
 export type AgentThreadRecord = {
-  /** Message-IDs the agent generated in this thread. Never populated from inbound mail. */
-  sentMessageIds: readonly string[];
+  /**
+   * Message-IDs the agent itself generated. The strong anchor: unguessable, and absent from
+   * inbound mail until the agent sends it.
+   *
+   * Only send paths that report the id they used can populate this. `mail-cli smtp-send`
+   * mints its own and returns it; Mail.app assigns one internally and reports nothing, so a
+   * reply sent through `mail-cli reply` contributes an inbound anchor and no sent id.
+   */
+  sentMessageIds?: readonly string[];
+  /**
+   * Message-IDs of inbound messages the agent replied to.
+   *
+   * Weaker, and deliberately kept separate rather than blurred into the field above. These
+   * are not secret: the original sender knows them, and so does anyone Cc'd or forwarded a
+   * copy. They select a thread; they do not grant entry to one. What actually carries the
+   * security is `addressedRecipients` below plus sender authentication, which `decideIngress`
+   * applies to thread-permitted mail exactly as it does to everything else. An attacker who
+   * learns an anchor still has to authenticate as somebody the agent addressed, and at that
+   * point they are that participant.
+   */
+  inboundAnchorIds?: readonly string[];
   /** Addresses the agent actually sent to. Membership is checked against this. */
   addressedRecipients: readonly string[];
 };
@@ -42,8 +61,13 @@ export type ThreadDecision = {
     | "no_thread_claim"
     | "claimed_parent_not_sent_by_agent"
     | "sender_not_addressed_in_thread";
-  /** The agent-generated Message-ID the claim resolved to, when it resolved. */
+  /** The recorded Message-ID the claim resolved to, when it resolved. */
   matchedMessageId?: string;
+  /**
+   * Which kind of anchor matched. Surfaced so audit can tell a thread proven by the agent's
+   * own Message-ID from one resolved through an anchor the sender could also have known.
+   */
+  matchedAnchor?: "agent_generated" | "inbound_anchor";
 };
 
 function normalizeId(raw: string | null | undefined): string {
@@ -52,6 +76,16 @@ function normalizeId(raw: string | null | undefined): string {
 
 function normalizeAddress(raw: string | null | undefined): string {
   return raw?.trim().toLowerCase() ?? "";
+}
+
+/** First recorded id the claim names, tagged with which anchor kind it came from. */
+function findClaimed(
+  ids: readonly string[] | undefined,
+  claimed: ReadonlySet<string>,
+  anchor: NonNullable<ThreadDecision["matchedAnchor"]>,
+): { id: string; anchor: NonNullable<ThreadDecision["matchedAnchor"]> } | undefined {
+  const id = (ids ?? []).map(normalizeId).find((value) => value && claimed.has(value));
+  return id ? { id, anchor } : undefined;
 }
 
 /**
@@ -90,15 +124,17 @@ export function decideThreadReply(
   // records for one that both matches a claimed ID and has this sender addressed. Stopping
   // at the first ID match would deny a legitimate participant whose record happened to sort
   // later, turning a correctness bug into a mysterious permission failure.
-  let sawIdMatch: string | undefined;
+  let sawIdMatch: { id: string; anchor: ThreadDecision["matchedAnchor"] } | undefined;
   for (const record of records) {
-    const matchedId = record.sentMessageIds
-      .map(normalizeId)
-      .find((sentId) => sentId && claimed.has(sentId));
-    if (!matchedId) {
+    // Agent-generated ids are tried first, so a thread that can be proven the strong way is
+    // reported that way even when both anchors are on the same record.
+    const matched =
+      findClaimed(record.sentMessageIds, claimed, "agent_generated") ??
+      findClaimed(record.inboundAnchorIds, claimed, "inbound_anchor");
+    if (!matched) {
       continue;
     }
-    sawIdMatch ??= matchedId;
+    sawIdMatch ??= matched;
     const addressed = record.addressedRecipients.some(
       (recipient) => normalizeAddress(recipient) === sender,
     );
@@ -106,7 +142,8 @@ export function decideThreadReply(
       return {
         permitted: true,
         reason: "thread_originated_by_agent",
-        matchedMessageId: matchedId,
+        matchedMessageId: matched.id,
+        matchedAnchor: matched.anchor,
       };
     }
   }
@@ -115,7 +152,12 @@ export function decideThreadReply(
     return { permitted: false, reason: "claimed_parent_not_sent_by_agent" };
   }
 
-  // The claim named a real agent message, but this sender was never addressed in any thread
-  // it belongs to. Forging In-Reply-To gains nothing unless you were already a participant.
-  return { permitted: false, reason: "sender_not_addressed_in_thread", matchedMessageId: sawIdMatch };
+  // The claim named a thread the agent knows, but this sender was never addressed in it.
+  // Forging In-Reply-To gains nothing unless you were already a participant.
+  return {
+    permitted: false,
+    reason: "sender_not_addressed_in_thread",
+    matchedMessageId: sawIdMatch.id,
+    matchedAnchor: sawIdMatch.anchor,
+  };
 }

--- a/skills/apple-pim/SKILL.md
+++ b/skills/apple-pim/SKILL.md
@@ -148,7 +148,6 @@ The `auth_check` action verifies sender identity by parsing Authentication-Resul
       "name": "Alice",
       "emails": ["alice@example.com"],
       "expectedDkimDomains": ["example.com"],
-      "requireDkim": true,
       "requireSpf": true
     }
   ]

--- a/swift/Sources/MailCLI/MIMEBuilder.swift
+++ b/swift/Sources/MailCLI/MIMEBuilder.swift
@@ -57,6 +57,17 @@ public struct MIMEMessage: Sendable {
     public var messageID: String?
     public var date: Date
 
+    /// `In-Reply-To` and `References`, so a reply joins the recipient's existing thread
+    /// instead of starting a new one. Emitted only when non-empty.
+    ///
+    /// These matter beyond presentation: an agent that records the `Message-ID` it sent can
+    /// later prove a thread was its own, which is what lets a reply be permitted without
+    /// widening into standing permission to contact that address. Sending unthreaded means
+    /// the recipient's client picks its own `References`, and the agent has nothing to
+    /// check a later claim against.
+    public var inReplyTo: String?
+    public var references: [String]
+
     /// When `true` (default) and the message has `html` but no `text`, a plain-text
     /// fallback is synthesized from the HTML so the message is emitted as
     /// `multipart/alternative` rather than a single `text/html` part. Set to `false`
@@ -78,6 +89,8 @@ public struct MIMEMessage: Sendable {
         attachments: [Attachment] = [],
         messageID: String? = nil,
         date: Date = Date(),
+        inReplyTo: String? = nil,
+        references: [String] = [],
         autoDeriveTextFallback: Bool = true
     ) {
         self.from = from
@@ -90,7 +103,18 @@ public struct MIMEMessage: Sendable {
         self.attachments = attachments
         self.messageID = messageID
         self.date = date
+        self.inReplyTo = inReplyTo
+        self.references = references
         self.autoDeriveTextFallback = autoDeriveTextFallback
+    }
+
+    /// Message-IDs travel in angle brackets. Callers hand us bare ids as often as bracketed
+    /// ones, and a `References` chain mixing both breaks threading in some clients.
+    static func bracketed(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.hasPrefix("<") && trimmed.hasSuffix(">") { return trimmed }
+        return "<\(trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "<>")))>"
     }
 
     /// All recipients (To + Cc + Bcc) for the SMTP `RCPT TO` phase.
@@ -119,6 +143,16 @@ public struct MIMEMessage: Sendable {
         headers.append(("Subject", subject))
         headers.append(("Date", Self.formatRFC5322Date(date)))
         headers.append(("Message-ID", resolvedMessageID))
+        // Threading headers sit next to Message-ID because they are the same kind of fact.
+        // Emitted only when populated: an empty References is meaningless to RFC 5322 and
+        // some relays reject the bare header.
+        if let parent = inReplyTo.flatMap(Self.bracketed) {
+            headers.append(("In-Reply-To", parent))
+        }
+        let chain = references.compactMap(Self.bracketed)
+        if !chain.isEmpty {
+            headers.append(("References", chain.joined(separator: " ")))
+        }
         headers.append(("MIME-Version", "1.0"))
         for (name, value) in bodyHeaders {
             headers.append((name, value))

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -2145,7 +2145,11 @@ private struct TrustedSender: Decodable {
     let name: String
     let emails: [String]
     let expectedDkimDomains: [String]?
-    let requireDkim: Bool?
+    /// SPF breaks on relaying while DKIM survives it, so a sender whose mail is relayed can
+    /// waive SPF. There is deliberately no matching `requireDkim`: DKIM against
+    /// `expectedDkimDomains` is the only evidence that binds a mailbox to a signer, so
+    /// waiving it would leave nothing per-sender behind a `verified` verdict. Existing
+    /// configs carrying `requireDkim` still decode; the key is ignored.
     let requireSpf: Bool?
 }
 
@@ -2395,7 +2399,6 @@ struct AuthCheck: AsyncParsableCommand {
         // domain-level result is available to callers.
         let enrolled = senderConfig != nil
         let expectedDkim = senderConfig?.expectedDkimDomains ?? []
-        let requireDkim = senderConfig?.requireDkim ?? true
         let requireSpf = senderConfig?.requireSpf ?? true
         var warnings = [String]()
 
@@ -2454,23 +2457,36 @@ struct AuthCheck: AsyncParsableCommand {
         let dkimDomainOk = (dkimCheck["match"] as? Bool) ?? false
         let spfPass = (spfCheck["match"] as? Bool) ?? false
 
+        // Enrolling a sender without naming their signers is a config error, not a policy:
+        // no signature can match, so the address silently never reaches `verified`. Say so,
+        // and quote the domains that did sign, so fixing it is a copy step.
+        if enrolled && expectedDkim.isEmpty {
+            warnings.append(
+                "Sender \(senderEmail) is enrolled but has no expectedDkimDomains, so it can "
+                    + "never reach 'verified'. Observed signing domains on this message: "
+                    + "\(allSigningDomains.filter { !$0.isEmpty }.sorted().joined(separator: ", "))"
+            )
+        }
+
+        // Every path to `verified` runs through a DKIM signature matching this sender's
+        // expectedDkimDomains. An aligned SPF pass authenticates the envelope *domain* and
+        // names no mailbox, so SPF alone can never carry an address claim: on a shared
+        // domain every user of it passes aligned SPF, which would make each of them
+        // `verified` as any other. Only the operator naming a signer for a specific address
+        // makes the leap from domain to mailbox.
         var verdict: String
         if dkimPass && dkimDomainOk && spfPass {
             verdict = "verified"
         } else if dkimPass && dkimDomainOk && !requireSpf {
             verdict = "verified"
             if !spfPass { warnings.append("SPF result is '\(spfCheck["result"] ?? "none")' but not required for this sender") }
-        } else if spfPass && !requireDkim {
-            verdict = "verified"
-            if !dkimPass { warnings.append("DKIM result is '\(dkimCheck["result"] ?? "none")' but not required for this sender") }
         } else {
             verdict = "suspicious"
-            // "required" only means something when the operator configured a requirement.
-            if enrolled && requireDkim && !dkimPass {
+            // These only mean something when the operator configured an expectation to violate.
+            if enrolled && !dkimPass {
                 warnings.append("DKIM required but result is '\(dkimCheck["result"] ?? "none")'")
             }
-            // Only meaningful when the operator configured an expectation to violate.
-            if enrolled && requireDkim && dkimPass && !dkimDomainOk {
+            if enrolled && dkimPass && !dkimDomainOk {
                 warnings.append("DKIM passed but signing domain mismatch — possible spoofing")
             }
             if enrolled && requireSpf && !spfPass {

--- a/swift/Sources/MailCLI/SMTPSendCommand.swift
+++ b/swift/Sources/MailCLI/SMTPSendCommand.swift
@@ -67,6 +67,12 @@ struct SMTPSend: AsyncParsableCommand {
     @Option(name: .long, parsing: .singleValue, help: "Attachment file path (repeatable).")
     var attachment: [String] = []
 
+    @Option(name: .customLong("in-reply-to"), help: "Message-ID this message replies to. Sets In-Reply-To.")
+    var inReplyTo: String?
+
+    @Option(name: .long, parsing: .singleValue, help: "Message-ID for the References chain, oldest first (repeatable).")
+    var references: [String] = []
+
     @Option(name: .long, help: "From address. Defaults to smtp.username from config.")
     var from: String?
 
@@ -151,7 +157,12 @@ struct SMTPSend: AsyncParsableCommand {
             subject: subject,
             text: body,
             html: htmlContent,
-            attachments: attachments
+            attachments: attachments,
+            inReplyTo: inReplyTo,
+            // A reply's References is the parent's chain plus the parent itself. Callers pass
+            // the chain they read off the inbound message; append the parent when they did
+            // not, so a bare --in-reply-to still threads.
+            references: references.isEmpty ? [inReplyTo].compactMap { $0 } : references
         )
 
         if dryRun {


### PR DESCRIPTION
## What this changes

Documents the `channels.apple-mail` configuration block, and then fixes the four defects that writing that documentation exposed.

Writing down what `minIdentifierAuthentication` did made it obvious it did not do it. The scenario doc says scenarios I2, I7, and I8 drop. They dispatched.

## The defects

**1. The documented default admitted spoofed operators.** `mailAuthToIdentifierStrengths` never returned `mutable` for the address identifier, so the only identifier admission tests against the configured minimum had a floor of `asserted`. The default minimum *is* `asserted`, which made it not a bar at all: every address in `allowFrom` was admitted on the strength of its own `From` header. The audit trail recorded `allowlisted_and_authenticated` while doing it.

```
I7 (spoofed operator, forged Authentication-Results), before:
  strengths: {"address":"asserted","domain":"asserted"}
  decision:  {"admission":"dispatch","reason":"allowlisted_and_authenticated"}
```

An unauthenticated `From` header now scores `mutable`, which is what it is: a string the sender typed, with no evidence from our side of the boundary.

**2. At the strict setting, `allowFrom` made things worse.** `decideIngress` checked the allowlist before the domain-authenticated `observe` branch, so under `minIdentifierAuthentication: "verified"` an allowlisted sender with no `expectedDkimDomains` entry dropped — while the identical message from a sender *not* on the allowlist was admitted to `observe`. Adding an address to `allowFrom` lowered its admission, silently, on exactly the addresses an operator cared enough to configure. Thread permission had the same bug: a participant in a thread the agent itself started dropped where a stranger would have been read.

A grant that fails to apply now leaves the sender where an ungranted one lands.

**3. SPF alone could reach `verified`.** With `requireDkim: false`, an aligned SPF pass produced a `verified` verdict with no `expectedDkimDomains` consulted. SPF authenticates an envelope *domain* and names no mailbox, so on any shared domain (gmail.com, a company domain, a hosting provider) every user of it passes aligned SPF and would authenticate as every other. The scenario doc lists this under "Deliberately not supported"; the code derived it.

Every path to `verified` now runs through a DKIM signature matching that sender's `expectedDkimDomains`. `requireDkim` is removed. `requireSpf: false` stays, because relaying breaks SPF while DKIM survives it and DKIM already carried the mailbox claim.

**4. Enrolling a sender with no signing domains failed closed and said nothing.** Now warned.

## Why the tests missed all of this

They pinned the minimum at `verified`, or asserted strengths without running them through admission. `scenarios.test.ts` executes the doc's ingress table at **both** minimums, plus three invariants: no grant may lower admission, strict is never more permissive than default, nothing unauthenticated reaches dispatch. The table and the code can't drift apart again.

## Startup diagnostics

Admission needs `openclaw.json` and `trusted-senders.json` to agree, and every way they can disagree fails closed and therefore silently. A control that does not apply looks exactly like one that passes. `config-check.ts` reports, once per account start:

- `selfAddresses` empty, so the loop guard cannot fire
- `trusted-senders.json` unreadable, so nothing authenticates
- no `trustedAuthservIds` at all, so every message drops
- an `allowFrom` entry with no enrollment behind it
- an enrollment naming no signing domains

The authserv-id check is deliberately unscoped: mail-cli resolves the set from the message's own account (`msg.mailbox().account().name()`, falling back to the account UUID), so startup cannot know which key a future message lands on. An earlier draft keyed it on the channel's `account` option and warned about a working install.

## Evidence

- 122 tests pass; `tsc --noEmit` clean; `swift build` clean.
- 25 real Archive messages through the real `mail-cli auth-check`, the real strength map, and the real policy: 23 authenticated-but-unenrolled senders `observe` at both minimums (I5/I11), 2 enrolled operator messages `dispatch` at both (I1). Verdicts identical before and after the Swift change.
- `checkChannelConfig` against a real `trusted-senders.json`: clean under the documented posture, both expected findings on a half-configured one.

**Proof gap:** every message in that mailbox authenticates at domain level, so there was no live unauthenticated sample. The `drop` paths are covered by test, not by live mail.

## Compatibility

Existing `trusted-senders.json` files carrying `requireDkim` still load — Swift ignores unknown JSON keys. Installs running the default `asserted` minimum will see previously-dispatched unauthenticated mail start dropping. That is the point.

---

## Also: the thread reply rule now works

It was implemented and inert. `decideThreadReply` matched claims against records nothing ever wrote, so every claim resolved against an empty set and was denied. The blocker: the rule required the claimed parent to be a Message-ID *the agent generated*, and `mail-cli reply` reports none — Mail.app assigns one internally and hands nothing back.

Resolved with two anchor kinds rather than by weakening the rule.

**`smtp-send` can now thread.** `MIMEMessage` gained `inReplyTo`/`references`, rendered next to `Message-ID` and only when populated, with bare and bracketed ids normalized so a mixed chain does not break threading. That path already minted and returned its own Message-ID, so it records the strong anchor.

**The Mail.app path records the inbound Message-ID it replied to.** That anchor is not secret — the original sender knows it, as does anyone Cc'd. It is still sound, and the doc now says why instead of glossing it:

> An anchor selects a thread. It does not grant entry to one.

Permission also requires the sender to be an address the agent addressed, and `decideIngress` independently requires that address to meet `minIdentifierAuthentication`, because thread permission waives the allowlist and never authentication (I9). Using a stolen anchor means authenticating as a participant — at which point you are that participant.

The two are separate fields and the decision reports which matched, so audit can tell them apart, and moving a deployment to `smtp-send` upgrades its threads with no policy change.

**Known false negative:** a client that sets `In-Reply-To` but writes no `References` names only the agent's own reply, which the Mail.app path never learned. Denied. Full chains are near-universal, but this is why the strong anchor is worth having.

`thread-store.ts` is the half that was missing: one bounded array under a single key (the plugin keyed store has no enumeration, and admission needs every record to evaluate a chain spanning several threads). Replies in an existing thread merge onto its record rather than appending, or a long exchange would evict every other thread from the bound. Recording happens **after delivery, never on permission** — a suppressed or empty reply must not confer thread standing. A store failure warns and fails closed rather than failing a dispatch whose mail already left.

143 tests, `tsc --noEmit` clean, `swift build` clean, threading headers verified via `smtp-send --dry-run`.
