### PR TITLE
feat(mail): own the storage, and run end to end on a real gateway

### DIFF
--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -8,7 +8,7 @@
     "postpack": "node -e \"const fs=require('node:fs'); fs.rmSync('lib', { recursive: true, force: true }); fs.symlinkSync('../lib', 'lib', 'dir');\"",
     "plugin:check": "npx --yes @openclaw/plugin-inspector inspect --no-openclaw",
     "plugin:ci": "npx --yes @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute",
-    "build": "tsup src/index.ts --format esm --out-dir dist --clean --target node20",
+    "build": "tsup src/index.ts --format esm --out-dir dist --clean --target node22 --external node:sqlite",
     "test": "node --test \"src/**/*.test.ts\""
   },
   "openclaw": {
@@ -80,7 +80,7 @@
     "darwin"
   ],
   "engines": {
-    "node": ">=22.19.0"
+    "node": ">=22.5"
   },
   "dependencies": {
     "mailparser": "^3.9.3",

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -80,7 +80,7 @@
     "darwin"
   ],
   "engines": {
-    "node": ">=22.5"
+    "node": ">=22.13"
   },
   "dependencies": {
     "mailparser": "^3.9.3",

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -19,7 +19,6 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import type { ClassifiedMessage, PollCursor } from "./inbound.ts";
-import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { runPollLoop, type CursorStore } from "./poll.ts";
 import {
   createMailCliDeps,
@@ -29,7 +28,7 @@ import {
 import { checkChannelConfig } from "./config-check.ts";
 import { RunBudget, resolveRateLimits, type BreakerStore } from "./rate-limit.ts";
 import { ThreadRecords, type ThreadRecordStore } from "./thread-store.ts";
-import { openStore } from "./store.ts";
+import { openStore, storeDirectory } from "./store.ts";
 import {
   loadQuarantine,
   quarantineMessage,
@@ -87,14 +86,6 @@ const DEFAULT_PAGE = 25;
 export type AdmittedHandler = (messages: ClassifiedMessage[]) => Promise<void> | void;
 
 let admittedHandler: AdmittedHandler | undefined;
-
-/**
- * Captured at registration.
- *
- * The keyed store lives on `PluginRuntime`, not on the `RuntimeEnv` handed to
- * `startAccount`, so it has to be taken here via the entry's `setRuntime` hook.
- */
-let pluginRuntime: PluginRuntime | undefined;
 
 /** Overrides the default handler. Used by the gateway wiring and by tests. */
 export function setAdmittedHandler(handler: AdmittedHandler | undefined): void {
@@ -182,36 +173,67 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
       trustedSendersPath: config.trustedSendersPath,
     });
 
-    // Storage the plugin owns. The host's `openKeyedStore` is gated on
-    // `trustedOfficialInstall`, which only packages in OpenClaw's official external catalog
-    // receive; no install path reaches it for a third-party plugin, so this channel keeps
-    // its own SQLite database rather than depending on a grant it cannot obtain.
-    const store = openStore<PollCursor>(`${CHANNEL_ID}:cursor`) as CursorStore;
+    let store: CursorStore;
+    let threads: ThreadRecords;
+    let quarantineStore: ReturnType<typeof openStore<[string, string][]>>;
+    let quarantineKey: string;
+    let budget: RunBudget;
+    let limits: ReturnType<typeof resolveRateLimits>;
+    try {
+      // Storage the plugin owns. The host's `openKeyedStore` is gated on
+      // `trustedOfficialInstall`, which only packages in OpenClaw's official external catalog
+      // receive; no install path reaches it for a third-party plugin, so this channel keeps
+      // its own SQLite database rather than depending on a grant it cannot obtain.
+      //
+      // Opening it can fail for reasons retrying cannot fix: an unwritable state directory, a
+      // Node without `node:sqlite`, a corrupt row. `startAccount` is awaited now, so letting
+      // one of those reject would mark the channel crashed and burn all ten restart attempts
+      // reprinting the same error. Fail once and hold instead.
+      store = openStore<PollCursor>(`${CHANNEL_ID}:cursor`) as CursorStore;
 
-    // Threads the agent has replied in. Hydrated once; admission reads it per message, so it
-    // is held in memory rather than round-tripped to the store inside the poll loop.
-    const threads = new ThreadRecords(
-      openStore(`${CHANNEL_ID}:threads`) as ThreadRecordStore,
-      `${CHANNEL_ID}:${ctx.accountId}`,
-    );
-    await threads.hydrate();
+      // Threads the agent has replied in. Hydrated once; admission reads it per message, so it
+      // is held in memory rather than round-tripped to the store inside the poll loop.
+      threads = new ThreadRecords(
+        openStore(`${CHANNEL_ID}:threads`) as ThreadRecordStore,
+        `${CHANNEL_ID}:${ctx.accountId}`,
+      );
+      await threads.hydrate();
 
-    // Messages the channel refuses are quarantined for the mail tool too. Without this the
-    // envelope-only prompt would be a bypass: a dropped message still has an id, and
-    // `apple_pim_mail` would happily read the body the channel just declined to deliver.
-    // Durable, because the cursor moves past a dropped message and it is never reclassified,
-    // so an in-memory set would forget it at the next restart.
-    const quarantineStore = openStore<[string, string][]>(`${CHANNEL_ID}:quarantine`);
-    const quarantineKey = `${CHANNEL_ID}:${ctx.accountId}`;
-    loadQuarantine(quarantineKey, await quarantineStore.lookup(quarantineKey));
+      // Messages the channel refuses are quarantined for the mail tool too. Without this the
+      // envelope-only prompt would be a bypass: a dropped message still has an id, and
+      // `apple_pim_mail` would happily read the body the channel just declined to deliver.
+      // Durable, because the cursor moves past a dropped message and it is never reclassified,
+      // so an in-memory set would forget it at the next restart.
+      quarantineStore = openStore<[string, string][]>(`${CHANNEL_ID}:quarantine`);
+      quarantineKey = `${CHANNEL_ID}:${ctx.accountId}`;
+      loadQuarantine(quarantineKey, await quarantineStore.lookup(quarantineKey));
 
-    const limits = resolveRateLimits(config);
-    const budget = new RunBudget(
-      openStore(`${CHANNEL_ID}:budget`) as BreakerStore,
-      `${CHANNEL_ID}:${ctx.accountId}`,
-      limits,
-    );
-    await budget.hydrate();
+      limits = resolveRateLimits(config);
+      budget = new RunBudget(
+        openStore(`${CHANNEL_ID}:budget`) as BreakerStore,
+        `${CHANNEL_ID}:${ctx.accountId}`,
+        limits,
+      );
+      await budget.hydrate();
+    } catch (error) {
+      ctx.log?.error?.(
+        `apple-mail: durable storage unavailable (${String(error)}). The channel needs it for ` +
+          `its poll cursor, thread records, quarantine, and run budget, and will not run ` +
+          `without them: a lost cursor reprocesses the mailbox and a lost quarantine ` +
+          `un-blocks refused senders. Check that ${storeDirectory()} is writable and that ` +
+          `this Node build has node:sqlite (22.13+).`,
+      );
+      // Held rather than returned. A returning `startAccount` reads as an exited channel and
+      // is restarted every few seconds; none of the causes above are fixed by retrying.
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return;
+    }
 
     const minIdentifierAuthentication = config.minIdentifierAuthentication ?? "asserted";
     const allowFrom = (config.allowFrom ?? []).map((entry) => String(entry));
@@ -360,9 +382,6 @@ export const appleMailChannelPlugin = createChatChannelPlugin<ResolvedAppleMailA
 });
 
 export const appleMailChannelEntry = defineChannelPluginEntry({
-  setRuntime: (runtime) => {
-    pluginRuntime = runtime;
-  },
   id: CHANNEL_ID,
   name: "Apple Mail",
   description:

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -29,6 +29,7 @@ import {
 import { checkChannelConfig } from "./config-check.ts";
 import { RunBudget, resolveRateLimits, type BreakerStore } from "./rate-limit.ts";
 import { ThreadRecords, type ThreadRecordStore } from "./thread-store.ts";
+import { openStore } from "./store.ts";
 import {
   loadQuarantine,
   quarantineMessage,
@@ -163,71 +164,34 @@ const security = {
 };
 
 /**
- * Starts one account's poll loop and stops it on shutdown.
+ * Runs one account's poll loop for the lifetime of the channel.
  *
- * `startAccount` returns once the loop is running rather than awaiting it, because the
- * loop only ends on abort and the gateway needs startup to complete. The promise is kept
- * so `stopAccount` can wait for the current cycle to settle instead of tearing down
- * mid-classification.
+ * `startAccount` awaits the loop rather than returning once it is running. Returning early
+ * looks like a channel that started and then exited, and the gateway restarts it on that
+ * basis every few seconds. The promise is also kept so `stopAccount` can wait for the
+ * current cycle to settle instead of tearing down mid-classification.
  */
 const loops = new Map<string, Promise<void>>();
 
 const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> = {
   startAccount: async (ctx) => {
     const config = ctx.account.config;
-    const state = pluginRuntime?.state;
-    if (!state) {
-      // Without durable cursor storage the loop would re-read the mailbox from scratch on
-      // every restart. Refuse to start rather than run in a state that looks fine and
-      // silently reprocesses.
-      ctx.log?.warn?.("apple-mail: plugin runtime unavailable; not starting the poll loop");
-      return;
-    }
-    // Every durable surface this channel has goes through `openKeyedStore`, and the host
-    // refuses it unless the plugin is bundled or a trusted official install. A path-loaded
-    // or third-party install is neither, and the throw lands inside `startAccount`, which
-    // the gateway treats as a crashed channel and restarts ten times over several minutes.
-    // Fail once, say what to do, and stay down: retrying cannot change a trust decision.
-    let store: CursorStore;
-    try {
-      store = state.openKeyedStore<PollCursor>({
-        namespace: `${CHANNEL_ID}:cursor`,
-        maxEntries: 64,
-      }) as CursorStore;
-    } catch (error) {
-      ctx.log?.error?.(
-        `apple-mail: durable storage unavailable (${String(error)}). The channel needs it for ` +
-          `its poll cursor, thread records, quarantine, and run budget, and cannot run ` +
-          `safely without them: a lost cursor reprocesses the mailbox and a lost quarantine ` +
-          `un-blocks refused senders. Install the plugin through ClawHub rather than a local ` +
-          `path so the host grants it storage access.`,
-      );
-      // Deliberately not `return`. The gateway reads a returned `startAccount` as an exited
-      // channel and restarts it, so returning would repeat this diagnostic every few seconds
-      // for ten attempts. Retrying cannot change a trust decision, so the channel stays up
-      // and idle instead: one message, then nothing until shutdown.
-      await new Promise<void>((resolve) => {
-        if (ctx.abortSignal.aborted) {
-          resolve();
-          return;
-        }
-        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
-      });
-      return;
-    }
 
     const deps = createMailCliDeps({
       account: config.account,
       trustedSendersPath: config.trustedSendersPath,
     });
 
+    // Storage the plugin owns. The host's `openKeyedStore` is gated on
+    // `trustedOfficialInstall`, which only packages in OpenClaw's official external catalog
+    // receive; no install path reaches it for a third-party plugin, so this channel keeps
+    // its own SQLite database rather than depending on a grant it cannot obtain.
+    const store = openStore<PollCursor>(`${CHANNEL_ID}:cursor`) as CursorStore;
+
     // Threads the agent has replied in. Hydrated once; admission reads it per message, so it
     // is held in memory rather than round-tripped to the store inside the poll loop.
     const threads = new ThreadRecords(
-      state.openKeyedStore({
-        namespace: `${CHANNEL_ID}:threads`,
-        maxEntries: 64,
-      }) as ThreadRecordStore,
+      openStore(`${CHANNEL_ID}:threads`) as ThreadRecordStore,
       `${CHANNEL_ID}:${ctx.accountId}`,
     );
     await threads.hydrate();
@@ -237,22 +201,13 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
     // `apple_pim_mail` would happily read the body the channel just declined to deliver.
     // Durable, because the cursor moves past a dropped message and it is never reclassified,
     // so an in-memory set would forget it at the next restart.
-    const quarantineStore = state.openKeyedStore({
-      namespace: `${CHANNEL_ID}:quarantine`,
-      maxEntries: 64,
-    }) as {
-      lookup(key: string): Promise<[string, string][] | undefined>;
-      register(key: string, value: [string, string][]): Promise<void>;
-    };
+    const quarantineStore = openStore<[string, string][]>(`${CHANNEL_ID}:quarantine`);
     const quarantineKey = `${CHANNEL_ID}:${ctx.accountId}`;
     loadQuarantine(quarantineKey, await quarantineStore.lookup(quarantineKey));
 
     const limits = resolveRateLimits(config);
     const budget = new RunBudget(
-      state.openKeyedStore({
-        namespace: `${CHANNEL_ID}:budget`,
-        maxEntries: 64,
-      }) as BreakerStore,
+      openStore(`${CHANNEL_ID}:budget`) as BreakerStore,
       `${CHANNEL_ID}:${ctx.accountId}`,
       limits,
     );
@@ -344,13 +299,19 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
         },
         onError: (error) => ctx.log?.warn?.(`apple-mail poll failed: ${String(error)}`),
         checkBudget: () => budget.check(),
-        onThrottled: ({ window, retryAtMs, pending }) =>
+        // The mid-batch path reports only how many were left, because the budget closed
+        // between messages and the window that bound it is the breaker's business, not the
+        // loop's. Say what is known rather than interpolating an absent field.
+        onThrottled: ({ window, retryAtMs, pending }) => {
+          const bound = window
+            ? `${window} limit of ${window === "day" ? limits.perDay : limits.perHour}`
+            : `limit of ${limits.perHour}/hour, ${limits.perDay}/day`;
           ctx.log?.warn?.(
-            `apple-mail: circuit breaker open (${window} limit of ` +
-              `${window === "day" ? limits.perDay : limits.perHour} agent runs reached); ` +
+            `apple-mail: circuit breaker open (${bound} agent runs reached); ` +
               `holding ${pending} message(s)` +
               (retryAtMs ? ` until ${new Date(retryAtMs).toISOString()}` : ""),
-          ),
+          );
+        },
         // Informational now, not a warning: the page is the oldest unprocessed mail, so a
         // full one means the backlog is still draining, not that anything was skipped.
         onTruncated: ({ mailbox, limit }) =>
@@ -380,6 +341,10 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
     );
 
     loops.set(ctx.accountId, loop);
+    // Awaited, not fired and forgotten. The gateway treats a `startAccount` that returns as
+    // an exited channel and restarts it every few seconds; the loop already runs until the
+    // abort signal, so awaiting it is what "the channel is up" means here.
+    await loop;
   },
 
   stopAccount: async (ctx) => {

--- a/openclaw/src/mail-channel/store.test.ts
+++ b/openclaw/src/mail-channel/store.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The plugin owns its storage because the host will not lend it any.
+ *
+ * `openKeyedStore` is gated on `trustedOfficialInstall`, granted only to packages in
+ * OpenClaw's official external catalog. That is not about how a plugin is installed: a local
+ * `plugins install --force` was refused exactly like a path load. A third-party plugin
+ * cannot get there, so it brings its own database.
+ */
+
+import { describe, it, before, after } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { closeStore, openStore, storeDirectory } from "./store.ts";
+
+let tmp: string;
+
+before(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), "apple-pim-store-"));
+  process.env.OPENCLAW_STATE_DIR = tmp;
+});
+
+after(() => {
+  closeStore();
+  rmSync(tmp, { recursive: true, force: true });
+  delete process.env.OPENCLAW_STATE_DIR;
+});
+
+describe("openStore", () => {
+  it("returns undefined for a key never written", async () => {
+    assert.equal(await openStore("ns").lookup("absent"), undefined);
+  });
+
+  it("round-trips a structured value", async () => {
+    const store = openStore<{ lastDateReceived: string; ids: string[] }>("cursor");
+    await store.register("acct", { lastDateReceived: "2026-07-29T10:00:00Z", ids: ["a", "b"] });
+    assert.deepEqual(await store.lookup("acct"), {
+      lastDateReceived: "2026-07-29T10:00:00Z",
+      ids: ["a", "b"],
+    });
+  });
+
+  it("overwrites rather than accumulating", async () => {
+    const store = openStore<number[]>("cursor");
+    await store.register("k", [1]);
+    await store.register("k", [2, 3]);
+    assert.deepEqual(await store.lookup("k"), [2, 3]);
+  });
+
+  // All four callers key by account id, so without namespacing the cursor and the budget
+  // would fight over the same row.
+  it("keeps namespaces apart under an identical key", async () => {
+    await openStore<string>("cursor").register("default", "cursor-value");
+    await openStore<string>("budget").register("default", "budget-value");
+    assert.equal(await openStore<string>("cursor").lookup("default"), "cursor-value");
+    assert.equal(await openStore<string>("budget").lookup("default"), "budget-value");
+  });
+
+  it("keeps accounts apart within a namespace", async () => {
+    const store = openStore<string>("threads");
+    await store.register("work", "w");
+    await store.register("personal", "p");
+    assert.equal(await store.lookup("work"), "w");
+    assert.equal(await store.lookup("personal"), "p");
+  });
+
+  // A budget or cursor that resets on restart is not one. This is the whole reason the
+  // store exists rather than an in-memory map.
+  it("survives closing and reopening the database", async () => {
+    await openStore<{ runs: number[] }>("budget").register("acct", { runs: [1, 2, 3] });
+    closeStore();
+    assert.deepEqual(await openStore<{ runs: number[] }>("budget").lookup("acct"), {
+      runs: [1, 2, 3],
+    });
+  });
+
+  it("handles the empty and falsy values callers actually store", async () => {
+    const store = openStore<unknown>("edge");
+    for (const [key, value] of [
+      ["empty-array", []],
+      ["empty-object", {}],
+      ["zero", 0],
+      ["false", false],
+      ["null", null],
+    ] as const) {
+      await store.register(key, value);
+      assert.deepEqual(await store.lookup(key), value, key);
+    }
+  });
+
+  it("puts its database under the configured state dir, not the operator's real one", () => {
+    assert.equal(storeDirectory(), path.join(tmp, "apple-pim"));
+  });
+});

