### PR TITLE
feat(mail): envelope prompting, gated fetch, and a circuit breaker

### DIFF
--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -373,6 +373,20 @@ fetch the body the channel just refused to deliver. The channel therefore quaran
 ids it drops, and `apple_pim_mail` refuses to read or save attachments from them. Lazy
 fetch without that gate is a bypass, not an optimization.
 
+Blocking direct reads is not sufficient on its own. `search --field content` reads every
+candidate body, so an unfiltered hit is a content oracle: the agent probes for a phrase and
+learns from the result whether a quarantined message contains it, without ever opening one.
+Listings leak the envelope the same way. Quarantined messages are therefore withheld from
+listing and search results as well, and the response says how many rows were withheld, since
+a quietly short listing is indistinguishable from an empty mailbox.
+
+**Volume ceiling.** When more unprocessed mail sits in the mailbox than one cycle can page
+through, the cursor advances past the remainder and the skipped mail is reported rather than
+retried. Holding the cursor instead looks safer and is worse: listing is newest-first, so a
+held cursor re-lists and redelivers the same newest page every cycle and still never reaches
+the older mail. That is unbounded duplicate delivery *plus* the same loss. Advancing bounds
+it to loss, once, loudly enough to raise `maxLimit` or narrow the mailbox.
+
 **Polling, not push.** The channel reads the local mail store on an interval rather than
 depending on a mail-client rule to wake it. That removes a GUI dependency, and it means the
 filter lives in the channel where policy belongs, instead of upstream where it would decide

--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -343,12 +343,35 @@ sees is indistinguishable from a bug.
 it. "Why did the agent not answer that?" must be answerable after the fact, and the answer
 must not require re-reading the mailbox.
 
-**Rate and volume.** Default-deny bounds *who* the agent may contact, not *how much*. A
-permitted recipient plus a loop the loop guard does not catch is still a way to send a
-hundred messages. Volume limits are a separate control and are not covered here.
+**Rate and volume.** Default-deny bounds *who* may drive the agent, not *how much*. One
+permitted correspondent, a mailing list that starts looping, or a mail rule gone wrong all
+produce unbounded agent runs from an entirely authorized sender, and every control above
+correctly waves each one through.
+
+A circuit breaker counts runs per hour and per day (`maxAgentRunsPerHour`,
+`maxAgentRunsPerDay`). It counts runs rather than judging senders: a per-sender breaker
+would let ten senders cost ten times as much, which is the failure it exists to prevent.
+When it trips the channel holds its cursor instead of discarding the backlog, so a burst is
+deferred and never lost. That costs a re-authentication per held message each cycle, which
+is the right trade: authentication is cheap, and losing the operator's mail to a flood of
+newsletters is not recoverable.
 
 **Attachments.** Orthogonal to admission. Inbound attachments do not change a sender's
 strength; outbound attachments are default-denied unless the operator opts specific paths in.
+
+Inbound attachments are never fetched automatically. The envelope reports that they exist
+and the agent saves one only if it decides to, through the same gate as a body.
+
+**What the agent is given.** The envelope, never the message: sender, subject, date,
+attachment count, and the message id. Sender and subject are usually enough to tell a
+newsletter from an instruction, and on a real mailbox most admitted mail is `observe`, so
+fetching every body meant a model call per newsletter whose reply was then discarded.
+
+This moves the security boundary onto the tool. A dropped message still has an id, and a
+general-purpose mail tool will read any id it is given, so an agent that learns one could
+fetch the body the channel just refused to deliver. The channel therefore quarantines the
+ids it drops, and `apple_pim_mail` refuses to read or save attachments from them. Lazy
+fetch without that gate is a bypass, not an optimization.
 
 **Polling, not push.** The channel reads the local mail store on an interval rather than
 depending on a mail-client rule to wake it. That removes a GUI dependency, and it means the

--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -380,12 +380,17 @@ Listings leak the envelope the same way. Quarantined messages are therefore with
 listing and search results as well, and the response says how many rows were withheld, since
 a quietly short listing is indistinguishable from an empty mailbox.
 
-**Volume ceiling.** When more unprocessed mail sits in the mailbox than one cycle can page
-through, the cursor advances past the remainder and the skipped mail is reported rather than
-retried. Holding the cursor instead looks safer and is worse: listing is newest-first, so a
-held cursor re-lists and redelivers the same newest page every cycle and still never reaches
-the older mail. That is unbounded duplicate delivery *plus* the same loss. Advancing bounds
-it to loss, once, loudly enough to raise `maxLimit` or narrow the mailbox.
+**Volume ceiling.** The channel reads the *oldest* unprocessed mail each cycle, paging
+forward from its cursor, so a full page simply means the backlog is still draining.
+
+This was originally newest-first, and that could not be made correct. The page grows
+backwards from now, so once more than one page of mail sat between the cursor and the
+present, older messages were unreachable: advancing the cursor skipped them, holding it
+redelivered the newest page forever and still never reached them. Worse, it was reachable on
+purpose. Anyone able to flood the mailbox could push a real message permanently out of view,
+and unauthenticated mail consumed page capacity before it was ever classified. Paging forward
+from the cursor removes the whole class: a flood is newer than the backlog, so it sorts
+behind it and waits its turn.
 
 **Polling, not push.** The channel reads the local mail store on an interval rather than
 depending on a mail-client rule to wake it. That removes a GUI dependency, and it means the

--- a/lib/handlers/mail.js
+++ b/lib/handlers/mail.js
@@ -1,6 +1,6 @@
 import { formatMailGetResult } from "../mail-format.js";
 import { validateAttachments, validateDestDir } from "../safe-attachments.js";
