### PR TITLE
fix(mail): first gateway run — storage trust gate blocks the channel

### DIFF
--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -5,6 +5,93 @@
   "channels": [
     "apple-mail"
   ],
+  "channelConfigs": {
+    "apple-mail": {
+      "label": "Apple Mail",
+      "blurb": "Polls the local Mail.app store and authorizes senders by DKIM/SPF authentication strength.",
+      "docsPath": "docs/mail-channel-scenarios.md",
+      "configSchema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "dmPolicy": {
+            "type": "string",
+            "enum": [
+              "allowlist",
+              "open",
+              "closed"
+            ],
+            "description": "Who may drive the agent. Default allowlist."
+          },
+          "allowFrom": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Addresses permitted to drive the agent. Policy only: authentication is proved separately via trustedSendersPath."
+          },
+          "minIdentifierAuthentication": {
+            "type": "string",
+            "enum": [
+              "verified",
+              "asserted",
+              "mutable"
+            ],
+            "default": "asserted",
+            "description": "Minimum strength before an identifier may authorize a sender. 'asserted' requires the sender's domain to have authenticated; 'verified' additionally requires a per-sender expectedDkimDomains entry."
+          },
+          "trustedSendersPath": {
+            "type": "string",
+            "description": "Path to trusted-senders.json, carrying expectedDkimDomains and trustedAuthservIds."
+          },
+          "selfAddresses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Addresses the agent sends as. Required: this is the inbound and outbound loop guard."
+          },
+          "operatorAddresses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The operator's own addresses. Always permitted reply recipients."
+          },
+          "egressAllowlist": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Recipients the agent may originate mail to. Egress is default-deny without this."
+          },
+          "mailbox": {
+            "type": "string",
+            "default": "INBOX",
+            "description": "Mailbox to poll. Not always INBOX: mail is often archived on arrival."
+          },
+          "pollIntervalSeconds": {
+            "type": "number",
+            "default": 60
+          },
+          "pageSize": {
+            "type": "number",
+            "default": 25,
+            "description": "Messages read per cycle, oldest unprocessed first."
+          },
+          "maxAgentRunsPerHour": {
+            "type": "number",
+            "default": 30,
+            "description": "Circuit breaker. Default-deny bounds who may drive the agent, not how much."
+          },
+          "maxAgentRunsPerDay": {
+            "type": "number",
+            "default": 200
+          }
+        }
+      }
+    }
+  },
   "version": "3.10.0",
   "configSchema": {
     "type": "object",

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -183,10 +183,27 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
       ctx.log?.warn?.("apple-mail: plugin runtime unavailable; not starting the poll loop");
       return;
     }
-    const store = state.openKeyedStore<PollCursor>({
-      namespace: `${CHANNEL_ID}:cursor`,
-      maxEntries: 64,
-    }) as CursorStore;
+    // Every durable surface this channel has goes through `openKeyedStore`, and the host
+    // refuses it unless the plugin is bundled or a trusted official install. A path-loaded
+    // or third-party install is neither, and the throw lands inside `startAccount`, which
+    // the gateway treats as a crashed channel and restarts ten times over several minutes.
+    // Fail once, say what to do, and stay down: retrying cannot change a trust decision.
+    let store: CursorStore;
+    try {
+      store = state.openKeyedStore<PollCursor>({
+        namespace: `${CHANNEL_ID}:cursor`,
+        maxEntries: 64,
+      }) as CursorStore;
+    } catch (error) {
+      ctx.log?.error?.(
+        `apple-mail: durable storage unavailable (${String(error)}). The channel needs it for ` +
+          `its poll cursor, thread records, quarantine, and run budget, and cannot run ` +
+          `safely without them: a lost cursor reprocesses the mailbox and a lost quarantine ` +
+          `un-blocks refused senders. Install the plugin through ClawHub rather than a local ` +
+          `path so the host grants it storage access.`,
+      );
+      return;
+    }
 
     const deps = createMailCliDeps({
       account: config.account,

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -202,6 +202,17 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
           `un-blocks refused senders. Install the plugin through ClawHub rather than a local ` +
           `path so the host grants it storage access.`,
       );
+      // Deliberately not `return`. The gateway reads a returned `startAccount` as an exited
+      // channel and restarts it, so returning would repeat this diagnostic every few seconds
+      // for ten attempts. Retrying cannot change a trust decision, so the channel stays up
+      // and idle instead: one message, then nothing until shutdown.
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
       return;
     }
 


### PR DESCRIPTION
## What Problem This Solves

First run under a real gateway (dev profile, port 19001). It found two problems that 191 passing tests could not, because both live in the host contract rather than in this code.

### The channel cannot start

Every durable surface this channel has — poll cursor, thread records, quarantine, run budget — goes through `state.openKeyedStore`. The host refuses it:

```
[apple-mail] [default] channel exited: openKeyedStore is only available for trusted plugins in this release.
[apple-mail] [default] auto-restart attempt 1/10 in 5s
[apple-mail] [default] auto-restart attempt 2/10 in 10s
...
```

The gate, from the installed host:

```js
if (record?.origin !== "bundled" && record?.trustedOfficialInstall !== true)
  throw new Error(`${methodName} is only available for trusted plugins in this release.`)
```

A path-loaded plugin is neither bundled nor a trusted official install. The tests never saw this because they inject a fake store.

### The manifest declared a channel with no config metadata

```
channel plugin manifest declares apple-mail without channelConfigs metadata;
add openclaw.plugin.json#channelConfigs so config schema and setup surfaces
work before runtime loads.
```

## Why This Change Was Made

**This PR does not fix the storage problem.** It stops the channel pretending a retry might help. The failure is caught once and reported with what it means and what to do, instead of ten identical stack traces over several minutes.

The channel still exits and the gateway still restarts it, because a `startAccount` that returns normally reads as an exited channel. Staying down needs a way to signal permanent failure that I have not found.

Adds `channelConfigs` describing every `channels.apple-mail` option. The host still warns, so the key placement is not what it expects; kept because the content is right.

## User Impact

None yet — the channel could not run before this and cannot run after it. What changes is that the reason is now legible in the log.

## Evidence

- Four gateway runs, logs captured. The channel loads (`4 plugins: apple-pim-cli, facetime, policy, xai`), registers, starts, and fails on first store access.
- 191 tests pass, `tsc --noEmit` clean, `npm run build` clean.
- Dev sandbox config restored to its exact prior state; no gateway left running.

## The actual open question

Whether a **ClawHub install** of this plugin is granted `trustedOfficialInstall`. Precedent suggests official ClawHub plugins are (see the WhatsApp `openKeyedStore` gate), but this plugin is third-party, so that is an assumption and not a finding.

Two outcomes:

- **Granted:** this is a dev-loading annoyance. Test via a real ClawHub install and move on.
- **Not granted:** persistence has to move to a store the plugin owns outright, most likely its own SQLite DB under the plugin's state directory. That is a real piece of work touching all four stores, and it should not be started until the question is answered, because the answer decides whether it is needed at all.