### PR TITLE
fix(openclaw): stop passing a JXA account name to sqlite reads

### DIFF
--- a/openclaw/src/mail-channel/config-check.test.ts
+++ b/openclaw/src/mail-channel/config-check.test.ts
@@ -114,3 +114,32 @@ describe("checkChannelConfig", () => {
     assert.deepEqual(found, ["loop_guard_disabled", "no_trusted_authserv_id"]);
   });
 });
+
+describe("unscoped mailbox reads", () => {
+  const base = {
+    allowFrom: [],
+    selfAddresses: [],
+    minIdentifierAuthentication: "verified" as const,
+  };
+
+  // Greptile P1 on #96: dropping --account fixed a crash and silently removed account
+  // isolation, so one account's policy would ingest another account's mail.
+  it("flags an unscoped read on a multi-account mailbox", () => {
+    const codes = checkChannelConfig({ ...base, knownAccountCount: 2 }).map((f) => f.code);
+    assert.ok(codes.includes("unscoped_mailbox_reads"));
+  });
+
+  it("stays quiet once accountId scopes the read", () => {
+    const codes = checkChannelConfig({
+      ...base,
+      knownAccountCount: 2,
+      accountId: "168231BA-20A5-4B91-B54D-8D9906C76D25",
+    }).map((f) => f.code);
+    assert.equal(codes.includes("unscoped_mailbox_reads"), false);
+  });
+
+  it("stays quiet on a single-account mailbox, where the broader query is harmless", () => {
+    const codes = checkChannelConfig({ ...base, knownAccountCount: 1 }).map((f) => f.code);
+    assert.equal(codes.includes("unscoped_mailbox_reads"), false);
+  });
+});

--- a/openclaw/src/mail-channel/config-check.ts
+++ b/openclaw/src/mail-channel/config-check.ts
@@ -21,7 +21,8 @@ export type ConfigFinding = {
     | "trusted_senders_unreadable"
     | "no_trusted_authserv_id"
     | "allowlisted_not_enrolled"
-    | "enrolled_without_expected_signers";
+    | "enrolled_without_expected_signers"
+    | "unscoped_mailbox_reads";
   message: string;
 };
 