-import { assertMailReadable } from "../mail-quarantine.js";
+import { assertMailReadable, filterQuarantinedResults } from "../mail-quarantine.js";
 
 export async function handleMail(args, runCLI) {
   const cliArgs = [];
@@ -20,7 +20,9 @@ export async function handleMail(args, runCLI) {
       if (args.account) cliArgs.push("--account", args.account);
       if (args.limit) cliArgs.push("--limit", String(args.limit));
       if (args.filter) cliArgs.push("--filter", args.filter);
-      return await runCLI("mail-cli", cliArgs);
+      // A listing that includes a refused message hands the agent the envelope the channel
+      // declined to deliver, so `drop` would only mean "delivered by a different route".
+      return filterQuarantinedResults(await runCLI("mail-cli", cliArgs));
 
     case "get": {
       if (!args.id) throw new Error("Message ID is required for mail get");
@@ -43,7 +45,11 @@ export async function handleMail(args, runCLI) {
       if (args.account) cliArgs.push("--account", args.account);
       if (args.limit) cliArgs.push("--limit", String(args.limit));
       if (args.since) cliArgs.push("--since", args.since);
-      return await runCLI("mail-cli", cliArgs);
+      // Filtering search matters more than filtering listings: `--field content` reads every
+      // candidate body, so an unfiltered hit is a content oracle. The agent probes for a
+      // phrase and learns whether a quarantined message contains it, without ever calling
+      // `get`. Withholding the row closes that without needing to inspect the query.
+      return filterQuarantinedResults(await runCLI("mail-cli", cliArgs));
 
     case "update": {
       if (!args.id) throw new Error("Message ID is required for mail update");

--- a/lib/handlers/mail.js
+++ b/lib/handlers/mail.js
@@ -22,7 +22,8 @@ export async function handleMail(args, runCLI) {
       if (args.filter) cliArgs.push("--filter", args.filter);
       // A listing that includes a refused message hands the agent the envelope the channel
       // declined to deliver, so `drop` would only mean "delivered by a different route".
-      return filterQuarantinedResults(await runCLI("mail-cli", cliArgs));
+      // The withheld count is safe to report here: it does not depend on a query.
+      return filterQuarantinedResults(await runCLI("mail-cli", cliArgs), { reportWithheld: true });
 
     case "get": {
       if (!args.id) throw new Error("Message ID is required for mail get");
@@ -48,7 +49,9 @@ export async function handleMail(args, runCLI) {
       // Filtering search matters more than filtering listings: `--field content` reads every
       // candidate body, so an unfiltered hit is a content oracle. The agent probes for a
       // phrase and learns whether a quarantined message contains it, without ever calling
-      // `get`. Withholding the row closes that without needing to inspect the query.
+      // `get`. Withholding the row closes that without needing to inspect the query, and the
+      // withheld count is deliberately not reported: a query-dependent count is the same
+      // oracle wearing a different hat.
       return filterQuarantinedResults(await runCLI("mail-cli", cliArgs));
 
     case "update": {

--- a/lib/mail-quarantine.js
+++ b/lib/mail-quarantine.js
@@ -1,32 +1,37 @@
 /**
  * Messages the Apple Mail channel refused to admit, and which the mail tool must therefore
- * also refuse to open.
+ * also refuse to surface.
  *
  * The channel stopped sending message bodies to the agent and started sending envelopes
  * with a message id, so the agent fetches a body only when it decides one is worth reading.
  * That moved the decision to the right place, and it moved the gate to the wrong one:
  * `apple_pim_mail` will read any id handed to it. A message the channel dropped as spoofed
  * or unauthenticated still has an id, and an agent that learns it (from a References chain,
- * a quoted reply, a summary of the mailbox) could read the body the channel just refused to
+ * a quoted reply, a listing of the mailbox) could read the body the channel just refused to
  * deliver. Lazy fetch without this is a bypass, not an optimization.
  *
- * The rule is deliberately narrow: only ids the channel explicitly dropped are refused.
- * Ordinary operator-driven mail work is untouched, because quarantine is a decision the
- * channel made about a specific message, not a mode the tool runs in.
+ * "Refuse to surface" is stronger than "refuse to open", and it has to be. Blocking only
+ * `get` leaves `search --field content` as a content oracle: the agent probes for a phrase
+ * and learns from the hit whether a quarantined message contains it, without ever reading a
+ * body. Listings leak the envelope the same way. So quarantined ids are filtered out of
+ * results as well as blocked on direct access.
+ *
+ * Entries are keyed per account. One shared map meant a second account starting up replaced
+ * the first account's set, silently un-quarantining everything it had refused.
  *
  * Plain JS rather than TypeScript so the tool handlers in this directory can import it
  * directly, the same way they import every other helper here.
  */
 
 /**
- * Bounded, because this is a rejection cache and an unbounded one is a leak. Dropping the
- * oldest entry re-exposes a message the channel already refused, so the bound is generous
- * relative to how much mail a poll cycle can drop.
+ * Bounded per account, because this is a rejection cache and an unbounded one is a leak.
+ * Dropping the oldest entry re-exposes a message the channel already refused, so the bound
+ * is generous relative to how much mail a poll cycle can drop.
  */
 const MAX_QUARANTINED = 2000;
 
-/** id -> reason code, insertion-ordered so the oldest is evictable. */
-let quarantined = new Map();
+/** account key -> (normalized id -> reason). Insertion-ordered, so the oldest is evictable. */
+const byAccount = new Map();
 
 /** Normalizes so `<id>`, ` id `, and `ID` are the same message. */
 function normalize(id) {
@@ -36,36 +41,63 @@ function normalize(id) {
     .toLowerCase();
 }
 
+function accountMap(account) {
+  const key = String(account ?? "default");
+  let map = byAccount.get(key);
+  if (!map) {
+    map = new Map();
+    byAccount.set(key, map);
+  }
+  return map;
+}
+
 /** Records that the channel refused this message. */
-export function quarantineMessage(id, reason) {
+export function quarantineMessage(account, id, reason) {
   const key = normalize(id);
   if (!key) {
     return;
   }
+  const map = accountMap(account);
   // Re-inserting moves it to the end, so an id the channel keeps rejecting stays fresh.
-  quarantined.delete(key);
-  quarantined.set(key, reason ?? "not_admitted");
-  while (quarantined.size > MAX_QUARANTINED) {
-    quarantined.delete(quarantined.keys().next().value);
+  map.delete(key);
+  map.set(key, reason ?? "not_admitted");
+  while (map.size > MAX_QUARANTINED) {
+    map.delete(map.keys().next().value);
   }
 }
 
-/** Replaces the whole set, for hydrating from durable storage at channel start. */
-export function loadQuarantine(entries) {
-  quarantined = new Map();
+/** Replaces one account's set, for hydrating from durable storage at channel start. */
+export function loadQuarantine(account, entries) {
+  byAccount.set(String(account ?? "default"), new Map());
   for (const [id, reason] of entries ?? []) {
-    quarantineMessage(id, reason);
+    quarantineMessage(account, id, reason);
   }
 }
 
-/** Current contents, for persisting. */
-export function quarantineSnapshot() {
-  return [...quarantined.entries()];
+/** One account's contents, for persisting. */
+export function quarantineSnapshot(account) {
+  return [...accountMap(account).entries()];
 }
 
-/** The reason this message was refused, or undefined when it was not. */
+/**
+ * The reason this message was refused, or undefined when it was not.
+ *
+ * Searches every account, because the mail tool is not account-scoped: it is handed an id
+ * and nothing else. A message refused by any account must not be readable through any
+ * other, since they share one mailbox and one agent.
+ */
 export function quarantineReason(id) {
-  return quarantined.get(normalize(id));
+  const key = normalize(id);
+  if (!key) {
+    return undefined;
+  }
+  for (const map of byAccount.values()) {
+    const reason = map.get(key);
+    if (reason) {
+      return reason;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -87,7 +119,33 @@ export function assertMailReadable(id, action) {
   );
 }
 
+/**
+ * Removes quarantined messages from a listing or search result.
+ *
+ * Operates on the parsed CLI payload and leaves everything else alone, including the count
+ * fields, which are corrected to match what is actually returned rather than left claiming
+ * rows that were withheld.
+ */
+export function filterQuarantinedResults(result) {
+  if (!result || typeof result !== "object" || !Array.isArray(result.messages)) {
+    return result;
+  }
+  const kept = result.messages.filter((m) => !quarantineReason(m?.messageId));
+  const withheld = result.messages.length - kept.length;
+  if (withheld === 0) {
+    return result;
+  }
+  const filtered = { ...result, messages: kept };
+  if (typeof result.count === "number") {
+    filtered.count = kept.length;
+  }
+  // Said out loud rather than silently: a listing that is quietly short reads as an empty
+  // mailbox, and an agent cannot tell "nothing matched" from "you may not see it".
+  filtered.withheldByChannelPolicy = withheld;
+  return filtered;
+}
+
 /** Test seam. Not part of the tool surface. */
 export function resetQuarantine() {
-  quarantined = new Map();
+  byAccount.clear();
 }

--- a/lib/mail-quarantine.js
+++ b/lib/mail-quarantine.js
@@ -122,11 +122,17 @@ export function assertMailReadable(id, action) {
 /**
  * Removes quarantined messages from a listing or search result.
  *
- * Operates on the parsed CLI payload and leaves everything else alone, including the count
- * fields, which are corrected to match what is actually returned rather than left claiming
- * rows that were withheld.
+ * `reportWithheld` controls whether the response admits that rows were removed. For a
+ * listing the answer does not depend on anything the agent chose, so saying "2 withheld" is
+ * a useful diagnostic: a quietly short listing is otherwise indistinguishable from an empty
+ * mailbox.
+ *
+ * For a search it must stay silent, because the count is query-dependent and therefore an
+ * oracle in its own right. `search --field content "secret phrase"` reporting one withheld
+ * row confirms the phrase appears in quarantined mail without ever returning it, which is
+ * the exact leak filtering the rows was meant to close.
  */
-export function filterQuarantinedResults(result) {
+export function filterQuarantinedResults(result, { reportWithheld = false } = {}) {
   if (!result || typeof result !== "object" || !Array.isArray(result.messages)) {
     return result;
   }
@@ -139,9 +145,9 @@ export function filterQuarantinedResults(result) {
   if (typeof result.count === "number") {
     filtered.count = kept.length;
   }
-  // Said out loud rather than silently: a listing that is quietly short reads as an empty
-  // mailbox, and an agent cannot tell "nothing matched" from "you may not see it".
-  filtered.withheldByChannelPolicy = withheld;
+  if (reportWithheld) {
+    filtered.withheldByChannelPolicy = withheld;
+  }
   return filtered;
 }
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -69,7 +69,12 @@ It is inert until `channels.apple-mail` exists in `openclaw.json`.
       "egressAllowlist": [],
       // Not always INBOX: mail is often archived on arrival.
       "mailbox": "INBOX",
-      "pollIntervalSeconds": 60
+      "pollIntervalSeconds": 60,
+      // Circuit breaker on agent runs. Default-deny bounds who may drive the agent, not
+      // how much; one permitted correspondent in a loop is otherwise unlimited model
+      // calls. When tripped the channel holds its cursor, so mail is deferred, not lost.
+      "maxAgentRunsPerHour": 30,
+      "maxAgentRunsPerDay": 200
     }
   }
 }

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -27,6 +27,7 @@ import {
   readTrustedSenders,
 } from "./runtime.ts";
 import { checkChannelConfig } from "./config-check.ts";
+import { RunBudget, resolveRateLimits, type BreakerStore } from "./rate-limit.ts";
 import { ThreadRecords, type ThreadRecordStore } from "./thread-store.ts";
 import {
   loadQuarantine,
@@ -60,6 +61,12 @@ export type ResolvedAppleMailAccount = {
     pageSize?: number;
     /** Path to trusted-senders.json. */
     trustedSendersPath?: string;
+    /**
+     * Circuit breaker on agent runs. Default-deny bounds who may drive the agent, not how
+     * much: one permitted correspondent in a loop is otherwise unlimited model calls.
+     */
+    maxAgentRunsPerHour?: number;
+    maxAgentRunsPerDay?: number;
   };
 };
 
@@ -212,6 +219,17 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
     const quarantineKey = `${CHANNEL_ID}:${ctx.accountId}`;
     loadQuarantine(await quarantineStore.lookup(quarantineKey));
 
+    const limits = resolveRateLimits(config);
+    const budget = new RunBudget(
+      state.openKeyedStore({
+        namespace: `${CHANNEL_ID}:budget`,
+        maxEntries: 64,
+      }) as BreakerStore,
+      `${CHANNEL_ID}:${ctx.accountId}`,
+      limits,
+    );
+    await budget.hydrate();
+
     const minIdentifierAuthentication = config.minIdentifierAuthentication ?? "asserted";
     const allowFrom = (config.allowFrom ?? []).map((entry) => String(entry));
 
@@ -246,6 +264,9 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
             return;
           }
           for (const message of messages) {
+            // Spend before the run, not after: a run that throws still consumed a model
+            // call, and a breaker that only counts successes cannot bound a crash loop.
+            await budget.consume();
             await dispatchAdmittedMessage(
               message,
               {
@@ -277,6 +298,14 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
           }
         },
         onError: (error) => ctx.log?.warn?.(`apple-mail poll failed: ${String(error)}`),
+        checkBudget: () => budget.check(),
+        onThrottled: ({ window, retryAtMs, pending }) =>
+          ctx.log?.warn?.(
+            `apple-mail: circuit breaker open (${window} limit of ` +
+              `${window === "day" ? limits.perDay : limits.perHour} agent runs reached); ` +
+              `holding ${pending} message(s)` +
+              (retryAtMs ? ` until ${new Date(retryAtMs).toISOString()}` : ""),
+          ),
         onTruncated: ({ mailbox, limit }) =>
           ctx.log?.warn?.(
             `apple-mail: ${mailbox} had more than ${limit} unread messages; some were not read this cycle`,

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -258,17 +258,13 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
           await quarantineStore.register(quarantineKey, quarantineSnapshot(quarantineKey));
         },
         onAdmitted: async (messages) => {
-          // Tests and embedders can take over delivery entirely.
-          if (admittedHandler) {
-            await admittedHandler(messages);
-            return;
-          }
-          for (const [index, message] of messages.entries()) {
+          let completed = 0;
+          for (const message of messages) {
             // Checked per message, not once per batch. A single check would let a batch of
-            // 25 run against a budget with 1 left, which is not a cap.
+            // 25 run against a budget with 1 left, which is not a cap. Ahead of the
+            // embedder override too, so taking over delivery cannot take over the cap.
             if (!budget.check().allowed) {
-              // Report what was left untouched so the loop holds the cursor for it.
-              return { deferred: messages.length - index };
+              return { completed };
             }
             // Spend before the run, not after: a run that throws still consumed a model
             // call, and a breaker that only counts successes cannot bound a crash loop.
@@ -278,6 +274,13 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
                 `apple-mail: agent-run budget not persisted (${String(spend.error)}); the cap ` +
                   `still holds for this process but will not survive a restart`,
               );
+            }
+            // Tests and embedders can take over delivery, one message at a time so the
+            // budget and the partial cursor still apply to them.
+            if (admittedHandler) {
+              await admittedHandler([message]);
+              completed += 1;
+              continue;
             }
             await dispatchAdmittedMessage(
               message,
@@ -307,8 +310,9 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
                 sessionPrefix: `${CHANNEL_ID}:${ctx.accountId}`,
               },
             );
+            completed += 1;
           }
-          return undefined;
+          return { completed };
         },
         onError: (error) => ctx.log?.warn?.(`apple-mail poll failed: ${String(error)}`),
         checkBudget: () => budget.check(),

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -217,7 +217,7 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
       register(key: string, value: [string, string][]): Promise<void>;
     };
     const quarantineKey = `${CHANNEL_ID}:${ctx.accountId}`;
-    loadQuarantine(await quarantineStore.lookup(quarantineKey));
+    loadQuarantine(quarantineKey, await quarantineStore.lookup(quarantineKey));
 
     const limits = resolveRateLimits(config);
     const budget = new RunBudget(
@@ -253,9 +253,9 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
         ...deps,
         onDropped: async (messages) => {
           for (const entry of messages) {
-            quarantineMessage(entry.message.messageId, entry.decision.reason);
+            quarantineMessage(quarantineKey, entry.message.messageId, entry.decision.reason);
           }
-          await quarantineStore.register(quarantineKey, quarantineSnapshot());
+          await quarantineStore.register(quarantineKey, quarantineSnapshot(quarantineKey));
         },
         onAdmitted: async (messages) => {
           // Tests and embedders can take over delivery entirely.
@@ -263,10 +263,22 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
             await admittedHandler(messages);
             return;
           }
-          for (const message of messages) {
+          for (const [index, message] of messages.entries()) {
+            // Checked per message, not once per batch. A single check would let a batch of
+            // 25 run against a budget with 1 left, which is not a cap.
+            if (!budget.check().allowed) {
+              // Report what was left untouched so the loop holds the cursor for it.
+              return { deferred: messages.length - index };
+            }
             // Spend before the run, not after: a run that throws still consumed a model
             // call, and a breaker that only counts successes cannot bound a crash loop.
-            await budget.consume();
+            const spend = await budget.consume();
+            if (!spend.persisted) {
+              ctx.log?.warn?.(
+                `apple-mail: agent-run budget not persisted (${String(spend.error)}); the cap ` +
+                  `still holds for this process but will not survive a restart`,
+              );
+            }
             await dispatchAdmittedMessage(
               message,
               {
@@ -296,6 +308,7 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
               },
             );
           }
+          return undefined;
         },
         onError: (error) => ctx.log?.warn?.(`apple-mail poll failed: ${String(error)}`),
         checkBudget: () => budget.check(),
@@ -308,7 +321,9 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
           ),
         onTruncated: ({ mailbox, limit }) =>
           ctx.log?.warn?.(
-            `apple-mail: ${mailbox} had more than ${limit} unread messages; some were not read this cycle`,
+            `apple-mail: ${mailbox} had more than ${limit} unprocessed messages. Older mail ` +
+              `behind that ceiling was skipped and will not be retried, because the cursor ` +
+              `has moved past it. Raise maxLimit or poll a narrower mailbox.`,
           ),
       },
       {

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -323,11 +323,12 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
               `holding ${pending} message(s)` +
               (retryAtMs ? ` until ${new Date(retryAtMs).toISOString()}` : ""),
           ),
+        // Informational now, not a warning: the page is the oldest unprocessed mail, so a
+        // full one means the backlog is still draining, not that anything was skipped.
         onTruncated: ({ mailbox, limit }) =>
-          ctx.log?.warn?.(
-            `apple-mail: ${mailbox} had more than ${limit} unprocessed messages. Older mail ` +
-              `behind that ceiling was skipped and will not be retried, because the cursor ` +
-              `has moved past it. Raise maxLimit or poll a narrower mailbox.`,
+          ctx.log?.info?.(
+            `apple-mail: ${mailbox} returned a full page of ${limit}; more unprocessed mail ` +
+              `remains and will be read next cycle`,
           ),
       },
       {

--- a/openclaw/src/mail-channel/inbound.test.ts
+++ b/openclaw/src/mail-channel/inbound.test.ts
@@ -221,3 +221,60 @@ describe("classifyMessage", () => {
     assert.notEqual(r.decision.reason, "thread_originated_by_agent");
   });
 });
+
+// Codex: a denied thread claim must not still be honoured for session scoping. Otherwise a
+// stranger who quotes a leaked Message-ID lands in the session of the person the agent was
+// really talking to, and reads their history.
+describe("thread key and session isolation", () => {
+  const records = [
+    {
+      inboundAnchorIds: ["known-thread@example.com"],
+      addressedRecipients: ["omar@shahine.com"],
+    },
+  ];
+  const deps = {
+    listMessages: async () => [],
+    authCheck: async () => ({
+      verdict: "untrusted" as const,
+      sender: "intruder@evil.example",
+      checks: {
+        dkim: { result: "pass", signingDomain: "evil.example", match: false },
+        spf: { result: "pass", mailFrom: "b@evil.example", aligned: true, match: true },
+      },
+    }),
+    readThreadHeaders: async () => ({ references: ["known-thread@example.com"] }),
+  };
+
+  it("does not file a denied claimant into the thread's session", async () => {
+    const result = await classifyMessage(
+      { messageId: "intrusion", sender: "intruder@evil.example" },
+      deps,
+      { minIdentifierAuthentication: "asserted", threadRecords: records },
+    );
+    assert.equal(result.decision.admission, "observe", "authenticated stranger, readable");
+    assert.equal(
+      result.threadKey,
+      "intrusion",
+      "must get its own session, not the one it claimed",
+    );
+  });
+
+  it("does file a real participant into it", async () => {
+    const result = await classifyMessage(
+      { messageId: "reply", sender: "omar@shahine.com" },
+      {
+        ...deps,
+        authCheck: async () => ({
+          verdict: "untrusted" as const,
+          sender: "omar@shahine.com",
+          checks: {
+            dkim: { result: "pass", signingDomain: "shahine.com", match: false },
+            spf: { result: "pass", mailFrom: "o@shahine.com", aligned: true, match: true },
+          },
+        }),
+      },
+      { minIdentifierAuthentication: "asserted", threadRecords: records },
+    );
+    assert.equal(result.threadKey, "known-thread@example.com");
+  });
+});

--- a/openclaw/src/mail-channel/inbound.ts
+++ b/openclaw/src/mail-channel/inbound.ts
@@ -35,8 +35,18 @@ export type MessageThreadHeaders = {
 };
 
 export type InboundDeps = {
-  /** Lists candidate messages, newest first. */
-  listMessages: (params: { mailbox: string; limit: number }) => Promise<MailboxMessage[]>;
+  /**
+   * Lists candidate messages.
+   *
+   * With `since`, returns the *oldest* messages at or after that timestamp; without it, the
+   * newest. The poll loop always passes its cursor, so it pages forward through the backlog
+   * rather than repeatedly grabbing whatever just arrived.
+   */
+  listMessages: (params: {
+    mailbox: string;
+    limit: number;
+    since?: string;
+  }) => Promise<MailboxMessage[]>;
   /** Runs `mail-cli auth-check` for one message. */
   authCheck: (messageId: string) => Promise<MailAuthCheckResult>;
   /** Reads References / In-Reply-To for one message. */

--- a/openclaw/src/mail-channel/inbound.ts
+++ b/openclaw/src/mail-channel/inbound.ts
@@ -195,10 +195,14 @@ export async function classifyMessage(
       records,
     );
     threadPermitted = thread.permitted;
-    // Session scoping follows a resolved thread even when the reply is not permitted: a
-    // denied message still belongs to that conversation, and filing it elsewhere would
-    // split the agent's view of it.
-    threadKey = thread.matchedMessageId ?? threadKey;
+    // Only a *permitted* thread claim sets the session key. `decideThreadReply` also returns
+    // the matched id when it denies, and adopting that would let an authenticated stranger
+    // who quotes a leaked Message-ID be filed into the session of the person the agent was
+    // actually talking to, reading their history. Denying the reply while honouring the
+    // claim for session scoping hands over exactly what the denial was protecting.
+    if (thread.permitted && thread.matchedMessageId) {
+      threadKey = thread.matchedMessageId;
+    }
   }
 
   return {

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -78,24 +78,58 @@ describe("runPollCycle", () => {
 
   // Greptile P1: newest-first paging stops short of the cursor when a burst arrives, and
   // advancing the watermark from that subset would skip the rest permanently.
-  it("widens the page to reach back past the cursor", async () => {
+  // Greptile P1: listing newest-first meant a flood of new mail could push an older
+  // unprocessed message past the row limit permanently. The page now starts at the cursor
+  // and walks forward, so the backlog's oldest end is always what gets read.
+  it("pages forward from the cursor rather than grabbing the newest page", async () => {
     const store = memoryStore();
     await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
-    const burst = Array.from({ length: 7 }, (_, i) =>
-      msg(`b${i}`, `2026-07-28T10:0${i}:00.000Z`),
-    );
-    let lastLimit = 0;
+    let sinceSeen: string | undefined;
     const d: InboundDeps = {
-      listMessages: async ({ limit }) => {
-        lastLimit = limit;
-        return burst.slice(-limit);
+      listMessages: async ({ since, limit }) => {
+        sinceSeen = since;
+        return [msg("old", "2026-07-28T09:30:00.000Z")].slice(0, limit);
       },
       authCheck: async () => VERIFIED,
     };
-    const r = await runPollCycle(d, { ...OPTIONS, limit: 2, maxLimit: 64 }, store);
-    assert.ok(lastLimit > 2, "should have widened past the initial limit");
-    assert.equal(r.classified.length, 7);
-    assert.equal(r.truncated, false);
+    await runPollCycle(d, { ...OPTIONS, limit: 2 }, store);
+    assert.equal(sinceSeen, "2026-07-28T09:00:00.000Z", "the cursor bounds the listing");
+  });
+
+  it("takes the newest page on a cold start, not the whole mailbox history", async () => {
+    let sinceSeen: string | undefined = "unset";
+    const d: InboundDeps = {
+      listMessages: async ({ since }) => {
+        sinceSeen = since;
+        return [];
+      },
+      authCheck: async () => VERIFIED,
+    };
+    const r = await runPollCycle(d, OPTIONS, memoryStore());
+    assert.equal(sinceSeen, undefined, "no cursor means no --since, so the CLI's newest page");
+    assert.equal(r.truncated, false, "and a cold start is never truncated");
+  });
+
+  // A flood cannot bury older mail now: the flood is *newer*, so it sorts behind the
+  // backlog and simply waits its turn.
+  it("reads the oldest unprocessed mail even when newer mail floods in", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
+    const pending = msg("legitimate", "2026-07-28T09:30:00.000Z");
+    const flood = Array.from({ length: 500 }, (_, i) => msg(`spam${i}`, "2026-07-28T23:00:00.000Z"));
+    const d: InboundDeps = {
+      // The engine returns oldest-first when `since` is set, which is the contract the
+      // CLI now implements.
+      listMessages: async ({ limit }) => [pending, ...flood].slice(0, limit),
+      authCheck: async () => VERIFIED,
+    };
+    const r = await runPollCycle(d, { ...OPTIONS, limit: 2 }, store);
+    assert.equal(
+      r.classified[0]?.message.messageId,
+      "legitimate",
+      "the pending message is read first, not buried under the flood",
+    );
+    assert.equal(r.truncated, true, "and the rest is reported as still pending");
   });
 
   it("flags truncation instead of silently skipping when the ceiling is hit", async () => {

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -257,9 +257,12 @@ describe("runPollLoop", () => {
     assert.deepEqual(delivered, ["a"]);
   });
 
-  // Greptile P1: reporting truncation was not enough; the cursor still advanced past the
-  // mail still sitting behind the ceiling.
-  it("does not advance the cursor on a truncated cycle", async () => {
+  // Holding the cursor here was an earlier fix and it was wrong, as Codex pointed out.
+  // Listing is newest-first, so a held cursor re-lists and redelivers the same newest page
+  // every cycle and *still* never reaches the older mail, because the page can only grow
+  // back from now. Advancing turns unbounded duplicate delivery plus loss into loss, once,
+  // reported loudly.
+  it("advances the cursor on a truncated cycle, bounding loss instead of looping", async () => {
     const store = memoryStore();
     await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
     const before = store.values.get(OPTIONS.cursorKey);
@@ -281,12 +284,20 @@ describe("runPollLoop", () => {
       signal,
     );
     assert.equal(truncations, 1);
-    assert.deepEqual(store.values.get(OPTIONS.cursorKey), before);
+    assert.notDeepEqual(
+      store.values.get(OPTIONS.cursorKey),
+      before,
+      "cursor must move, or this page is redelivered forever and the backlog is still lost",
+    );
+    assert.equal(
+      store.values.get(OPTIONS.cursorKey)?.lastDateReceived,
+      "2026-07-28T11:00:00.000Z",
+    );
   });
 
   // A truncated cycle must still sleep. An earlier version used `continue`, which skipped
   // the sleep and spun a tight infinite loop; the only symptom was a hanging test run.
-  it("holds the cursor on truncation without spinning the loop", async () => {
+  it("reports truncation and still advances, without spinning the loop", async () => {
     const store = memoryStore();
     // Seed a prior cursor: truncation is only possible once there is a watermark to fall
     // short of. A cold start deliberately takes the page as-is.
@@ -319,10 +330,10 @@ describe("runPollLoop", () => {
       controller.signal,
     );
     assert.equal(sleeps, 2, "each truncated cycle must reach the sleep");
-    assert.deepEqual(
+    assert.notDeepEqual(
       store.values.get(OPTIONS.cursorKey),
       seeded,
-      "cursor must not advance past a truncated page",
+      "the cursor advances; truncation is reported, not held",
     );
   });
 

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -373,3 +373,101 @@ describe("runPollLoop", () => {
     assert.equal(maxInFlight, 1);
   });
 });
+
+// The breaker has to defer, not discard. Holding the cursor costs a re-classification next
+// cycle; advancing it would lose an operator's mail to a burst of newsletters.
+describe("circuit breaker", () => {
+  const message = {
+    messageId: "m1",
+    sender: "omar@shahine.com",
+    dateReceived: "2026-07-29T10:00:00Z",
+  };
+
+  function loopDeps(allowed: boolean) {
+    const registered: unknown[] = [];
+    const admitted: string[] = [];
+    const throttled: { pending: number }[] = [];
+    const controller = new AbortController();
+    return {
+      registered,
+      admitted,
+      throttled,
+      controller,
+      run: () =>
+        runPollLoop(
+          {
+            listMessages: async () => [message],
+            authCheck: async () => ({
+              verdict: "verified" as const,
+              sender: "omar@shahine.com",
+              checks: {
+                dkim: { result: "pass", signingDomain: "shahine.com", match: true },
+                spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+              },
+            }),
+            onAdmitted: async (m) => {
+              admitted.push(...m.map((e) => e.message.messageId));
+            },
+            checkBudget: () => ({ allowed, window: "hour", retryAtMs: 1 }),
+            onThrottled: (p) => throttled.push(p),
+            sleep: async () => controller.abort(),
+          },
+          {
+            mailbox: "INBOX",
+            limit: 10,
+            cursorKey: "k",
+            intervalMs: 1,
+            classify: { minIdentifierAuthentication: "asserted" },
+          },
+          {
+            lookup: async () => undefined,
+            register: async (_k, v) => {
+              registered.push(v);
+            },
+          },
+          controller.signal,
+        ),
+    };
+  }
+
+  it("delivers and advances the cursor when the breaker is closed", async () => {
+    const t = loopDeps(true);
+    await t.run();
+    assert.deepEqual(t.admitted, ["m1"]);
+    assert.equal(t.registered.length, 1, "cursor persisted");
+    assert.deepEqual(t.throttled, []);
+  });
+
+  it("holds the cursor and delivers nothing when the breaker is open", async () => {
+    const t = loopDeps(false);
+    await t.run();
+    assert.deepEqual(t.admitted, [], "no agent run");
+    assert.deepEqual(t.registered, [], "cursor held, so the batch is retried not lost");
+    assert.deepEqual(t.throttled, [{ window: "hour", retryAtMs: 1, pending: 1 }]);
+  });
+
+  it("does not report throttling when there is nothing to deliver", async () => {
+    const controller = new AbortController();
+    const throttled: unknown[] = [];
+    await runPollLoop(
+      {
+        listMessages: async () => [],
+        authCheck: async () => ({ verdict: "verified" as const }),
+        onAdmitted: async () => {},
+        checkBudget: () => ({ allowed: false, window: "hour" }),
+        onThrottled: (p) => throttled.push(p),
+        sleep: async () => controller.abort(),
+      },
+      {
+        mailbox: "INBOX",
+        limit: 10,
+        cursorKey: "k",
+        intervalMs: 1,
+        classify: { minIdentifierAuthentication: "asserted" },
+      },
+      { lookup: async () => undefined, register: async () => {} },
+      controller.signal,
+    );
+    assert.deepEqual(throttled, []);
+  });
+});

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -482,3 +482,100 @@ describe("circuit breaker", () => {
     assert.deepEqual(throttled, []);
   });
 });
+
+// Codex, second pass: holding the whole cursor on a partial batch replayed everything
+// already delivered, and could starve the undelivered tail forever if the batch kept
+// exceeding the budget. Oldest-first dispatch makes a partial cursor expressible.
+describe("partial delivery", () => {
+  function boundedSignal(cycles: number) {
+    const controller = new AbortController();
+    let seen = 0;
+    return {
+      signal: controller.signal,
+      sleep: async () => {
+        seen += 1;
+        if (seen >= cycles) {
+          controller.abort();
+        }
+      },
+    };
+  }
+
+  it("hands messages to the delivery callback oldest first", async () => {
+    const { signal, sleep } = boundedSignal(1);
+    const seen: string[] = [];
+    await runPollLoop(
+      {
+        listMessages: async () => [
+          msg("newest", "2026-07-28T12:00:00.000Z"),
+          msg("oldest", "2026-07-28T10:00:00.000Z"),
+          msg("middle", "2026-07-28T11:00:00.000Z"),
+        ],
+        authCheck: async () => VERIFIED,
+        onAdmitted: (messages) => {
+          seen.push(...messages.map((m) => m.message.messageId));
+        },
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      memoryStore(),
+      signal,
+    );
+    assert.deepEqual(seen, ["oldest", "middle", "newest"]);
+  });
+
+  it("advances the cursor through the delivered prefix only", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(1);
+    await runPollLoop(
+      {
+        listMessages: async () => [
+          msg("a", "2026-07-28T10:00:00.000Z"),
+          msg("b", "2026-07-28T11:00:00.000Z"),
+          msg("c", "2026-07-28T12:00:00.000Z"),
+        ],
+        authCheck: async () => VERIFIED,
+        // Budget runs out after two.
+        onAdmitted: () => ({ completed: 2 }),
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    const cursor = store.values.get(OPTIONS.cursorKey);
+    assert.equal(
+      cursor?.lastDateReceived,
+      "2026-07-28T11:00:00.000Z",
+      "cursor sits at the last delivered message, not the last listed one",
+    );
+  });
+
+  it("redelivers neither the prefix nor loses the suffix across cycles", async () => {
+    const store = memoryStore();
+    const { signal, sleep } = boundedSignal(2);
+    const delivered: string[] = [];
+    let cycle = 0;
+    await runPollLoop(
+      {
+        listMessages: async () => [
+          msg("a", "2026-07-28T10:00:00.000Z"),
+          msg("b", "2026-07-28T11:00:00.000Z"),
+          msg("c", "2026-07-28T12:00:00.000Z"),
+        ],
+        authCheck: async () => VERIFIED,
+        onAdmitted: (messages) => {
+          cycle += 1;
+          const budget = cycle === 1 ? 2 : messages.length;
+          delivered.push(...messages.slice(0, budget).map((m) => m.message.messageId));
+          return { completed: budget };
+        },
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    assert.deepEqual(delivered, ["a", "b", "c"], "each message delivered exactly once");
+  });
+});

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -579,3 +579,69 @@ describe("partial delivery", () => {
     assert.deepEqual(delivered, ["a", "b", "c"], "each message delivered exactly once");
   });
 });
+
+// Codex, third pass: cursorThrough built a cursor from the delivered slice alone. A prefix
+// of only undated messages then produced no watermark at all, resetting the cursor to cold
+// and redelivering every dated message in the mailbox.
+describe("partial cursor merges with the previous one", () => {
+  function boundedSignal(cycles: number) {
+    const controller = new AbortController();
+    let seen = 0;
+    return {
+      signal: controller.signal,
+      sleep: async () => {
+        seen += 1;
+        if (seen >= cycles) {
+          controller.abort();
+        }
+      },
+    };
+  }
+
+  async function runOnce(store: ReturnType<typeof memoryStore>, messages: MailboxMessage[], completed: number) {
+    const { signal, sleep } = boundedSignal(1);
+    await runPollLoop(
+      {
+        listMessages: async () => messages,
+        authCheck: async () => VERIFIED,
+        onAdmitted: () => ({ completed }),
+        sleep,
+      },
+      { ...OPTIONS, intervalMs: 1 },
+      store,
+      signal,
+    );
+    return store.values.get(OPTIONS.cursorKey);
+  }
+
+  it("keeps the existing watermark when the delivered prefix is undated", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T09:00:00.000Z" });
+    const undated = { messageId: "u1", sender: "a@example.com" } as MailboxMessage;
+    const cursor = await runOnce(store, [undated, msg("dated", "2026-07-28T12:00:00.000Z")], 1);
+    assert.equal(
+      cursor?.lastDateReceived,
+      "2026-07-28T09:00:00.000Z",
+      "watermark must not be erased by an undated-only prefix",
+    );
+    assert.deepEqual(cursor?.seenUndated, ["u1"]);
+  });
+
+  it("never moves the watermark backwards", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, { lastDateReceived: "2026-07-28T15:00:00.000Z" });
+    const cursor = await runOnce(store, [msg("old", "2026-07-28T16:00:00.000Z")], 0);
+    assert.equal(cursor?.lastDateReceived, "2026-07-28T15:00:00.000Z");
+  });
+
+  it("carries prior undated ids forward", async () => {
+    const store = memoryStore();
+    await store.register(OPTIONS.cursorKey, {
+      lastDateReceived: "2026-07-28T09:00:00.000Z",
+      seenUndated: ["older-undated"],
+    });
+    const undated = { messageId: "u2", sender: "a@example.com" } as MailboxMessage;
+    const cursor = await runOnce(store, [undated, msg("d", "2026-07-28T12:00:00.000Z")], 1);
+    assert.deepEqual(cursor?.seenUndated, ["older-undated", "u2"]);
+  });
+});

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -128,6 +128,14 @@ export type PollLoopDeps = {
   onError?: (error: unknown) => void;
   /** Reports that the page ceiling was hit with unread mail still behind it. */
   onTruncated?: (params: { mailbox: string; limit: number }) => void;
+  /**
+   * Whether the agent may run at all this cycle. Returns a refusal when the circuit breaker
+   * is open, which holds the cursor rather than discarding the batch: a burst is deferred,
+   * never lost.
+   */
+  checkBudget?: () => { allowed: boolean; window?: string; retryAtMs?: number };
+  /** Reports a cycle skipped because the breaker was open. */
+  onThrottled?: (params: { window?: string; retryAtMs?: number; pending: number }) => void;
   /** Injected so tests do not wait in real time. */
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
 };
@@ -173,6 +181,23 @@ export async function runPollLoop(
         await deps.onDropped?.(dropped);
       }
       const admitted = classified.filter((entry) => entry.decision.admission !== "drop");
+      // The breaker is consulted only when there is something to spend budget on, so a quiet
+      // mailbox never reports itself throttled.
+      const budget = admitted.length > 0 ? (deps.checkBudget?.() ?? { allowed: true }) : { allowed: true };
+      if (!budget.allowed) {
+        // Hold the cursor. Reclassifying this page next cycle costs an auth-check per
+        // message, which is the right price for not losing an operator's mail to a burst
+        // of newsletters.
+        deps.onThrottled?.({
+          window: budget.window,
+          retryAtMs: budget.retryAtMs,
+          pending: admitted.length,
+        });
+        if (!signal.aborted) {
+          await sleep(options.intervalMs, signal);
+        }
+        continue;
+      }
       if (admitted.length > 0) {
         // Deliver first. If this throws, the cursor is left untouched and the batch is
         // retried next cycle rather than silently skipped.

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -97,44 +97,36 @@ function cursorThrough(
 const MAX_SEEN_UNDATED_CURSOR = 200;
 
 /**
- * Lists far enough back to reach the previous cursor.
+ * Lists the oldest unprocessed messages, paging forward from the cursor.
  *
- * Listing is newest-first with a limit, so if more than `limit` messages arrive between
- * cycles the page stops short of the cursor and everything behind it would be skipped
- * forever once the watermark advanced. This widens the page until it reaches back past the
- * cursor, the page is no longer full, or the ceiling is hit.
+ * This used to list newest-first and widen the page until it reached back past the cursor.
+ * That could not work: the page grows backwards from *now*, so once more than `maxLimit`
+ * messages sat between the cursor and the present, older mail was unreachable no matter what
+ * the loop did. Advancing skipped it, holding redelivered the newest page forever, and
+ * either way anyone who could flood the mailbox could push a real message out of reach.
  *
- * With no cursor yet the page is taken as-is: a first run starts from now rather than
- * ingesting the entire mailbox history.
+ * Passing the cursor as `--since` inverts it: the page starts at the backlog's oldest end
+ * and walks forward, so a flood delays delivery by a cycle or two and never prevents it.
+ * Truncation stops being a correctness problem and becomes ordinary paging.
+ *
+ * With no cursor yet the page is taken as-is, newest-first: a first run starts from now
+ * rather than ingesting the entire mailbox history.
  */
 async function listBackToCursor(
   deps: InboundDeps,
   options: PollOptions,
   previousWatermark: string | undefined,
 ): Promise<{ messages: MailboxMessage[]; truncated: boolean }> {
-  const ceiling = options.maxLimit ?? DEFAULT_MAX_LIMIT;
-  let limit = options.limit;
-  let messages = await deps.listMessages({ mailbox: options.mailbox, limit });
+  const limit = options.limit;
+  const messages = await deps.listMessages({
+    mailbox: options.mailbox,
+    limit,
+    since: previousWatermark,
+  });
 
-  if (!previousWatermark) {
-    return { messages, truncated: false };
-  }
-
-  while (messages.length >= limit && limit < ceiling) {
-    const dates = messages.map((m) => m.dateReceived).filter(Boolean) as string[];
-    const oldest = dates.sort()[0];
-    if (oldest && oldest <= previousWatermark) {
-      // The page now spans the cursor, so nothing is hiding behind it.
-      return { messages, truncated: false };
-    }
-    limit = Math.min(limit * 4, ceiling);
-    messages = await deps.listMessages({ mailbox: options.mailbox, limit });
-  }
-
-  const dates = messages.map((m) => m.dateReceived).filter(Boolean) as string[];
-  const oldest = dates.sort()[0];
-  const stillShort = messages.length >= limit && !!oldest && oldest > previousWatermark;
-  return { messages, truncated: stillShort };
+  // A full page means there is more behind it. That is now just "more to do next cycle",
+  // not mail at risk: the next page starts where this one ended.
+  return { messages, truncated: !!previousWatermark && messages.length >= limit };
 }
 
 /**

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -49,6 +49,26 @@ export type PollCycleResult = {
 const DEFAULT_MAX_LIMIT = 500;
 
 /**
+ * A cursor covering exactly the messages handed in, for a partially delivered batch.
+ *
+ * Undated messages are recorded by id, because they cannot be placed against a watermark
+ * and would otherwise be redelivered on every cycle.
+ */
+function cursorThrough(delivered: readonly ClassifiedMessage[]): PollCursor {
+  const dates = delivered.map((e) => e.message.dateReceived).filter(Boolean) as string[];
+  const highest = dates.sort().at(-1);
+  return {
+    lastDateReceived: highest,
+    seenAtWatermark: delivered
+      .filter((e) => e.message.dateReceived && e.message.dateReceived === highest)
+      .map((e) => e.message.messageId),
+    seenUndated: delivered
+      .filter((e) => !e.message.dateReceived)
+      .map((e) => e.message.messageId),
+  };
+}
+
+/**
  * Lists far enough back to reach the previous cursor.
  *
  * Listing is newest-first with a limit, so if more than `limit` messages arrive between
@@ -117,13 +137,17 @@ export type PollLoopDeps = {
   /**
    * Called with the messages a cycle admitted. Dropped messages never reach it.
    *
-   * May return `{ deferred }` to say it stopped early, which holds the cursor so the
-   * untouched messages are retried. The budget is per run, not per batch, so a batch that
-   * exhausts it mid-way must not let the cursor move past what it never delivered.
+   * Receives messages **oldest first**, and may return `{ completed }` to say it stopped
+   * early. The cursor then advances through exactly the completed prefix, so the untouched
+   * suffix is retried next cycle and the delivered prefix is not.
+   *
+   * Oldest-first is what makes a partial cursor expressible. Dispatching newest-first would
+   * leave the undelivered messages *behind* the watermark, where advancing loses them and
+   * holding replays everything already delivered.
    */
   onAdmitted: (
     messages: ClassifiedMessage[],
-  ) => Promise<void | { deferred: number }> | void | { deferred: number };
+  ) => Promise<void | { completed: number }> | void | { completed: number };
   /**
    * Called with the messages a cycle refused, before the cursor moves past them.
    *
@@ -206,14 +230,22 @@ export async function runPollLoop(
         }
         continue;
       }
-      let deferred = 0;
+      let partialCursor: PollCursor | undefined;
       if (admitted.length > 0) {
+        // Oldest first, so a partial delivery has a cursor that can describe it.
+        const ordered = [...admitted].sort((a, b) =>
+          (a.message.dateReceived ?? "").localeCompare(b.message.dateReceived ?? ""),
+        );
         // Deliver first. If this throws, the cursor is left untouched and the batch is
         // retried next cycle rather than silently skipped.
-        const outcome = await deps.onAdmitted(admitted);
-        deferred = outcome?.deferred ?? 0;
-        if (deferred > 0) {
-          deps.onThrottled?.({ pending: deferred });
+        const outcome = await deps.onAdmitted(ordered);
+        const completed = outcome?.completed ?? ordered.length;
+        if (completed < ordered.length) {
+          deps.onThrottled?.({ pending: ordered.length - completed });
+          // Advance only through what was delivered. Holding everything would replay the
+          // delivered prefix on every retry and, if the batch keeps exceeding the budget,
+          // starve the suffix forever.
+          partialCursor = cursorThrough(ordered.slice(0, completed));
         }
       }
       // Truncation advances the cursor even though mail behind the ceiling was never
@@ -227,9 +259,11 @@ export async function runPollLoop(
       // A deferred batch is different and is genuinely retryable, so its cursor is held.
       //
       // Deliberately not `continue`: that would skip the sleep below and spin the loop.
-      if (deferred === 0) {
-        await store.register(options.cursorKey, cursor);
-      }
+      // A partial cursor wins over the full one, and over truncation: it describes exactly
+      // what was delivered, which is the only claim safe to persist. When it is absent the
+      // full cursor applies, truncated or not, because a fully delivered page has nothing
+      // left to retry and holding it would re-list the same newest page forever.
+      await store.register(options.cursorKey, partialCursor ?? cursor);
     } catch (error) {
       deps.onError?.(error);
     }

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -114,8 +114,16 @@ export async function runPollCycle(
 }
 
 export type PollLoopDeps = {
-  /** Called with the messages a cycle admitted. Dropped messages never reach it. */
-  onAdmitted: (messages: ClassifiedMessage[]) => Promise<void> | void;
+  /**
+   * Called with the messages a cycle admitted. Dropped messages never reach it.
+   *
+   * May return `{ deferred }` to say it stopped early, which holds the cursor so the
+   * untouched messages are retried. The budget is per run, not per batch, so a batch that
+   * exhausts it mid-way must not let the cursor move past what it never delivered.
+   */
+  onAdmitted: (
+    messages: ClassifiedMessage[],
+  ) => Promise<void | { deferred: number }> | void | { deferred: number };
   /**
    * Called with the messages a cycle refused, before the cursor moves past them.
    *
@@ -198,19 +206,28 @@ export async function runPollLoop(
         }
         continue;
       }
+      let deferred = 0;
       if (admitted.length > 0) {
         // Deliver first. If this throws, the cursor is left untouched and the batch is
         // retried next cycle rather than silently skipped.
-        await deps.onAdmitted(admitted);
+        const outcome = await deps.onAdmitted(admitted);
+        deferred = outcome?.deferred ?? 0;
+        if (deferred > 0) {
+          deps.onThrottled?.({ pending: deferred });
+        }
       }
-      // Reporting truncation is not enough. The cursor derives from a newest-first
-      // partial page, so persisting it would bury the older mail still behind the
-      // ceiling. Holding it reprocesses this page next cycle, which is duplicates
-      // instead of loss, and truncation keeps being reported until the backlog drains
-      // or the operator raises maxLimit.
+      // Truncation advances the cursor even though mail behind the ceiling was never
+      // examined. Holding it instead looks safer and is worse: listing is newest-first, so
+      // a held cursor re-lists the same newest page every cycle, redelivers it every cycle,
+      // and still never reaches the older mail, because the page can only ever grow up to
+      // `maxLimit` back from *now*. That is unbounded duplicate delivery plus the same loss.
+      // Advancing bounds it to loss, once, reported loudly enough for the operator to raise
+      // `maxLimit` or narrow the mailbox.
+      //
+      // A deferred batch is different and is genuinely retryable, so its cursor is held.
       //
       // Deliberately not `continue`: that would skip the sleep below and spin the loop.
-      if (!truncated) {
+      if (deferred === 0) {
         await store.register(options.cursorKey, cursor);
       }
     } catch (error) {

--- a/openclaw/src/mail-channel/poll.ts
+++ b/openclaw/src/mail-channel/poll.ts
@@ -49,24 +49,52 @@ export type PollCycleResult = {
 const DEFAULT_MAX_LIMIT = 500;
 
 /**
- * A cursor covering exactly the messages handed in, for a partially delivered batch.
+ * A cursor covering the previous one plus exactly the messages handed in, for a partially
+ * delivered batch.
  *
- * Undated messages are recorded by id, because they cannot be placed against a watermark
- * and would otherwise be redelivered on every cycle.
+ * Merged with `previous` rather than built fresh. A prefix consisting only of undated
+ * messages has no watermark of its own, and returning one without `lastDateReceived` would
+ * reset the cursor to cold and redeliver every dated message in the mailbox. The same
+ * applies to `seenUndated`: dropping the inherited ids lets older undated mail replay.
+ *
+ * Undated messages are recorded by id, because they cannot be placed against a watermark.
  */
-function cursorThrough(delivered: readonly ClassifiedMessage[]): PollCursor {
+function cursorThrough(
+  previous: PollCursor,
+  delivered: readonly ClassifiedMessage[],
+): PollCursor {
   const dates = delivered.map((e) => e.message.dateReceived).filter(Boolean) as string[];
-  const highest = dates.sort().at(-1);
+  const deliveredHighest = dates.sort().at(-1);
+  // Never move the watermark backwards: a partial batch can only ever add to what the
+  // previous cursor already covered.
+  const highest =
+    deliveredHighest && (!previous.lastDateReceived || deliveredHighest > previous.lastDateReceived)
+      ? deliveredHighest
+      : previous.lastDateReceived;
+
+  const atWatermark = delivered
+    .filter((e) => e.message.dateReceived && e.message.dateReceived === highest)
+    .map((e) => e.message.messageId);
+
   return {
     lastDateReceived: highest,
-    seenAtWatermark: delivered
-      .filter((e) => e.message.dateReceived && e.message.dateReceived === highest)
-      .map((e) => e.message.messageId),
-    seenUndated: delivered
-      .filter((e) => !e.message.dateReceived)
-      .map((e) => e.message.messageId),
+    // Carry the prior ids forward when the watermark did not move, so a partial batch that
+    // adds nothing newer cannot erase the dedupe set for that instant.
+    seenAtWatermark:
+      highest && highest === previous.lastDateReceived
+        ? [...new Set([...(previous.seenAtWatermark ?? []), ...atWatermark])]
+        : atWatermark,
+    seenUndated: [
+      ...new Set([
+        ...(previous.seenUndated ?? []),
+        ...delivered.filter((e) => !e.message.dateReceived).map((e) => e.message.messageId),
+      ]),
+    ].slice(-MAX_SEEN_UNDATED_CURSOR),
   };
 }
+
+/** Mirrors the bound in `selectNewMessages`, which owns the same field. */
+const MAX_SEEN_UNDATED_CURSOR = 200;
 
 /**
  * Lists far enough back to reach the previous cursor.
@@ -202,6 +230,9 @@ export async function runPollLoop(
   const sleep = deps.sleep ?? defaultSleep;
   while (!signal.aborted) {
     try {
+      // Read once per cycle: the partial cursor has to be merged onto what was already
+      // persisted, not built from the delivered slice alone.
+      const previous = (await store.lookup(options.cursorKey)) ?? {};
       const { classified, cursor, truncated } = await runPollCycle(deps, options, store);
       if (truncated) {
         deps.onTruncated?.({ mailbox: options.mailbox, limit: options.maxLimit ?? DEFAULT_MAX_LIMIT });
@@ -245,7 +276,7 @@ export async function runPollLoop(
           // Advance only through what was delivered. Holding everything would replay the
           // delivered prefix on every retry and, if the batch keeps exceeding the budget,
           // starve the suffix forever.
-          partialCursor = cursorThrough(ordered.slice(0, completed));
+          partialCursor = cursorThrough(previous, ordered.slice(0, completed));
         }
       }
       // Truncation advances the cursor even though mail behind the ceiling was never

--- a/openclaw/src/mail-channel/quarantine.test.ts
+++ b/openclaw/src/mail-channel/quarantine.test.ts
@@ -15,6 +15,7 @@ import {
   quarantineMessage,
   quarantineReason,
   quarantineSnapshot,
+  filterQuarantinedResults,
   resetQuarantine,
 } from "../../lib/mail-quarantine.js";
 import { runPollLoop } from "./poll.ts";
@@ -27,7 +28,7 @@ describe("mail quarantine", () => {
   });
 
   it("refuses a message the channel dropped, naming why", () => {
-    quarantineMessage("<spoof@example.com>", "unauthenticated_sender");
+    quarantineMessage("acct", "<spoof@example.com>", "unauthenticated_sender");
     assert.throws(
       () => assertMailReadable("spoof@example.com", "read"),
       /did not admit it \(unauthenticated_sender\)/,
@@ -35,7 +36,7 @@ describe("mail quarantine", () => {
   });
 
   it("refuses attachments from it too", () => {
-    quarantineMessage("spoof@example.com", "identifier_authentication_too_weak");
+    quarantineMessage("acct", "spoof@example.com", "identifier_authentication_too_weak");
     assert.throws(
       () => assertMailReadable("spoof@example.com", "save an attachment from"),
       /Refusing to save an attachment from/,
@@ -43,37 +44,99 @@ describe("mail quarantine", () => {
   });
 
   it("matches regardless of brackets, case, or padding", () => {
-    quarantineMessage("<Spoof@Example.COM>", "unauthenticated_sender");
+    quarantineMessage("acct", "<Spoof@Example.COM>", "unauthenticated_sender");
     for (const variant of ["spoof@example.com", "<spoof@example.com>", "  SPOOF@EXAMPLE.com "]) {
       assert.equal(quarantineReason(variant), "unauthenticated_sender", variant);
     }
   });
 
   it("ignores an empty id rather than quarantining everything", () => {
-    quarantineMessage("", "unauthenticated_sender");
-    quarantineMessage("   ", "unauthenticated_sender");
-    assert.deepEqual(quarantineSnapshot(), []);
+    quarantineMessage("acct", "", "unauthenticated_sender");
+    quarantineMessage("acct", "   ", "unauthenticated_sender");
+    assert.deepEqual(quarantineSnapshot("acct"), []);
     assert.doesNotThrow(() => assertMailReadable("", "read"));
   });
 
   // A dropped message is never reclassified, because the cursor moves past it. If the set
   // did not survive a restart the refusal would silently expire.
   it("round-trips through storage", () => {
-    quarantineMessage("a@example.com", "unauthenticated_sender");
-    quarantineMessage("b@example.com", "self_addressed");
-    const saved = quarantineSnapshot();
+    quarantineMessage("acct", "a@example.com", "unauthenticated_sender");
+    quarantineMessage("acct", "b@example.com", "self_addressed");
+    const saved = quarantineSnapshot("acct");
 
     resetQuarantine();
     assert.doesNotThrow(() => assertMailReadable("a@example.com", "read"));
 
-    loadQuarantine(saved);
+    loadQuarantine("acct", saved);
     assert.throws(() => assertMailReadable("a@example.com", "read"));
     assert.throws(() => assertMailReadable("b@example.com", "read"));
   });
 
   it("survives an absent stored value", () => {
-    assert.doesNotThrow(() => loadQuarantine(undefined));
-    assert.deepEqual(quarantineSnapshot(), []);
+    assert.doesNotThrow(() => loadQuarantine("acct", undefined));
+    assert.deepEqual(quarantineSnapshot("acct"), []);
+  });
+
+  // Codex: one shared map meant a second account starting up replaced the first account's
+  // set, silently un-quarantining everything it had refused.
+  it("keeps accounts separate, and starting one does not clear another", () => {
+    quarantineMessage("work", "w@example.com", "unauthenticated_sender");
+    quarantineMessage("personal", "p@example.com", "unauthenticated_sender");
+
+    // Personal restarts and rehydrates. Work's refusals must survive.
+    loadQuarantine("personal", [["p@example.com", "unauthenticated_sender"]]);
+    assert.throws(() => assertMailReadable("w@example.com", "read"));
+    assert.throws(() => assertMailReadable("p@example.com", "read"));
+    assert.deepEqual(quarantineSnapshot("work"), [["w@example.com", "unauthenticated_sender"]]);
+  });
+
+  // The tool is handed an id and nothing else, and both accounts share one mailbox and one
+  // agent, so a refusal by either has to bind everywhere.
+  it("refuses across accounts, since the tool is not account-scoped", () => {
+    quarantineMessage("work", "w@example.com", "unauthenticated_sender");
+    assert.equal(quarantineReason("w@example.com"), "unauthenticated_sender");
+  });
+});
+
+// Codex: blocking `get` alone left `search --field content` as a content oracle. The agent
+// probes for a phrase and learns from the hit whether a quarantined message contains it,
+// without ever reading a body. Listings leak the envelope the same way.
+describe("filterQuarantinedResults", () => {
+  const payload = () => ({
+    count: 3,
+    messages: [
+      { messageId: "ok1", sender: "a@example.com", subject: "hello" },
+      { messageId: "spoofed", sender: "b@evil.example", subject: "secret phrase" },
+      { messageId: "ok2", sender: "c@example.com", subject: "hi" },
+    ],
+  });
+
+  it("passes results through untouched when nothing is quarantined", () => {
+    assert.deepEqual(filterQuarantinedResults(payload()), payload());
+  });
+
+  it("withholds a quarantined row and corrects the count", () => {
+    quarantineMessage("acct", "spoofed", "unauthenticated_sender");
+    const filtered = filterQuarantinedResults(payload());
+    assert.deepEqual(
+      filtered.messages.map((m: { messageId: string }) => m.messageId),
+      ["ok1", "ok2"],
+    );
+    assert.equal(filtered.count, 2, "count must match what was returned");
+  });
+
+  // A quietly short listing reads as an empty mailbox. The agent cannot tell "nothing
+  // matched" from "you may not see it" unless we say so.
+  it("says how many rows it withheld", () => {
+    quarantineMessage("acct", "spoofed", "unauthenticated_sender");
+    assert.equal(filterQuarantinedResults(payload()).withheldByChannelPolicy, 1);
+  });
+
+  it("leaves a non-listing payload alone", () => {
+    for (const shape of [undefined, null, {}, { success: true }, "text"]) {
+      assert.doesNotThrow(() => filterQuarantinedResults(shape));
+    }
+    assert.deepEqual(filterQuarantinedResults({ success: true }), { success: true });
   });
 });
 

--- a/openclaw/src/mail-channel/quarantine.test.ts
+++ b/openclaw/src/mail-channel/quarantine.test.ts
@@ -125,11 +125,24 @@ describe("filterQuarantinedResults", () => {
     assert.equal(filtered.count, 2, "count must match what was returned");
   });
 
-  // A quietly short listing reads as an empty mailbox. The agent cannot tell "nothing
-  // matched" from "you may not see it" unless we say so.
-  it("says how many rows it withheld", () => {
+  // A quietly short listing reads as an empty mailbox, so listings say what was withheld.
+  it("reports the withheld count when asked", () => {
     quarantineMessage("acct", "spoofed", "unauthenticated_sender");
-    assert.equal(filterQuarantinedResults(payload()).withheldByChannelPolicy, 1);
+    assert.equal(
+      filterQuarantinedResults(payload(), { reportWithheld: true }).withheldByChannelPolicy,
+      1,
+    );
+  });
+
+  // Codex, second pass: the count is itself an oracle for a search. "1 withheld" for
+  // `--field content "secret phrase"` confirms the phrase is in quarantined mail without
+  // returning it, which is the leak filtering the rows was meant to close.
+  it("stays silent about the count by default, since a query-dependent count leaks", () => {
+    quarantineMessage("acct", "spoofed", "unauthenticated_sender");
+    const filtered = filterQuarantinedResults(payload());
+    assert.equal(filtered.withheldByChannelPolicy, undefined);
+    assert.equal(filtered.messages.length, 2);
+    assert.equal(filtered.count, 2);
   });
 
   it("leaves a non-listing payload alone", () => {

--- a/openclaw/src/mail-channel/rate-limit.test.ts
+++ b/openclaw/src/mail-channel/rate-limit.test.ts
@@ -1,0 +1,156 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  checkBreaker,
+  DEFAULT_RATE_LIMITS,
+  recordRun,
+  resolveRateLimits,
+  RunBudget,
+  type BreakerState,
+} from "./rate-limit.ts";
+
+const T0 = Date.UTC(2026, 6, 29, 12, 0, 0);
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+
+const LIMITS = { perHour: 3, perDay: 5 };
+
+/** Builds state with runs at the given offsets (ms) before `now`. */
+function runsAgo(...offsets: number[]): BreakerState {
+  return { runs: offsets.map((o) => T0 - o).sort((a, b) => a - b) };
+}
+
+describe("checkBreaker", () => {
+  it("allows a run when nothing has happened", () => {
+    assert.equal(checkBreaker({ runs: [] }, LIMITS, T0).allowed, true);
+  });
+
+  it("allows up to the hourly limit", () => {
+    assert.equal(checkBreaker(runsAgo(MIN, 2 * MIN), LIMITS, T0).allowed, true);
+  });
+
+  it("trips at the hourly limit", () => {
+    const d = checkBreaker(runsAgo(MIN, 2 * MIN, 3 * MIN), LIMITS, T0);
+    assert.equal(d.allowed, false);
+    assert.equal(d.window, "hour");
+  });
+
+  // Recovery is when the oldest run ages out, not a fixed cooldown. A flat cooldown would
+  // either recover too early, re-opening the flood, or too late, stalling real mail.
+  it("recovers exactly when the oldest run leaves the window", () => {
+    const state = runsAgo(59 * MIN, 30 * MIN, 10 * MIN);
+    const d = checkBreaker(state, LIMITS, T0);
+    assert.equal(d.allowed, false);
+    assert.equal(d.retryAtMs, T0 - 59 * MIN + HOUR);
+
+    // One minute later that run is an hour old and the budget has room again.
+    assert.equal(checkBreaker(state, LIMITS, T0 + MIN + 1).allowed, true);
+  });
+
+  it("trips on the daily limit even when the hour is quiet", () => {
+    const state = runsAgo(20 * HOUR, 19 * HOUR, 18 * HOUR, 17 * HOUR, 16 * HOUR);
+    const d = checkBreaker(state, LIMITS, T0);
+    assert.equal(d.allowed, false);
+    assert.equal(d.window, "day");
+  });
+
+  it("reports the hour when both windows are full, since it recovers first", () => {
+    const state = runsAgo(20 * HOUR, 19 * HOUR, MIN, 2 * MIN, 3 * MIN);
+    assert.equal(checkBreaker(state, LIMITS, T0).window, "hour");
+  });
+
+  it("forgets runs older than a day", () => {
+    const state = runsAgo(25 * HOUR, 26 * HOUR, 27 * HOUR, 28 * HOUR, 29 * HOUR);
+    assert.equal(checkBreaker(state, LIMITS, T0).allowed, true);
+  });
+
+  it("treats a zero limit as closed", () => {
+    assert.equal(checkBreaker({ runs: [] }, { perHour: 0, perDay: 10 }, T0).allowed, false);
+  });
+});
+
+describe("recordRun", () => {
+  it("counts the run and prunes the expired ones", () => {
+    const state = recordRun(runsAgo(30 * HOUR, MIN), T0);
+    assert.deepEqual(state.runs, [T0 - MIN, T0]);
+  });
+
+  it("drives the breaker from allowed to tripped", () => {
+    let state: BreakerState = { runs: [] };
+    for (let i = 0; i < LIMITS.perHour; i += 1) {
+      assert.equal(checkBreaker(state, LIMITS, T0).allowed, true, `run ${i}`);
+      state = recordRun(state, T0);
+    }
+    assert.equal(checkBreaker(state, LIMITS, T0).allowed, false);
+  });
+});
+
+describe("resolveRateLimits", () => {
+  it("falls back to the defaults", () => {
+    assert.deepEqual(resolveRateLimits({}), DEFAULT_RATE_LIMITS);
+  });
+
+  it("takes configured values, including a deliberate zero", () => {
+    assert.deepEqual(resolveRateLimits({ maxAgentRunsPerHour: 0, maxAgentRunsPerDay: 7 }), {
+      perHour: 0,
+      perDay: 7,
+    });
+  });
+});
+
+describe("RunBudget", () => {
+  function store() {
+    const data = new Map<string, BreakerState>();
+    return {
+      data,
+      lookup: async (k: string) => data.get(k),
+      register: async (k: string, v: BreakerState) => {
+        data.set(k, v);
+      },
+    };
+  }
+
+  // A budget that resets on restart is not a budget: a crash loop would spend it repeatedly.
+  it("survives a restart", async () => {
+    const s = store();
+    let now = T0;
+    const first = new RunBudget(s, "acct", LIMITS, () => now);
+    await first.hydrate();
+    for (let i = 0; i < LIMITS.perHour; i += 1) {
+      await first.consume();
+    }
+
+    const second = new RunBudget(s, "acct", LIMITS, () => now);
+    await second.hydrate();
+    assert.equal(second.check().allowed, false);
+
+    // ...and opens again once the window rolls.
+    now = T0 + HOUR + 1;
+    assert.equal(second.check().allowed, true);
+  });
+
+  it("keeps accounts on separate budgets", async () => {
+    const s = store();
+    const a = new RunBudget(s, "work", LIMITS, () => T0);
+    const b = new RunBudget(s, "personal", LIMITS, () => T0);
+    await a.hydrate();
+    await b.hydrate();
+    for (let i = 0; i < LIMITS.perHour; i += 1) {
+      await a.consume();
+    }
+    assert.equal(a.check().allowed, false);
+    assert.equal(b.check().allowed, true);
+  });
+
+  // The breaker counts runs, not senders. Trip it with one sender and it stays tripped for
+  // the next, or ten senders would cost ten times the cap.
+  it("does not reset for a different sender", async () => {
+    const s = store();
+    const budget = new RunBudget(s, "acct", LIMITS, () => T0);
+    await budget.hydrate();
+    for (let i = 0; i < LIMITS.perHour; i += 1) {
+      await budget.consume();
+    }
+    assert.equal(budget.check().allowed, false);
+  });
+});

--- a/openclaw/src/mail-channel/rate-limit.test.ts
+++ b/openclaw/src/mail-channel/rate-limit.test.ts
@@ -154,3 +154,60 @@ describe("RunBudget", () => {
     assert.equal(budget.check().allowed, false);
   });
 });
+
+// Codex found the cap was checked once per batch and spent per message, so a batch of 25
+// against a budget with 1 left ran all 25. These pin the arithmetic the fix depends on.
+describe("batch spending", () => {
+  it("refuses partway through a batch rather than after it", () => {
+    let state: BreakerState = { runs: [] };
+    const batch = 25;
+    let ran = 0;
+    for (let i = 0; i < batch; i += 1) {
+      if (!checkBreaker(state, LIMITS, T0).allowed) {
+        break;
+      }
+      state = recordRun(state, T0);
+      ran += 1;
+    }
+    assert.equal(ran, LIMITS.perHour, "must stop at the cap, not at the batch size");
+    assert.equal(state.runs.length, LIMITS.perHour);
+  });
+
+  it("reports the untouched remainder so the caller can hold its cursor", () => {
+    let state: BreakerState = { runs: [] };
+    const batch = 10;
+    let index = 0;
+    for (; index < batch; index += 1) {
+      if (!checkBreaker(state, LIMITS, T0).allowed) {
+        break;
+      }
+      state = recordRun(state, T0);
+    }
+    assert.equal(batch - index, batch - LIMITS.perHour);
+  });
+});
+
+// A budget that un-counts when the store is unavailable is a budget an unavailable store
+// disables, which is backwards: bounding spend matters most when something is wrong.
+describe("persistence failure", () => {
+  it("keeps counting when the store throws, and says so", async () => {
+    const budget = new RunBudget(
+      {
+        lookup: async () => undefined,
+        register: async () => {
+          throw new Error("store offline");
+        },
+      },
+      "acct",
+      LIMITS,
+      () => T0,
+    );
+    await budget.hydrate();
+    for (let i = 0; i < LIMITS.perHour; i += 1) {
+      const outcome = await budget.consume();
+      assert.equal(outcome.persisted, false);
+      assert.match(String(outcome.error), /store offline/);
+    }
+    assert.equal(budget.check().allowed, false, "the cap still binds in-process");
+  });
+});

--- a/openclaw/src/mail-channel/rate-limit.ts
+++ b/openclaw/src/mail-channel/rate-limit.ts
@@ -131,8 +131,21 @@ export class RunBudget {
     return checkBreaker(this.#state, this.#limits, this.#now());
   }
 
-  async consume(): Promise<void> {
+  /**
+   * Counts one run.
+   *
+   * The in-memory count is authoritative and is never rolled back on a persistence failure.
+   * A budget that un-counts when the store is unavailable is a budget an unavailable store
+   * disables, which is exactly backwards: the whole point is to bound spend when something
+   * has gone wrong. Persistence failure costs durability across a restart, not the cap.
+   */
+  async consume(): Promise<{ persisted: boolean; error?: unknown }> {
     this.#state = recordRun(this.#state, this.#now());
-    await this.#store.register(this.#key, this.#state);
+    try {
+      await this.#store.register(this.#key, this.#state);
+      return { persisted: true };
+    } catch (error) {
+      return { persisted: false, error };
+    }
   }
 }

--- a/openclaw/src/mail-channel/rate-limit.ts
+++ b/openclaw/src/mail-channel/rate-limit.ts
@@ -1,0 +1,138 @@
+/**
+ * Circuit breaker on agent runs.
+ *
+ * Default-deny bounds *who* may drive the agent. It does not bound *how much*. One
+ * permitted correspondent, a mailing list that starts looping, or a bug in a mail rule can
+ * all produce unbounded model calls from an entirely authorized sender, and every control
+ * elsewhere in this channel will correctly wave each one through.
+ *
+ * So this counts runs rather than judging them. It is deliberately not a policy about
+ * senders: a breaker that trips per sender would let ten senders cost ten times as much,
+ * which is the failure it exists to prevent.
+ *
+ * When the breaker is open the poll loop holds its cursor rather than discarding the
+ * backlog, so a burst is deferred and not lost. That means the same mail is reclassified
+ * next cycle, which costs an auth-check per message and is the right trade: authentication
+ * is cheap, and losing an operator's mail because a newsletter flooded the mailbox is not a
+ * recoverable error.
+ */
+
+/** Runs allowed per window. Both apply; the tighter one binds. */
+export type RateLimits = {
+  perHour: number;
+  perDay: number;
+};
+
+/**
+ * Conservative rather than generous. A mail channel that legitimately needs more than a few
+ * dozen agent runs an hour is either very busy or misconfigured, and the operator should
+ * find out which by seeing the breaker trip rather than by seeing a bill.
+ */
+export const DEFAULT_RATE_LIMITS: RateLimits = { perHour: 30, perDay: 200 };
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Run timestamps, newest last. Persisted so a restart cannot reset the budget. */
+export type BreakerState = {
+  runs: readonly number[];
+};
+
+export type BreakerDecision = {
+  allowed: boolean;
+  /** Populated when refused, so the log says which limit bound and when it recovers. */
+  window?: "hour" | "day";
+  retryAtMs?: number;
+};
+
+/** Drops timestamps older than a day, which is the longest window anything here needs. */
+function prune(runs: readonly number[], nowMs: number): number[] {
+  const cutoff = nowMs - DAY_MS;
+  return runs.filter((at) => at > cutoff);
+}
+
+/**
+ * Decides whether one more agent run is permitted, without recording it.
+ *
+ * Split from `record` so a caller can check before doing expensive work and still only
+ * count runs that actually happened.
+ */
+export function checkBreaker(
+  state: BreakerState,
+  limits: RateLimits,
+  nowMs: number,
+): BreakerDecision {
+  const runs = prune(state.runs, nowMs);
+  const inHour = runs.filter((at) => at > nowMs - HOUR_MS);
+
+  if (inHour.length >= limits.perHour) {
+    // Recovery is when the oldest run in the window ages out, not a fixed cooldown: that is
+    // the moment the count actually drops below the limit.
+    return { allowed: false, window: "hour", retryAtMs: (inHour[0] ?? nowMs) + HOUR_MS };
+  }
+  if (runs.length >= limits.perDay) {
+    return { allowed: false, window: "day", retryAtMs: (runs[0] ?? nowMs) + DAY_MS };
+  }
+  return { allowed: true };
+}
+
+/** Returns the state with this run counted. Pure, so the caller owns persistence. */
+export function recordRun(state: BreakerState, nowMs: number): BreakerState {
+  return { runs: [...prune(state.runs, nowMs), nowMs] };
+}
+
+/** Reads limits off channel config, falling back to the defaults. */
+export function resolveRateLimits(config: {
+  maxAgentRunsPerHour?: number;
+  maxAgentRunsPerDay?: number;
+}): RateLimits {
+  return {
+    perHour: config.maxAgentRunsPerHour ?? DEFAULT_RATE_LIMITS.perHour,
+    perDay: config.maxAgentRunsPerDay ?? DEFAULT_RATE_LIMITS.perDay,
+  };
+}
+
+/** The subset of the plugin keyed store this needs. */
+export type BreakerStore = {
+  lookup(key: string): Promise<BreakerState | undefined>;
+  register(key: string, value: BreakerState): Promise<void>;
+};
+
+/**
+ * Process-local view over the durable budget.
+ *
+ * Held in memory and written on each run, because the count changes only here and reading
+ * it back per message would be a round trip inside the poll loop.
+ */
+export class RunBudget {
+  readonly #store: BreakerStore;
+  readonly #key: string;
+  readonly #limits: RateLimits;
+  readonly #now: () => number;
+  #state: BreakerState = { runs: [] };
+
+  constructor(
+    store: BreakerStore,
+    key: string,
+    limits: RateLimits,
+    now: () => number = () => Date.now(),
+  ) {
+    this.#store = store;
+    this.#key = key;
+    this.#limits = limits;
+    this.#now = now;
+  }
+
+  async hydrate(): Promise<void> {
+    this.#state = (await this.#store.lookup(this.#key)) ?? { runs: [] };
+  }
+
+  check(): BreakerDecision {
+    return checkBreaker(this.#state, this.#limits, this.#now());
+  }
+
+  async consume(): Promise<void> {
+    this.#state = recordRun(this.#state, this.#now());
+    await this.#store.register(this.#key, this.#state);
+  }
+}

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -88,13 +88,16 @@ export function createMailCliDeps(options: MailCliOptions): InboundDeps {
     : [];
 
   return {
-    listMessages: async ({ mailbox, limit }) => {
+    listMessages: async ({ mailbox, limit, since }) => {
       const result = await runJson<{ messages?: MailboxMessage[] }>(options, [
         "messages",
         "--mailbox",
         mailbox,
         "--limit",
         String(limit),
+        // Pages forward from the cursor. Without it the CLI returns the newest page, so a
+        // burst of new mail hides unprocessed older mail behind the row limit permanently.
+        ...(since ? ["--since", since] : []),
         ...accountArgs,
         "--engine",
         "sqlite",

--- a/swift/Sources/MailCLI/EnvelopeIndex.swift
+++ b/swift/Sources/MailCLI/EnvelopeIndex.swift
@@ -214,6 +214,10 @@ final class EnvelopeIndex {
         /// LIKE match against subject / sender / both.
         var queryText: String?
         var queryField: String = "all"
+        /// Oldest-first ordering. Newest-first answers "what just arrived"; oldest-first
+        /// answers "what have I not processed yet", which is the only one a cursor can page
+        /// through without a flood of new mail hiding the backlog behind the row limit.
+        var oldestFirst = false
     }
 
     func messages(filter: MessageFilter, limit: Int) throws -> [[String: Any]] {
@@ -257,7 +261,7 @@ final class EnvelopeIndex {
             SELECT \(Self.messageColumns)
             \(Self.messageJoins)
             WHERE \(conditions.joined(separator: " AND "))
-            ORDER BY m.date_received DESC
+            ORDER BY m.date_received \(filter.oldestFirst ? "ASC" : "DESC")
             LIMIT ?
             """
         binds.append(.int(Int64(limit)))

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -867,14 +867,35 @@ struct ListMessages: AsyncParsableCommand {
     @Option(name: .long, help: "Read engine: auto (SQLite with JXA fallback), sqlite, or jxa")
     var engine: EngineChoice = .auto
 
+    @Option(name: .long, help: "Only messages received at or after this ISO 8601 timestamp. Implies oldest-first.")
+    var since: String?
+
     func run() async throws {
         let config = pimOptions.loadConfig()
         try checkMailEnabled(config: config)
 
+        // `--since` exists for cursor-driven consumers. Newest-first answers "what just
+        // arrived"; a consumer working through a backlog needs "what have I not processed
+        // yet", and only oldest-first lets it page forward without a burst of new mail
+        // hiding older unprocessed messages behind the row limit. So --since implies it.
+        var sinceEpoch: Double?
+        if let since {
+            guard let epoch = epochFromISO8601(since) else {
+                throw CLIError.invalidInput(
+                    "Invalid date format for --since. Use ISO 8601: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ")
+            }
+            sinceEpoch = epoch
+        }
+
         if engine != .jxa {
             do {
                 outputJSON(try SQLiteEngine().messages(
-                    mailbox: mailbox, account: account, limit: limit, filter: filter))
+                    mailbox: mailbox,
+                    account: account,
+                    limit: limit,
+                    filter: filter,
+                    sinceEpoch: sinceEpoch,
+                    oldestFirst: sinceEpoch != nil))
                 return
             } catch {
                 try rethrowIfForcedSQLite(engine, error)

--- a/swift/Sources/MailCLI/SQLiteEngine.swift
+++ b/swift/Sources/MailCLI/SQLiteEngine.swift
@@ -128,7 +128,14 @@ struct SQLiteEngine {
         return ["success": true, "mailboxes": result, "engine": "sqlite"]
     }
 
-    func messages(mailbox: String, account: String?, limit: Int, filter: String?) throws -> [String: Any] {
+    func messages(
+        mailbox: String,
+        account: String?,
+        limit: Int,
+        filter: String?,
+        sinceEpoch: Double? = nil,
+        oldestFirst: Bool = false
+    ) throws -> [String: Any] {
         let refs = try resolveMailboxes(account: account, mailbox: mailbox)
         guard !refs.isEmpty else {
             throw EnvelopeIndexError.notFound("Mailbox not found: \(mailbox)")
@@ -136,6 +143,8 @@ struct SQLiteEngine {
         var messageFilter = EnvelopeIndex.MessageFilter(mailboxRowIDs: refs.map { $0.rowid })
         messageFilter.unreadOnly = filter == "unread"
         messageFilter.flaggedOnly = filter == "flagged"
+        messageFilter.sinceEpoch = sinceEpoch
+        messageFilter.oldestFirst = oldestFirst
 
         let rows = try index.messages(filter: messageFilter, limit: limit)
         let result = rows.map { summaryDict($0, includeJunkAndAttachments: true, includeLocation: false) }


### PR DESCRIPTION

---

## Review rounds

Codex reviewed this branch three times. It found **ten defects**, seven of them in code written earlier the same session. All are fixed; each round's fixes were re-reviewed rather than assumed.

### Round 1 — six defects

| | Defect |
|---|---|
| High | **The breaker capped nothing.** Budget checked once per batch, spent per message: 25 admitted messages against a budget with 1 left ran all 25. |
| High | **A second account erased the first's quarantine.** One module-global map, replaced on every account start. |
| High | **`search --field content` was a content oracle.** Blocking `get` left probing intact: ask for a phrase, learn from the hit whether quarantined mail contains it. Listings leaked envelopes the same way, so "drop never reaches the agent" was untrue. |
| High | **A denied thread claim still set the session key.** An authenticated stranger quoting a leaked Message-ID was filed into the session of the person the agent was really talking to. The comment asserting this could not happen was false. |
| Medium | **Truncation looped forever.** Holding the cursor past the page ceiling re-listed and redelivered the same newest page every cycle and *still* never reached older mail. The comment claimed the backlog would drain; nothing drained it. |
| Medium | **A failed budget write un-counted the run.** Counted, then not dispatched, then retried and counted again. |

### Round 2 — three of those only partly fixed

- **Deferred batches replayed their delivered prefix**, and could starve the tail indefinitely. Root cause was dispatch order: newest-first leaves the remainder *older* than any watermark the cursor can express. Now sorted oldest-first with a `{completed}` prefix cursor.
- **`admittedHandler` skipped the breaker entirely.** Moved inside the budget loop.
- **The withheld count was itself an oracle.** `1 withheld` for a content search confirms the phrase without returning it. Now opt-in, listings only.

### Round 3 — one more

- **The partial cursor was built from the delivered slice alone.** A prefix of only undated messages produced no watermark, resetting the cursor to cold and redelivering every dated message in the mailbox. Now merged onto the persisted cursor, watermark monotonic.

Round 3 reported the remaining categories clean: truncated-plus-partial, the embedder override, and search leakage.

## Evidence

- **189 tests**, `tsc --noEmit` clean, `npm run build` clean, dist loads.
- Each defect above has a test that fails without its fix. The partial-delivery test drives two cycles across a budget that runs out mid-batch and asserts every message is delivered exactly once.
- CI: all five checks green.

**Proof gap, unchanged:** this has never run under a real gateway. `~/GitHub/openclaw-dev-gw` no longer exists, and standing one up plus granting Mail permissions is not something to do unattended next to a live gateway. That is the first thing to do before this ships.


---

## Review rounds

Codex reviewed this branch three times. It found **ten defects**, seven of them in code written earlier the same session. All are fixed; each round's fixes were re-reviewed rather than assumed.

### Round 1 — six defects

| | Defect |
|---|---|
| High | **The breaker capped nothing.** Budget checked once per batch, spent per message: 25 admitted messages against a budget with 1 left ran all 25. |
| High | **A second account erased the first's quarantine.** One module-global map, replaced on every account start. |
| High | **`search --field content` was a content oracle.** Blocking `get` left probing intact: ask for a phrase, learn from the hit whether quarantined mail contains it. Listings leaked envelopes the same way, so "drop never reaches the agent" was untrue. |
| High | **A denied thread claim still set the session key.** An authenticated stranger quoting a leaked Message-ID was filed into the session of the person the agent was really talking to. The comment asserting this could not happen was false. |
| Medium | **Truncation looped forever.** Holding the cursor past the page ceiling re-listed and redelivered the same newest page every cycle and *still* never reached older mail. The comment claimed the backlog would drain; nothing drained it. |
| Medium | **A failed budget write un-counted the run.** Counted, then not dispatched, then retried and counted again. |

### Round 2 — three of those only partly fixed

- **Deferred batches replayed their delivered prefix**, and could starve the tail indefinitely. Root cause was dispatch order: newest-first leaves the remainder *older* than any watermark the cursor can express. Now sorted oldest-first with a `{completed}` prefix cursor.
- **`admittedHandler` skipped the breaker entirely.** Moved inside the budget loop.
- **The withheld count was itself an oracle.** `1 withheld` for a content search confirms the phrase without returning it. Now opt-in, listings only.

### Round 3 — one more

- **The partial cursor was built from the delivered slice alone.** A prefix of only undated messages produced no watermark, resetting the cursor to cold and redelivering every dated message in the mailbox. Now merged onto the persisted cursor, watermark monotonic.

Round 3 reported the remaining categories clean: truncated-plus-partial, the embedder override, and search leakage.

## Evidence

- **189 tests**, `tsc --noEmit` clean, `npm run build` clean, dist loads.
- Each defect above has a test that fails without its fix. The partial-delivery test drives two cycles across a budget that runs out mid-batch and asserts every message is delivered exactly once.
- CI: all five checks green.

**Proof gap, unchanged:** this has never run under a real gateway. `~/GitHub/openclaw-dev-gw` no longer exists, and standing one up plus granting Mail permissions is not something to do unattended next to a live gateway. That is the first thing to do before this ships.