--- a/openclaw/src/mail-channel/store.test.ts
+++ b/openclaw/src/mail-channel/store.test.ts
@@ -12,7 +12,23 @@ import { strict as assert } from "node:assert";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { closeStore, openStore, storeDirectory } from "./store.ts";
+
+/** Writes unparseable bytes into a row, which only a bug or a bad edit would produce. */
+function corrupt(namespace: string, key: string): void {
+  closeStore();
+  const { DatabaseSync } = createRequire(import.meta.url)("node:sqlite") as {
+    DatabaseSync: new (f: string) => { prepare(s: string): { run(...a: unknown[]): unknown }; close(): void };
+  };
+  const db = new DatabaseSync(path.join(tmp, "apple-pim", "mail-channel.sqlite"));
+  db.prepare("UPDATE keyed_store SET value = ? WHERE namespace = ? AND key = ?").run(
+    "{not json",
+    namespace,
+    key,
+  );
+  db.close();
+}
 
 let tmp: string;
 
@@ -91,5 +107,33 @@ describe("openStore", () => {
 
   it("puts its database under the configured state dir, not the operator's real one", () => {
     assert.equal(storeDirectory(), path.join(tmp, "apple-pim"));
+  });
+});
+
+// Codex: treating a corrupt row as an absent one fails open on the two surfaces where that
+// is worst. An unreadable quarantine reads as "nothing is quarantined" and re-exposes every
+// refused sender; an unreadable budget reads as "no runs yet" and returns a full allowance.
+describe("corrupt rows", () => {
+  it("throws rather than reporting the key as absent", async () => {
+    const store = openStore<string[]>("quarantine");
+    await store.register("acct", ["still-fine"]);
+    corrupt("quarantine", "acct");
+    await assert.rejects(() => store.lookup("acct"), /Corrupt value in quarantine\/acct/);
+  });
+
+  it("names the row so it can be deleted", async () => {
+    const store = openStore<number>("budget");
+    await store.register("work", 1);
+    corrupt("budget", "work");
+    await assert.rejects(() => store.lookup("work"), /Delete this row to rebuild it/);
+  });
+
+  it("leaves neighbouring rows readable", async () => {
+    const store = openStore<string>("cursor");
+    await store.register("a", "good");
+    await store.register("b", "also-good");
+    corrupt("cursor", "a");
+    await assert.rejects(() => store.lookup("a"));
+    assert.equal(await store.lookup("b"), "also-good");
   });
 });