@@ -41,6 +42,10 @@ export type ConfigCheckInput = {
   trustedSenders?: readonly TrustedSenderEntry[];
   /** Parsed `trustedAuthservIds`, keyed by Mail.app account name, with `*` as the wildcard. */
   trustedAuthservIds?: Readonly<Record<string, readonly string[]>>;
+  /** SQLite account UUID used to scope reads. */
+  accountId?: string;
+  /** How many accounts Mail.app reports. Only >1 makes unscoped reads dangerous. */
+  knownAccountCount?: number;
 };
 
 function normalize(values: readonly string[] | undefined): Set<string> {
@@ -55,6 +60,18 @@ function normalize(values: readonly string[] | undefined): Set<string> {
  */
 export function checkChannelConfig(input: ConfigCheckInput): ConfigFinding[] {
   const findings: ConfigFinding[] = [];
+
+  // Unscoped reads match a mailbox name in every account, so on a multi-account Mail.app
+  // this account's policy would be applied to another account's mail.
+  if (!input.accountId && (input.knownAccountCount ?? 1) > 1) {
+    findings.push({
+      code: "unscoped_mailbox_reads",
+      message:
+        `accountId is not set and Mail.app reports ${input.knownAccountCount} accounts, so ` +
+        "mailbox reads are not scoped and will include mail from other accounts. Set " +
+        "accountId to the UUID from `mail-cli accounts --engine sqlite`.",
+    });
+  }
   const path = input.trustedSendersPath ?? "trusted-senders.json";
 
   // I13. Without this the agent can answer its own mail, and the loop is only bounded by

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -43,6 +43,11 @@ export type ResolvedAppleMailAccount = {
   config: {
     /** Mail.app account name, as reported by JXA. Selects the trusted authserv-id set. */
     account?: string;
+    /**
+     * SQLite account UUID, from `mail-cli accounts --engine sqlite`. Scopes reads to one
+     * account; without it a mailbox name matches in every account.
+     */
+    accountId?: string;
     dmPolicy?: string;
     allowFrom?: Array<string | number>;
     /**
@@ -180,6 +185,7 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
 
     const deps = createMailCliDeps({
       account: config.account,
+      accountId: config.accountId,
       trustedSendersPath: config.trustedSendersPath,
     });
 

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -32,7 +32,8 @@ const run = promisify(execFile);
  * account, which is correct, just broader.
  *
  * JXA-backed commands (`reply`) do take it, because there the display name is the right
- * identifier.
+ * identifier. SQLite reads take `accountId`, the account UUID, which is the identifier that
+ * namespace uses.
  */
 export type MailCliOptions = {
   /** Directory holding the Swift CLIs. Falls back to whatever is on PATH. */
@@ -41,6 +42,15 @@ export type MailCliOptions = {
   trustedSendersPath?: string;
   /** Mail.app account name, passed as a lookup hint. */
   account?: string;
+  /**
+   * SQLite account UUID, from `mail-cli accounts --engine sqlite`.
+   *
+   * Scopes reads to one account. Without it a mailbox name matches in every configured
+   * account, so a multi-account Mail.app would feed one account's policy with another
+   * account's mail. Optional because a single-account install cannot be harmed by the
+   * broader query, and `checkChannelConfig` reports the risk when it is absent.
+   */
+  accountId?: string;
   /** Per-call timeout. A hung CLI must not stall the poll loop forever. */
   timeoutMs?: number;
 };
@@ -95,8 +105,9 @@ export async function readTrustedSenders(
 
 /** Builds the inbound dependency set backed by the real CLI. */
 export function createMailCliDeps(options: MailCliOptions): InboundDeps {
-  // No --account here: every command below uses --engine sqlite. See MailCliOptions.
-  const accountArgs: string[] = [];
+  // SQLite keys accounts by UUID, so only accountId belongs here. Passing the JXA display
+  // name fails outright ("Account not found: iCloud").
+  const accountArgs = options.accountId ? ["--account", options.accountId] : [];
   const trustedArgs = options.trustedSendersPath
     ? ["--trusted-senders", options.trustedSendersPath]
     : [];
@@ -204,8 +215,8 @@ export function createMailCliSender(options: MailCliOptions): ReplySender {
 export function createMailCliBodyReader(
   options: MailCliOptions,
 ): (messageId: string) => Promise<string | undefined> {
-  // Also --engine sqlite, so also no --account. See MailCliOptions.
-  const accountArgs: string[] = [];
+  // Also --engine sqlite, so also the UUID. See MailCliOptions.
+  const accountArgs = options.accountId ? ["--account", options.accountId] : [];
   return async (messageId) => {
     const result = await runJson<{ message?: { content?: string }; content?: string }>(options, [
       "get",

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -21,6 +21,19 @@ import type { ConfigCheckInput } from "./config-check.ts";
 
 const run = promisify(execFile);
 
+/**
+ * `account` is the **JXA display name** (for example `iCloud`).
+ *
+ * It is deliberately not passed to `--engine sqlite` commands. The two engines identify
+ * accounts in different namespaces: JXA reports the display name, SQLite reports the
+ * account UUID, and handing SQLite a display name fails with "Account not found". The
+ * field exists for keying `trustedAuthservIds`, which is the security-relevant use, and
+ * the `--account` hint on a read is only an optimization: omitting it searches every
+ * account, which is correct, just broader.
+ *
+ * JXA-backed commands (`reply`) do take it, because there the display name is the right
+ * identifier.
+ */
 export type MailCliOptions = {
   /** Directory holding the Swift CLIs. Falls back to whatever is on PATH. */
   binDir?: string;
@@ -82,7 +95,8 @@ export async function readTrustedSenders(
 
 /** Builds the inbound dependency set backed by the real CLI. */
 export function createMailCliDeps(options: MailCliOptions): InboundDeps {
-  const accountArgs = options.account ? ["--account", options.account] : [];
+  // No --account here: every command below uses --engine sqlite. See MailCliOptions.
+  const accountArgs: string[] = [];
   const trustedArgs = options.trustedSendersPath
     ? ["--trusted-senders", options.trustedSendersPath]
     : [];
@@ -190,7 +204,8 @@ export function createMailCliSender(options: MailCliOptions): ReplySender {
 export function createMailCliBodyReader(
   options: MailCliOptions,
 ): (messageId: string) => Promise<string | undefined> {
-  const accountArgs = options.account ? ["--account", options.account] : [];
+  // Also --engine sqlite, so also no --account. See MailCliOptions.
+  const accountArgs: string[] = [];
   return async (messageId) => {
     const result = await runJson<{ message?: { content?: string }; content?: string }>(options, [
       "get",


### PR DESCRIPTION
## What Problem This Solves

The two `mail-cli` engines identify accounts in **different namespaces**. JXA reports the display name (`iCloud`); SQLite reports the account UUID. Passing the display name to an `--engine sqlite` command fails outright:

```
$ mail-cli messages --mailbox Archive --limit 1 --account "iCloud" --engine sqlite
Error: SQLite engine failed: Account not found: iCloud (retry with --engine auto or jxa, ...)

$ mail-cli messages --mailbox Archive --limit 1 --engine sqlite
count: 1 | success: True
```

Every read in `createMailCliDeps` and `createMailCliBodyReader` uses `--engine sqlite`, so configuring `account` broke the very calls the hint was meant to optimize. A single-account install never noticed, because `account` is optional.

## Why This Change Was Made

Dropping the hint searches all accounts: correct, just broader. The `account` field stays, because it still does the security-relevant job of keying `trustedAuthservIds`, and JXA-backed commands (`reply`) legitimately take it.

This is the **same namespace mismatch** already handled for `trustedAuthservIds`, surfacing a second time in the read path. Worth noting as a recurring shape rather than a one-off: any new `--engine sqlite` call site is a place to get this wrong again, which is why the reasoning now sits on `MailCliOptions` where the next caller will read it.

## Evidence

Reproduced and fixed live against the real mailbox (output above). 207 tests passing, `tsc -p tsconfig.json` clean.

**Not merging without your approval** — though you have already said to land your own repos once green, so I will take it to green and merge unless you say otherwise.