### PR TITLE
refactor(mail): adopt the RFC 0027 `unverified` level

### DIFF
--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -72,16 +72,25 @@ as every other.
 The three levels have to stay honest about the bottom of the scale, which is the part that
 is easy to get wrong:
 
-| Level | Means | An address gets it when |
+| Level | Means | An identifier gets it when |
 | --- | --- | --- |
 | `verified` | our boundary proved this exact mailbox | an expected signer signed it |
 | `asserted` | our boundary proved the domain, and nothing narrower | the domain authenticated but no operator assertion names the mailbox |
-| `mutable` | nobody vouched for it; it is a string the sender typed | authentication produced nothing |
+| `unverified` | presented by a party nobody authenticated; stable, attacker-chosen, unproven | authentication produced nothing |
+| `mutable` | a user-changeable alias that identifies nobody even when honestly set | always, for a display name |
 
-A `From` header on a message that failed authentication belongs in `mutable`. Scoring it
+A `From` header on a message that failed authentication belongs in `unverified`. Scoring it
 `asserted` gives the address identifier a floor, which silently turns the lowest configurable
 minimum into no minimum at all, and every scenario below that says `drop` stops dropping.
 That was a real defect here, not a hypothetical.
+
+The bottom two levels are both untrustworthy and are kept apart because they are
+untrustworthy for *different reasons*. An alias is weak because two people can hold the same
+one. An unauthenticated address is weak because nothing bound it to its sender, though it is
+perfectly precise. This channel emits exactly one of each: the display name is always
+`mutable`, and no address is ever `mutable`. Collapsing them, which an earlier version of
+this channel did, yields the right admission and a diagnostic that calls a precise address a
+nickname.
 
 ### Provenance
 
@@ -104,19 +113,19 @@ not act or reply. `drop` means it never reaches the agent.
 | # | Scenario | Domain | Address | Outcome |
 | --- | --- | --- | --- | --- |
 | I1 | Operator, authenticated, enrolled | `verified` | `verified` | `dispatch` |
-| I2 | Operator's address, authentication failed | `mutable` | `mutable` | `drop` |
-| I3 | Operator's address, no trusted `authserv-id` configured | `mutable` | `mutable` | `drop`, with a config warning |
+| I2 | Operator's address, authentication failed | `unverified` | `unverified` | `drop` |
+| I3 | Operator's address, no trusted `authserv-id` configured | `unverified` | `unverified` | `drop`, with a config warning |
 | I4 | Enrolled non-operator (family, colleague) | `verified` | `verified` | `dispatch`, subject to sender policy |
 | I4a | Allowlisted, domain authenticated, **not** enrolled | `verified` | `asserted` | `dispatch` at the default minimum, `observe` under `verified` |
 | I5 | Authenticated stranger | `verified` | `asserted` | `observe` |
-| I6 | Unauthenticated stranger | `mutable` | `mutable` | `drop` |
-| I7 | Spoofed operator, forged `Authentication-Results` | `mutable` | `mutable` | `drop`, forged header never read |
-| I8 | Spoofed operator, valid SPF for the attacker's own domain | `mutable` | `mutable` | `drop`, unaligned pass does not count |
+| I6 | Unauthenticated stranger | `unverified` | `unverified` | `drop` |
+| I7 | Spoofed operator, forged `Authentication-Results` | `unverified` | `unverified` | `drop`, forged header never read |
+| I8 | Spoofed operator, valid SPF for the attacker's own domain | `unverified` | `unverified` | `drop`, unaligned pass does not count |
 | I9 | Reply inside a thread the agent started, from an addressed participant | inherits | inherits | `dispatch`, or `observe` if the address is under the minimum (see E1) |
 | I10 | Reply inside a thread the agent did not start | per I1-I6 | | as if new |
 | I10a | Claimed thread membership from a non-participant | per I1-I6 | | thread claim ignored, treated as new |
 | I11 | Bulk or marketing mail, authenticated | `verified` | `asserted` | `observe` |
-| I12 | Forwarded mail, alignment broken in transit | usually `mutable` | `mutable` | `drop` unless the forwarding address is enrolled |
+| I12 | Forwarded mail, alignment broken in transit | usually `unverified` | `unverified` | `drop` unless the forwarding address is enrolled |
 | I13 | Mail from the agent's own address | n/a | n/a | `drop`, loop guard |
 | I14 | Mail in Junk | n/a | n/a | not polled |
 | I15 | Mail with attachments | per above | | admission unchanged; attachments separately gated |