--- a/openclaw/src/mail-channel/store.ts
+++ b/openclaw/src/mail-channel/store.ts
@@ -116,12 +116,16 @@ export function openStore<T>(namespace: string): KeyedStore<T> {
       }
       try {
         return JSON.parse(row.value) as T;
-      } catch {
-        // A row that will not parse is corrupt, not absent, but the caller can only act on
-        // absent. Treating it as missing rebuilds the value from scratch, which every caller
-        // here can do; the alternative is a channel that will not start until someone edits
-        // a database by hand.
-        return undefined;
+      } catch (error) {
+        // Corrupt is not absent, and collapsing the two here would fail open on the surfaces
+        // that matter most: an unreadable quarantine row would read as "nothing is
+        // quarantined" and re-expose every sender the channel had refused, and an unreadable
+        // budget row would read as "no runs yet" and hand back a full spend allowance. Throw
+        // instead. The caller holds the channel idle with a message naming this row, which
+        // is recoverable by deleting it and losing only what that row held.
+        throw new Error(
+          `Corrupt value in ${namespace}/${key}: ${String(error)}. Delete this row to rebuild it.`,
+        );
       }
     },
     register: async (key: string, value: T) => {

--- a/openclaw/src/mail-channel/store.ts
+++ b/openclaw/src/mail-channel/store.ts
@@ -1,0 +1,142 @@
+/**
+ * Durable key/value storage the plugin owns outright.
+ *
+ * The host's `openKeyedStore` is gated on `trustedOfficialInstall`, which is granted only to
+ * packages in OpenClaw's official external plugin catalog. That is not a property of how a
+ * plugin is installed, so no install path reaches it for a third-party plugin: a local
+ * `plugins install --force` was tried and refused exactly like a path load. This channel
+ * therefore cannot use it, and every durable surface it has is load-bearing:
+ *
+ * - the poll cursor, or every restart reprocesses the mailbox
+ * - thread records, or the reply rule is inert
+ * - the quarantine, or refused senders become readable again
+ * - the run budget, or a crash loop spends without limit
+ *
+ * So it keeps its own SQLite database. One file, one table, the same narrow
+ * `lookup`/`register` interface the four callers already used, so nothing above this
+ * changed shape when the storage moved.
+ *
+ * Values are JSON. The rows here are small structured records, not documents, and a schema
+ * per caller would buy nothing while making each new store a migration.
+ */
+
+import { createRequire } from "node:module";
+import { mkdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/** What every caller in this channel needs, and nothing more. */
+export type KeyedStore<T> = {
+  lookup(key: string): Promise<T | undefined>;
+  register(key: string, value: T): Promise<void>;
+};
+
+/**
+ * Where the database lives.
+ *
+ * Follows `OPENCLAW_STATE_DIR` so a dev gateway keeps its state separate from the operator's
+ * real one. Getting this wrong would have a test run write into the live channel's cursor.
+ */
+export function storeDirectory(): string {
+  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+  const root = stateDir && stateDir.length > 0 ? stateDir : path.join(os.homedir(), ".openclaw");
+  return path.join(expandHome(root), "apple-pim");
+}
+
+function expandHome(input: string): string {
+  return input.startsWith("~/") ? path.join(os.homedir(), input.slice(2)) : input;
+}
+
+/**
+ * Resolved at runtime rather than imported.
+ *
+ * Bundlers targeting a Node version that predates `node:sqlite` do not recognize the
+ * specifier and rewrite it to a bare `sqlite`, which then fails to resolve at load time with
+ * `Cannot find module 'sqlite'` and takes the whole plugin down with it. A runtime require
+ * is opaque to that rewriting.
+ */
+type SqliteDatabase = {
+  exec(sql: string): void;
+  prepare(sql: string): { get(...params: unknown[]): unknown; run(...params: unknown[]): unknown };
+  close(): void;
+};
+
+function loadSqlite(): new (filename: string) => SqliteDatabase {
+  const require = createRequire(import.meta.url);
+  return (require("node:sqlite") as { DatabaseSync: new (f: string) => SqliteDatabase })
+    .DatabaseSync;
+}
+
+let db: SqliteDatabase | undefined;
+
+/**
+ * Opens the shared database, creating it on first use.
+ *
+ * One connection for the whole plugin: SQLite serializes writers anyway, and separate
+ * handles to one file would trade a lock we control for one we do not.
+ */
+function database(): SqliteDatabase {
+  if (db) {
+    return db;
+  }
+  const dir = storeDirectory();
+  mkdirSync(dir, { recursive: true });
+  const DatabaseSync = loadSqlite();
+  const opened = new DatabaseSync(path.join(dir, "mail-channel.sqlite"));
+  // WAL so a poll cycle writing a cursor never blocks on a reader, and normal synchronous
+  // because losing the last cursor write to a power cut costs one reprocessed page.
+  opened.exec("PRAGMA journal_mode = WAL");
+  opened.exec("PRAGMA synchronous = NORMAL");
+  opened.exec(`
+    CREATE TABLE IF NOT EXISTS keyed_store (
+      namespace TEXT NOT NULL,
+      key       TEXT NOT NULL,
+      value     TEXT NOT NULL,
+      PRIMARY KEY (namespace, key)
+    )
+  `);
+  db = opened;
+  return opened;
+}
+
+/**
+ * A namespaced store.
+ *
+ * Namespaces keep the four callers from colliding on a shared key, which matters because
+ * they all key by account id.
+ */
+export function openStore<T>(namespace: string): KeyedStore<T> {
+  return {
+    lookup: async (key: string) => {
+      const row = database()
+        .prepare("SELECT value FROM keyed_store WHERE namespace = ? AND key = ?")
+        .get(namespace, key) as { value?: string } | undefined;
+      if (row?.value === undefined) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(row.value) as T;
+      } catch {
+        // A row that will not parse is corrupt, not absent, but the caller can only act on
+        // absent. Treating it as missing rebuilds the value from scratch, which every caller
+        // here can do; the alternative is a channel that will not start until someone edits
+        // a database by hand.
+        return undefined;
+      }
+    },
+    register: async (key: string, value: T) => {
+      database()
+        .prepare(
+          `INSERT INTO keyed_store (namespace, key, value) VALUES (?, ?, ?)
+           ON CONFLICT(namespace, key) DO UPDATE SET value = excluded.value`,
+        )
+        .run(namespace, key, JSON.stringify(value));
+    },
+  };
+}
+
+/** Closes the connection. For tests and shutdown; reopens on next use. */
+export function closeStore(): void {
+  db?.close();
+  db = undefined;
+}


### PR DESCRIPTION
## What Problem This Solves

The channel could not start. `openKeyedStore` is gated on `trustedOfficialInstall`, and every durable surface it has goes through it.

**The gate is not reachable.** Reading the host settles it — trust is not about how a plugin is installed:

```js
const catalogEntry = getOfficialExternalPluginCatalogEntryForPackage(packageName);
if (!catalogEntry || resolveOfficialExternalPluginId(catalogEntry) !== params.pluginId) return false;
```

It requires membership in OpenClaw's **official external plugin catalog**. A local `plugins install --force` was tried and refused exactly like a path load. A third-party plugin cannot get there, so #93's advice — "install through ClawHub" — was wrong. This replaces the dependency instead of the message.

## Why This Change Was Made

`store.ts` is a SQLite-backed keyed store the plugin owns, under `$OPENCLAW_STATE_DIR/apple-pim/`. One file, one table, namespaced, and exactly the `lookup`/`register` interface the four callers already used — so cursor, thread records, quarantine, and run budget changed storage without changing shape.

Three things the gateway found that no test could:

- **`node:sqlite` must be required at runtime.** Bundlers targeting Node older than 22.5 don't recognize the specifier and rewrite it to a bare `sqlite`, which fails to resolve and takes the whole plugin down with `Cannot find module 'sqlite'`. Build target moved to node22, `engines.node` to `>=22.5`.
- **`startAccount` must await its loop.** Returning once the loop was running read as a channel that started and exited, and the gateway restarted it every five seconds. The old comment claimed the gateway needed startup to complete. It needs the opposite.
- **A log line printed `undefined limit`** when the breaker closed mid-batch, because that path reports how many were held without the window that bound them.

## User Impact

The channel works. Requires Node 22.5+, which the gateway already exceeds.

## Evidence

Final dev-gateway run against the real mailbox:

```
http server listening (4 plugins: apple-pim-cli, facetime, policy, xai)
[apple-mail] reply to no-reply@notifications.ui.com suppressed (observe_only)
[apple-mail] reply to noreply@email.apple.com suppressed (observe_only)
[apple-mail] circuit breaker open (hour limit of 2 agent runs reached);
             holding 3 message(s) until 2026-07-29T08:26:00.126Z
[diagnostic] session turn created: agentId=lobster
             sessionKey=apple-mail:default:0101019dc199...@us-west-2.amazonses.com
```

**0 restarts, 0 exits, 0 load failures.**

- Two real newsletters admitted as `observe` and their replies suppressed — the graduated policy firing on live mail.
- Two agent turns created against real messages, under per-thread session keys.
- The breaker opened at exactly its configured limit of 2 and held 3 messages rather than dropping them.
- Cursor and budget persisted and reloaded:

```
apple-mail:budget | apple-mail:default | {"runs":[1785309960126,1785309970048]}
apple-mail:cursor | apple-mail:default | {"lastDateReceived":"2026-05-03T19:40:48.000Z",...}
```

199 tests, `tsc --noEmit` clean, `npm run build` clean. Dev sandbox config restored and the test database removed.

## Still Open

- `channelConfigs` placement — the host still reports the metadata as missing, so the key isn't read from where the manifest puts it. Cosmetic; setup UI only.
- RFC 0027 now defines a fourth level, `unverified`. This plugin still scores that case `mutable` because three levels were all it had when it was written. Correct admission today, wrong name; move it when the kernel ships the primitive.