@@ -431,7 +440,7 @@ The two minimums are different postures, not strictness dials on the same one:
   signers. It is the right posture once enrollment is complete, and until then it leaves
   allowlisted senders readable but not actioned (I4a).
 
-`asserted` is a real bar only because an unauthenticated `From` address scores `mutable`.
+`asserted` is a real bar only because an unauthenticated `From` address scores `unverified`.
 If it scored `asserted`, this row would be decorative and I2, I7, and I8 would all dispatch.
 The channel reports any `allowFrom` entry with no enrollment behind it at startup, so the
 gap between the two files is visible rather than inferred.

--- a/openclaw/src/mail-auth/strength.test.ts
+++ b/openclaw/src/mail-auth/strength.test.ts
@@ -21,11 +21,15 @@ function result(overrides: Partial<MailAuthCheckResult> = {}): MailAuthCheckResu
 }
 
 describe("ordering", () => {
-  it("ranks verified above asserted above mutable", () => {
+  it("ranks verified above asserted above unverified above mutable", () => {
     assert.equal(meetsMinimum("verified", "asserted"), true);
     assert.equal(meetsMinimum("asserted", "asserted"), true);
+    assert.equal(meetsMinimum("unverified", "asserted"), false);
     assert.equal(meetsMinimum("mutable", "asserted"), false);
     assert.equal(meetsMinimum("asserted", "verified"), false);
+    // The two weak levels are distinct, not aliases: unverified outranks mutable.
+    assert.equal(meetsMinimum("unverified", "mutable"), true);
+    assert.equal(meetsMinimum("mutable", "unverified"), false);
   });
 
   it("takes the weaker side, which is how entry and subject combine", () => {
@@ -36,6 +40,31 @@ describe("ordering", () => {
 });
 
 describe("mailAuthToIdentifierStrengths", () => {
+  // RFC 0027 conformance. The two weak levels mean different things, and this channel emits
+  // exactly one of each: an alias it never checks, and an address nobody authenticated.
+  // Conflating them was the original defect here, and produced a diagnostic that described
+  // a precise address as a nickname.
+  it("separates the unproven address from the alias", () => {
+    const unauthenticated = mailAuthToIdentifierStrengths({
+      verdict: "suspicious",
+      sender: "omar@shahine.com",
+      checks: { dkim: { result: "fail" }, spf: { result: "fail", match: false } },
+    });
+    assert.equal(unauthenticated.address, "unverified", "stable, attacker-chosen, unproven");
+    assert.equal(unauthenticated.displayName, "mutable", "an alias, whoever set it");
+    // Both are below the default minimum, so the distinction is descriptive, not permissive.
+    assert.equal(meetsMinimum(unauthenticated.address, "asserted"), false);
+    assert.equal(meetsMinimum(unauthenticated.displayName, "asserted"), false);
+  });
+
+  it("never emits `mutable` for an address, whatever the verdict", () => {
+    for (const verdict of ["verified", "suspicious", "unknown", "untrusted"] as const) {
+      const s = mailAuthToIdentifierStrengths(result({ verdict }));
+      assert.notEqual(s.address, "mutable", verdict);
+      assert.notEqual(s.domain, "mutable", verdict);
+    }
+  });
+
   it("a display name is never promoted, whatever the verdict", () => {
     for (const verdict of ["verified", "suspicious", "unknown", "untrusted"] as const) {
       assert.equal(mailAuthToIdentifierStrengths(result({ verdict })).displayName, "mutable");
@@ -62,8 +91,8 @@ describe("mailAuthToIdentifierStrengths", () => {
       warnings: ["No trustedAuthservIds configured for account key 'iCloud'"],
     });
     assert.deepEqual(mailAuthToIdentifierStrengths(forged), {
-      address: "mutable",
-      domain: "mutable",
+      address: "unverified",
+      domain: "unverified",
       displayName: "mutable",
     });
   });
@@ -76,8 +105,8 @@ describe("mailAuthToIdentifierStrengths", () => {
         spf: { result: "pass", mailFrom: "bounce@attacker.example", aligned: false, match: false },
       },
     });
-    assert.equal(mailAuthToIdentifierStrengths(unaligned).domain, "mutable");
-    assert.equal(mailAuthToIdentifierStrengths(unaligned).address, "mutable");
+    assert.equal(mailAuthToIdentifierStrengths(unaligned).domain, "unverified");
+    assert.equal(mailAuthToIdentifierStrengths(unaligned).address, "unverified");
   });
 
   // A DKIM pass authenticates header.d, not the From domain. An unaligned signature means
@@ -91,8 +120,8 @@ describe("mailAuthToIdentifierStrengths", () => {
       },
     });
     assert.deepEqual(mailAuthToIdentifierStrengths(unalignedSigner), {
-      address: "mutable",
-      domain: "mutable",
+      address: "unverified",
+      domain: "unverified",
       displayName: "mutable",
     });
   });
@@ -145,7 +174,7 @@ describe("mailAuthToIdentifierStrengths", () => {
     assert.equal(strengths.domain, "verified");
   });
 
-  it("keeps an unauthenticated stranger fully mutable", () => {
+  it("keeps an unauthenticated stranger fully unverified", () => {
     const stranger = result({
       verdict: "untrusted",
       sender: "spoofed@example.com",
@@ -155,16 +184,16 @@ describe("mailAuthToIdentifierStrengths", () => {
       },
     });
     assert.deepEqual(mailAuthToIdentifierStrengths(stranger), {
-      address: "mutable",
-      domain: "mutable",
+      address: "unverified",
+      domain: "unverified",
       displayName: "mutable",
     });
   });
 
   it("treats missing checks as unproven rather than absent-therefore-fine", () => {
     assert.deepEqual(mailAuthToIdentifierStrengths({ verdict: "suspicious" }), {
-      address: "mutable",
-      domain: "mutable",
+      address: "unverified",
+      domain: "unverified",
       displayName: "mutable",
     });
   });
@@ -192,7 +221,7 @@ describe("mailAuthToIdentifierStrengths", () => {
 
   // The bug this mapping exists to prevent. `address` used to have a floor of `asserted`,
   // so `mutable` was unreachable for it and the default `asserted` minimum was not a bar.
-  it("reaches mutable on the address, so the default minimum is a real bar", () => {
+  it("reaches unverified on the address, so the default minimum is a real bar", () => {
     const unauthenticated: MailAuthCheckResult[] = [
       { verdict: "unknown", sender: "omar@shahine.com" },
       { verdict: "suspicious", sender: "omar@shahine.com" },
@@ -200,7 +229,7 @@ describe("mailAuthToIdentifierStrengths", () => {
     ];
     for (const r of unauthenticated) {
       const strengths = mailAuthToIdentifierStrengths(r);
-      assert.equal(strengths.address, "mutable", `verdict ${r.verdict}`);
+      assert.equal(strengths.address, "unverified", `verdict ${r.verdict}`);
       assert.equal(meetsMinimum(strengths.address, "asserted"), false, `verdict ${r.verdict}`);
     }
   });

--- a/openclaw/src/mail-auth/strength.ts
+++ b/openclaw/src/mail-auth/strength.ts
@@ -14,12 +14,26 @@
  * alignment); this module refuses to promote anything it cannot justify.
  */
 
-/** Ordered authentication strength. Mirrors the RFC 0027 scale. */
-export type IdentifierAuthentication = "verified" | "asserted" | "mutable";
+/**
+ * Ordered authentication strength. Mirrors the RFC 0027 scale.
+ *
+ * `unverified` and `mutable` are both untrustworthy and are separated because they are
+ * untrustworthy for different reasons. A display name is weak because it is an *alias*: two
+ * people can hold the same one, and it identifies nobody even when honestly set. An
+ * unauthenticated `From:` is weak because nothing *bound* it to its sender: it is an exact,
+ * stable identifier whose claimed ownership is simply unproven.
+ *
+ * This module originally collapsed the two, scoring an unauthenticated address `mutable`,
+ * because three levels were all the scale had. That produced the right admission and the
+ * wrong reason, which is how a diagnostic ends up describing a precise address as a
+ * nickname. The RFC gained the fourth level after implementing it here surfaced the gap.
+ */
+export type IdentifierAuthentication = "verified" | "asserted" | "unverified" | "mutable";
 
 const RANK: Record<IdentifierAuthentication, number> = {
-  verified: 2,
-  asserted: 1,
+  verified: 3,
+  asserted: 2,
+  unverified: 1,
   mutable: 0,
 };
 
@@ -121,7 +135,7 @@ export function mailAuthToIdentifierStrengths(
   const displayName: IdentifierAuthentication = "mutable";
 
   if (!provenanceEstablished(result)) {
-    return { address: "mutable", domain: "mutable", displayName };
+    return { address: "unverified", domain: "unverified", displayName };
   }
 
   // A DKIM pass authenticates the *signing* domain (header.d), which is not automatically
@@ -143,13 +157,13 @@ export function mailAuthToIdentifierStrengths(
     ? "verified"
     : domainAuthenticated
       ? "asserted"
-      : "mutable";
+      : "unverified";
 
   // An expected signer need not align: mailbox providers routinely sign with their own
   // domain (fastmail.com for a shahine.com address). Naming that signer for that sender is
   // a narrower operator statement than alignment, so it carries the domain claim as well.
   const domain: IdentifierAuthentication =
-    domainAuthenticated || operatorAssertedMailbox ? "verified" : "mutable";
+    domainAuthenticated || operatorAssertedMailbox ? "verified" : "unverified";
 
   return { address, domain, displayName };
 }

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -45,7 +45,17 @@ export type ResolvedAppleMailAccount = {
     account?: string;
     dmPolicy?: string;
     allowFrom?: Array<string | number>;
-    /** Minimum identifier authentication strength required to authorize a sender. */
+    /**
+     * Minimum identifier authentication strength required to authorize a sender.
+     *
+     * Deliberately narrower than `IdentifierAuthentication`, which also has `unverified`.
+     * Offering it here would add a setting with no distinct effect: this channel never scores
+     * an address or a domain `mutable`, so a minimum of `unverified` and a minimum of
+     * `mutable` admit exactly the same mail. `mutable` stays as the single break-glass value
+     * because it is the one already shipped. A test pins the equivalence, so if a future
+     * mapping does emit `mutable` for an address, the omission stops being harmless and the
+     * test fails.
+     */
     minIdentifierAuthentication?: "verified" | "asserted" | "mutable";
     /** Addresses the agent sends as. Used for the inbound and outbound loop guards. */
     selfAddresses?: string[];

--- a/openclaw/src/mail-channel/policy.test.ts
+++ b/openclaw/src/mail-channel/policy.test.ts
@@ -13,9 +13,12 @@ const AUTHENTICATED_STRANGER: MailIdentifierStrengths = {
   domain: "verified",
   displayName: "mutable",
 };
+// Nothing authenticated, so both identifiers are `unverified`: presented by a party nobody
+// vouched for. `asserted` here would model a state the mapper cannot produce and would stop
+// these cases distinguishing a proven domain from an unproven one.
 const UNAUTHENTICATED: MailIdentifierStrengths = {
-  address: "asserted",
-  domain: "asserted",
+  address: "unverified",
+  domain: "unverified",
   displayName: "mutable",
 };
 
@@ -62,7 +65,8 @@ describe("ingress admission", () => {
   });
 
   it("I7/I8: a forged or unaligned pass lands as unauthenticated, not as a stranger to read", () => {
-    // Both attacks resolve to asserted/asserted upstream, so they cannot even reach observe.
+    // Both attacks resolve to unverified/unverified upstream, so they cannot reach observe:
+    // the `observe` branch needs a verified domain, and nothing proved one.
     const forged = decideIngress(ingress({ strengths: UNAUTHENTICATED, allowlisted: false }));
     assert.equal(forged.admission, "drop");
   });
@@ -99,12 +103,22 @@ describe("ingress admission", () => {
     );
   });
 
-  it("honors a relaxed minimum, matching today's default behavior", () => {
-    // minIdentifierAuthentication: "asserted" is the shipped default, under which an
-    // allowlisted sender is admitted without any authentication improvement.
+  // This test used to assert the opposite, and passed only because the fixture above scored
+  // an unauthenticated address `asserted`. It was the original bypass written down as
+  // expected behavior: allowlisted plus the shipped default minimum, admitted with nothing
+  // authenticated. Correcting the fixture surfaced it.
+  it("drops an allowlisted sender who authenticated nothing, at the shipped default", () => {
+    const decision = decideIngress(
+      ingress({ strengths: UNAUTHENTICATED, minIdentifierAuthentication: "asserted" }),
+    );
+    assert.equal(decision.admission, "drop");
+    assert.equal(decision.reason, "identifier_authentication_too_weak");
+  });
+
+  it("admits that same sender only under the break-glass minimum", () => {
     assert.equal(
       decideIngress(
-        ingress({ strengths: UNAUTHENTICATED, minIdentifierAuthentication: "asserted" }),
+        ingress({ strengths: UNAUTHENTICATED, minIdentifierAuthentication: "mutable" }),
       ).admission,
       "dispatch",
     );

--- a/openclaw/src/mail-channel/scenarios.test.ts
+++ b/openclaw/src/mail-channel/scenarios.test.ts
@@ -71,7 +71,7 @@ const ROWS: Row[] = [
       checks: { dkim: { result: "fail" }, spf: { result: "fail", match: false } },
     },
     allowlisted: true,
-    strengths: { address: "mutable", domain: "mutable" },
+    strengths: { address: "unverified", domain: "unverified" },
     // The operator is not special. A failed authentication is dropped, not escalated.
     atDefault: "drop",
     atStrict: "drop",
@@ -82,7 +82,7 @@ const ROWS: Row[] = [
     // auth-check fails closed and returns no checks at all: every header is sender-writable.
     auth: { verdict: "unknown", sender: OPERATOR },
     allowlisted: true,
-    strengths: { address: "mutable", domain: "mutable" },
+    strengths: { address: "unverified", domain: "unverified" },
     atDefault: "drop",
     atStrict: "drop",
   },
@@ -136,7 +136,7 @@ const ROWS: Row[] = [
       sender: "stranger@example.com",
       checks: { dkim: { result: "none" }, spf: { result: "fail", match: false } },
     },
-    strengths: { address: "mutable", domain: "mutable" },
+    strengths: { address: "unverified", domain: "unverified" },
     atDefault: "drop",
     atStrict: "drop",
   },
@@ -147,7 +147,7 @@ const ROWS: Row[] = [
     // it and reports no checks. The forgery buys the attacker nothing.
     auth: { verdict: "suspicious", sender: OPERATOR },
     allowlisted: true,
-    strengths: { address: "mutable", domain: "mutable" },
+    strengths: { address: "unverified", domain: "unverified" },
     atDefault: "drop",
     atStrict: "drop",
   },
@@ -164,7 +164,7 @@ const ROWS: Row[] = [
       },
     },
     allowlisted: true,
-    strengths: { address: "mutable", domain: "mutable" },
+    strengths: { address: "unverified", domain: "unverified" },
     atDefault: "drop",
     atStrict: "drop",
   },
@@ -195,7 +195,7 @@ const ROWS: Row[] = [
       checks: { dkim: { result: "none" }, spf: { result: "none", match: false } },
     },
     threadPermitted: false,
-    strengths: { address: "mutable", domain: "mutable" },
+    strengths: { address: "unverified", domain: "unverified" },
     atDefault: "drop",
     atStrict: "drop",
   },
@@ -222,7 +222,7 @@ const ROWS: Row[] = [
         spf: { result: "fail", mailFrom: "bounce@forwarder.example", aligned: false, match: false },
       },
     },
-    strengths: { address: "mutable", domain: "mutable" },
+    strengths: { address: "unverified", domain: "unverified" },
     atDefault: "drop",
     atStrict: "drop",
   },
@@ -337,7 +337,7 @@ describe("scenario doc: invariants across the table", () => {
 
   // A `From` header nobody vouched for must not clear the lowest configurable bar.
   it("no unauthenticated row reaches dispatch at any minimum", () => {
-    for (const row of ROWS.filter((r) => r.strengths.domain === "mutable")) {
+    for (const row of ROWS.filter((r) => r.strengths.domain === "unverified")) {
       assert.equal(row.atDefault, "drop", `${row.id} at the default minimum`);
       assert.equal(row.atStrict, "drop", `${row.id} at the strict minimum`);
     }

--- a/openclaw/src/mail-channel/scenarios.test.ts
+++ b/openclaw/src/mail-channel/scenarios.test.ts
@@ -335,11 +335,57 @@ describe("scenario doc: invariants across the table", () => {
     }
   });
 
-  // A `From` header nobody vouched for must not clear the lowest configurable bar.
-  it("no unauthenticated row reaches dispatch at any minimum", () => {
-    for (const row of ROWS.filter((r) => r.strengths.domain === "unverified")) {
+  // A `From` header nobody vouched for must not clear either posture an operator would
+  // realistically run. Named for the two minimums it actually checks: the weak values are
+  // break-glass and are asserted separately below, rather than folded in here where the
+  // stored expectations would make this pass without testing them.
+  it("no unauthenticated row reaches dispatch at either supported minimum", () => {
+    const unauthenticated = ROWS.filter((r) => r.strengths.domain === "unverified");
+    assert.ok(unauthenticated.length > 0, "the table must cover unauthenticated senders");
+    for (const row of unauthenticated) {
       assert.equal(row.atDefault, "drop", `${row.id} at the default minimum`);
       assert.equal(row.atStrict, "drop", `${row.id} at the strict minimum`);
     }
+  });
+
+  // `unverified` is not offered as a config value because it would do nothing distinct: this
+  // channel never scores an address or domain `mutable`, so the two weakest minimums admit
+  // the same mail. If a future mapping emits `mutable` for an address, that stops being true
+  // and this fails, which is the point.
+  it("treats `unverified` and `mutable` as the same minimum, which is why only one is configurable", () => {
+    for (const row of ROWS) {
+      if (row.selfAddressed) {
+        continue;
+      }
+      const strengths = mailAuthToIdentifierStrengths(row.auth);
+      const base = {
+        strengths,
+        senderAddress: row.auth.sender ?? "",
+        allowlisted: row.allowlisted ?? false,
+        selfAddressed: false,
+        threadPermitted: row.threadPermitted ?? false,
+      };
+      assert.equal(
+        decideIngress({ ...base, minIdentifierAuthentication: "unverified" }).admission,
+        decideIngress({ ...base, minIdentifierAuthentication: "mutable" }).admission,
+        row.id,
+      );
+    }
+  });
+
+  // And the break-glass value is genuinely break-glass: it admits what the real postures
+  // reject, so nobody reads the equivalence above as "the weak setting is safe".
+  it("the break-glass minimum does admit what the supported ones drop", () => {
+    const spoofed = ROWS.find((r) => r.id === "I7");
+    assert.ok(spoofed, "I7 is the spoofed-operator row");
+    const decision = decideIngress({
+      strengths: mailAuthToIdentifierStrengths(spoofed.auth),
+      senderAddress: spoofed.auth.sender ?? "",
+      allowlisted: true,
+      selfAddressed: false,
+      threadPermitted: false,
+      minIdentifierAuthentication: "mutable",
+    });
+    assert.equal(decision.admission, "dispatch", "break-glass means exactly that");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

This channel is RFC 0027's reference implementation and did not conform to it.

It scored an unauthenticated `From:` as `mutable`, because three levels were all the scale had when this was written. Implementing it here is what surfaced the missing fourth level, and the RFC has it now (openclaw/rfcs#51).

`mutable` means **alias** — a nickname two people can hold, which identifies nobody even when honestly set. An unauthenticated address is the opposite shape of wrong: exact and stable, with nothing binding it to its sender. Collapsing them yields the right admission and a diagnostic that describes a precise address as a nickname.

## Why This Change Was Made

| Level | Means | An identifier gets it when |
| --- | --- | --- |
| `verified` | our boundary proved this exact mailbox | an expected signer signed it |
| `asserted` | our boundary proved the domain, nothing narrower | the domain authenticated but no operator assertion names the mailbox |
| `unverified` | presented by a party nobody authenticated | authentication produced nothing |
| `mutable` | a user-changeable alias | always, for a display name |

`mutable` is now unreachable for an address or a domain here. That is correct rather than dead code: it is pinned to the display name, and the level exists for channels whose allowlists can match nicknames. A test asserts no address or domain ever receives it, so a future mapping cannot quietly reintroduce the conflation.

## User Impact

**None.** `unverified` sits below the default `asserted` minimum exactly where `mutable` did, so every scenario that dropped still drops. This is a naming correction, not a policy change.

## Evidence

- 204 tests, `tsc --noEmit` clean, `npm run build` clean.
- Re-run against the same 25 real Archive messages used to validate the original mapping: **23 `observe`, 2 `dispatch` — identical to the run before this change.**
- New tests pin the property directly: the four-level ordering, that `unverified` outranks `mutable` rather than aliasing it, that both sit below the default minimum so the distinction is descriptive rather than permissive, and that no address or domain is ever scored `mutable`.

## Still Not Conforming

The RFC's premise is that **core** owns the gate. This channel still enforces it plugin-side, with a shim comment saying so, because the kernel primitive is PR 2 of a stack that does not exist yet. So this is a reference implementation of the *design*, and closer to the *contract* than it was, but not yet a consumer of the primitive.