### PR TITLE
test(mail): scrub personal address from test fixtures (PII)

### DIFF
--- a/openclaw/src/mail-auth/strength.test.ts
+++ b/openclaw/src/mail-auth/strength.test.ts
@@ -11,10 +11,10 @@ import {
 function result(overrides: Partial<MailAuthCheckResult> = {}): MailAuthCheckResult {
   return {
     verdict: "verified",
-    sender: "omar@shahine.com",
+    sender: "operator@example.com",
     checks: {
-      dkim: { result: "pass", signingDomain: "shahine.com", match: true },
-      spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+      dkim: { result: "pass", signingDomain: "example.com", match: true },
+      spf: { result: "pass", mailFrom: "operator@example.com", aligned: true, match: true },
     },
     ...overrides,
   };
@@ -47,7 +47,7 @@ describe("mailAuthToIdentifierStrengths", () => {
   it("separates the unproven address from the alias", () => {
     const unauthenticated = mailAuthToIdentifierStrengths({
       verdict: "suspicious",
-      sender: "omar@shahine.com",
+      sender: "operator@example.com",
       checks: { dkim: { result: "fail" }, spf: { result: "fail", match: false } },
     });
     assert.equal(unauthenticated.address, "unverified", "stable, attacker-chosen, unproven");
@@ -85,8 +85,8 @@ describe("mailAuthToIdentifierStrengths", () => {
     const forged = result({
       verdict: "unknown",
       checks: {
-        dkim: { result: "pass", signingDomain: "shahine.com", match: true },
-        spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+        dkim: { result: "pass", signingDomain: "example.com", match: true },
+        spf: { result: "pass", mailFrom: "operator@example.com", aligned: true, match: true },
       },
       warnings: ["No trustedAuthservIds configured for account key 'iCloud'"],
     });
@@ -130,7 +130,7 @@ describe("mailAuthToIdentifierStrengths", () => {
     const subdomainSigner = result({
       verdict: "suspicious",
       checks: {
-        dkim: { result: "pass", signingDomain: "mail.shahine.com", match: false },
+        dkim: { result: "pass", signingDomain: "mail.example.com", match: false },
         spf: { result: "none", match: false },
       },
     });
@@ -143,7 +143,7 @@ describe("mailAuthToIdentifierStrengths", () => {
     const alignedUnexpected = result({
       verdict: "suspicious",
       checks: {
-        dkim: { result: "pass", signingDomain: "shahine.com", match: false },
+        dkim: { result: "pass", signingDomain: "example.com", match: false },
         spf: { result: "none", match: false },
       },
     });
@@ -206,10 +206,10 @@ describe("mailAuthToIdentifierStrengths", () => {
   it("carries the domain claim when the operator named an unaligned expected signer", () => {
     const providerSigned = result({
       verdict: "verified",
-      sender: "omar@shahine.com",
+      sender: "operator@example.com",
       checks: {
         dkim: { result: "pass", signingDomain: "fastmail.com", match: true },
-        spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+        spf: { result: "pass", mailFrom: "operator@example.com", aligned: true, match: true },
       },
     });
     assert.deepEqual(mailAuthToIdentifierStrengths(providerSigned), {
@@ -223,9 +223,9 @@ describe("mailAuthToIdentifierStrengths", () => {
   // so `mutable` was unreachable for it and the default `asserted` minimum was not a bar.
   it("reaches unverified on the address, so the default minimum is a real bar", () => {
     const unauthenticated: MailAuthCheckResult[] = [
-      { verdict: "unknown", sender: "omar@shahine.com" },
-      { verdict: "suspicious", sender: "omar@shahine.com" },
-      { verdict: "untrusted", sender: "omar@shahine.com" },
+      { verdict: "unknown", sender: "operator@example.com" },
+      { verdict: "suspicious", sender: "operator@example.com" },
+      { verdict: "untrusted", sender: "operator@example.com" },
     ];
     for (const r of unauthenticated) {
       const strengths = mailAuthToIdentifierStrengths(r);

--- a/openclaw/src/mail-auth/strength.ts
+++ b/openclaw/src/mail-auth/strength.ts
@@ -160,7 +160,7 @@ export function mailAuthToIdentifierStrengths(
       : "unverified";
 
   // An expected signer need not align: mailbox providers routinely sign with their own
-  // domain (fastmail.com for a shahine.com address). Naming that signer for that sender is
+  // domain (fastmail.com for a example.com address). Naming that signer for that sender is
   // a narrower operator statement than alignment, so it carries the domain claim as well.
   const domain: IdentifierAuthentication =
     domainAuthenticated || operatorAssertedMailbox ? "verified" : "unverified";

--- a/openclaw/src/mail-channel/config-check.test.ts
+++ b/openclaw/src/mail-channel/config-check.test.ts
@@ -4,12 +4,12 @@ import { checkChannelConfig, type ConfigCheckInput } from "./config-check.ts";
 
 function input(overrides: Partial<ConfigCheckInput> = {}): ConfigCheckInput {
   return {
-    allowFrom: ["omar@shahine.com"],
+    allowFrom: ["operator@example.com"],
     selfAddresses: ["lobster@example.com"],
     minIdentifierAuthentication: "verified",
     trustedSendersPath: "~/.config/lobster/trusted-senders.json",
     trustedSenders: [
-      { name: "Omar", emails: ["omar@shahine.com"], expectedDkimDomains: ["shahine.com"] },
+      { name: "Operator", emails: ["operator@example.com"], expectedDkimDomains: ["example.com"] },
     ],
     trustedAuthservIds: { "*": ["mx.icloud.com"] },
     ...overrides,
@@ -30,12 +30,12 @@ describe("checkChannelConfig", () => {
   // The whole reason this module exists: the strict posture makes a missing enrollment
   // change behavior, and nothing else in the system says so.
   it("reports an allowFrom entry with no enrollment behind it", () => {
-    const found = checkChannelConfig(input({ allowFrom: ["omar@shahine.com", "lora@shahine.com"] }));
+    const found = checkChannelConfig(input({ allowFrom: ["operator@example.com", "family@example.com"] }));
     assert.deepEqual(
       found.map((f) => f.code),
       ["allowlisted_not_enrolled"],
     );
-    assert.match(found[0]!.message, /lora@shahine\.com/);
+    assert.match(found[0]!.message, /family@example\.com/);
     assert.match(found[0]!.message, /readable\s+but never actioned/);
   });
 
@@ -43,7 +43,7 @@ describe("checkChannelConfig", () => {
     const found = codes(
       input({
         allowFrom: [],
-        trustedSenders: [{ name: "Omar", emails: ["omar@shahine.com"], expectedDkimDomains: [] }],
+        trustedSenders: [{ name: "Operator", emails: ["operator@example.com"], expectedDkimDomains: [] }],
       }),
     );
     assert.deepEqual(found, ["enrolled_without_expected_signers"]);
@@ -53,7 +53,7 @@ describe("checkChannelConfig", () => {
     const found = codes(
       input({
         trustedSenders: [
-          { name: "Omar", emails: ["omar@shahine.com"], expectedDkimDomains: ["  "] },
+          { name: "Operator", emails: ["operator@example.com"], expectedDkimDomains: ["  "] },
         ],
       }),
     );
@@ -63,7 +63,7 @@ describe("checkChannelConfig", () => {
   });
 
   it("matches allowFrom against enrollment case-insensitively", () => {
-    assert.deepEqual(checkChannelConfig(input({ allowFrom: ["Omar@Shahine.COM"] })), []);
+    assert.deepEqual(checkChannelConfig(input({ allowFrom: ["Operator@example.com"] })), []);
   });
 
   it("reports a missing authserv-id pin, which drops everything", () => {
@@ -78,7 +78,7 @@ describe("checkChannelConfig", () => {
     const maps: Record<string, readonly string[]>[] = [
       { "*": ["mx.icloud.com"] },
       { iCloud: ["mx.icloud.com"] },
-      { "168231BA-20A5-4B91-B54D-8D9906C76D25": ["mx.icloud.com"] },
+      { "00000000-0000-0000-0000-000000000000": ["mx.icloud.com"] },
       { Fastmail: ["mx.fastmail.com"] },
     ];
     for (const map of maps) {
@@ -133,7 +133,7 @@ describe("unscoped mailbox reads", () => {
     const codes = checkChannelConfig({
       ...base,
       knownAccountCount: 2,
-      accountId: "168231BA-20A5-4B91-B54D-8D9906C76D25",
+      accountId: "00000000-0000-0000-0000-000000000000",
     }).map((f) => f.code);
     assert.equal(codes.includes("unscoped_mailbox_reads"), false);
   });

--- a/openclaw/src/mail-channel/dispatch.test.ts
+++ b/openclaw/src/mail-channel/dispatch.test.ts
@@ -6,7 +6,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 
 const OPTIONS: DispatchOptions = {
   cfg: {} as OpenClawConfig,
-  operatorAddresses: ["omar@shahine.com"],
+  operatorAddresses: ["operator@example.com"],
   egressAllowlist: ["known@example.com"],
   selfAddresses: ["lobster@example.com"],
   sessionPrefix: "apple-mail:default",
@@ -44,9 +44,9 @@ function deps(overrides: Partial<DispatchDeps> = {}) {
 describe("dispatchAdmittedMessage", () => {
   it("replies to the operator", async () => {
     const { deps: d, sent } = deps();
-    const r = await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    const r = await dispatchAdmittedMessage(classified("operator@example.com"), d, OPTIONS);
     assert.equal(r.replied, true);
-    assert.deepEqual(sent, [{ to: "omar@shahine.com", body: "the agent's reply" }]);
+    assert.deepEqual(sent, [{ to: "operator@example.com", body: "the agent's reply" }]);
   });
 
   it("replies to an egress-allowlisted correspondent", async () => {
@@ -98,7 +98,7 @@ describe("dispatchAdmittedMessage", () => {
         await dispatcherOptions.deliver({ text: "   " });
       },
     });
-    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    await dispatchAdmittedMessage(classified("operator@example.com"), d, OPTIONS);
     assert.deepEqual(sent, []);
   });
 
@@ -111,13 +111,13 @@ describe("dispatchAdmittedMessage", () => {
         bodies.push(ctx.Body);
       },
     });
-    const m = classified("omar@shahine.com");
+    const m = classified("operator@example.com");
     m.message.dateReceived = "2026-07-29T14:02:00Z";
     m.message.attachmentCount = 2;
     await dispatchAdmittedMessage(m, d, OPTIONS);
     assert.equal(
       bodies[0],
-      "From: omar@shahine.com\nSubject: hello\nDate: 2026-07-29T14:02:00Z\nAttachments: 2\nMessage-ID: m1",
+      "From: operator@example.com\nSubject: hello\nDate: 2026-07-29T14:02:00Z\nAttachments: 2\nMessage-ID: m1",
     );
   });
 
@@ -128,10 +128,10 @@ describe("dispatchAdmittedMessage", () => {
         bodies.push(ctx.Body);
       },
     });
-    const m = classified("omar@shahine.com");
+    const m = classified("operator@example.com");
     m.message.subject = undefined;
     return dispatchAdmittedMessage(m, d, OPTIONS).then(() => {
-      assert.equal(bodies[0], "From: omar@shahine.com\nSubject: (none)\nMessage-ID: m1");
+      assert.equal(bodies[0], "From: operator@example.com\nSubject: (none)\nMessage-ID: m1");
     });
   });
 
@@ -144,7 +144,7 @@ describe("dispatchAdmittedMessage", () => {
         bodies.push(ctx.Body);
       },
     });
-    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    await dispatchAdmittedMessage(classified("operator@example.com"), d, OPTIONS);
     assert.match(bodies[0] ?? "", /Summary:\nA receipt for one coffee\.$/);
   });
 
@@ -155,7 +155,7 @@ describe("dispatchAdmittedMessage", () => {
         await dispatcherOptions.deliver({ text: "   " });
       },
     });
-    const r = await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    const r = await dispatchAdmittedMessage(classified("operator@example.com"), d, OPTIONS);
     assert.deepEqual(sent, []);
     assert.equal(r.replied, false);
     assert.equal(r.reason, "empty_reply");
@@ -170,11 +170,11 @@ describe("dispatchAdmittedMessage", () => {
         keys.push(ctx.SessionKey);
       },
     });
-    const first = classified("omar@shahine.com");
-    const laterInSameThread = classified("omar@shahine.com");
+    const first = classified("operator@example.com");
+    const laterInSameThread = classified("operator@example.com");
     laterInSameThread.message.messageId = "m2";
     laterInSameThread.threadKey = "m1";
-    const unrelated = classified("omar@shahine.com");
+    const unrelated = classified("operator@example.com");
     unrelated.message.messageId = "m3";
     unrelated.threadKey = "m3";
 
@@ -195,7 +195,7 @@ describe("dispatchAdmittedMessage", () => {
         keys.push(ctx.SessionKey);
       },
     });
-    const a = classified("omar@shahine.com");
+    const a = classified("operator@example.com");
     const b = classified("known@example.com");
     b.threadKey = "m1";
     await dispatchAdmittedMessage(a, d, OPTIONS);
@@ -216,12 +216,12 @@ describe("thread recording", () => {
         recorded.push(reply);
       },
     });
-    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    await dispatchAdmittedMessage(classified("operator@example.com"), d, OPTIONS);
     assert.deepEqual(recorded, [
       {
         inboundMessageId: "m1",
         sentMessageId: "<agent-1@lobster.example>",
-        recipients: ["omar@shahine.com"],
+        recipients: ["operator@example.com"],
       },
     ]);
   });
@@ -247,7 +247,7 @@ describe("thread recording", () => {
         recorded.push(reply);
       },
     });
-    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    await dispatchAdmittedMessage(classified("operator@example.com"), d, OPTIONS);
     assert.deepEqual(recorded, []);
   });
 
@@ -259,7 +259,7 @@ describe("thread recording", () => {
         recorded.push(reply);
       },
     });
-    await dispatchAdmittedMessage(classified("omar@shahine.com"), d, OPTIONS);
+    await dispatchAdmittedMessage(classified("operator@example.com"), d, OPTIONS);
     assert.equal(recorded.length, 1);
     assert.equal(recorded[0]?.sentMessageId, undefined);
   });

--- a/openclaw/src/mail-channel/inbound.test.ts
+++ b/openclaw/src/mail-channel/inbound.test.ts
@@ -12,7 +12,7 @@ import type { MailAuthCheckResult } from "../mail-auth/strength.ts";
 function msg(overrides: Partial<MailboxMessage> = {}): MailboxMessage {
   return {
     messageId: "m1@example.com",
-    sender: "Omar Shahine <omar@shahine.com>",
+    sender: "Test Operator <operator@example.com>",
     dateReceived: "2026-07-28T10:00:00.000Z",
     ...overrides,
   };
@@ -20,10 +20,10 @@ function msg(overrides: Partial<MailboxMessage> = {}): MailboxMessage {
 
 const VERIFIED_AUTH: MailAuthCheckResult = {
   verdict: "verified",
-  sender: "omar@shahine.com",
+  sender: "operator@example.com",
   checks: {
-    dkim: { result: "pass", signingDomain: "shahine.com", match: true },
-    spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+    dkim: { result: "pass", signingDomain: "example.com", match: true },
+    spf: { result: "pass", mailFrom: "operator@example.com", aligned: true, match: true },
   },
 };
 
@@ -37,10 +37,10 @@ function deps(overrides: Partial<InboundDeps> = {}): InboundDeps {
 
 describe("senderAddress", () => {
   it("extracts from a display-name form", () => {
-    assert.equal(senderAddress("Omar Shahine <Omar@Shahine.com>"), "omar@shahine.com");
+    assert.equal(senderAddress("Test Operator <Operator@example.com>"), "operator@example.com");
   });
   it("passes a bare address through", () => {
-    assert.equal(senderAddress("  omar@shahine.com "), "omar@shahine.com");
+    assert.equal(senderAddress("  operator@example.com "), "operator@example.com");
   });
 });
 
@@ -107,11 +107,11 @@ describe("selectNewMessages", () => {
 describe("classifyMessage", () => {
   it("dispatches an authenticated allowlisted sender", async () => {
     const r = await classifyMessage(msg(), deps(), {
-      allowFrom: ["omar@shahine.com"],
+      allowFrom: ["operator@example.com"],
       minIdentifierAuthentication: "verified",
     });
     assert.equal(r.decision.admission, "dispatch");
-    assert.equal(r.address, "omar@shahine.com");
+    assert.equal(r.address, "operator@example.com");
   });
 
   it("observes an authenticated stranger", async () => {
@@ -129,9 +129,9 @@ describe("classifyMessage", () => {
   });
 
   it("drops a spoofed sender whose provenance never held", async () => {
-    const forged: MailAuthCheckResult = { verdict: "unknown", sender: "omar@shahine.com" };
+    const forged: MailAuthCheckResult = { verdict: "unknown", sender: "operator@example.com" };
     const r = await classifyMessage(msg(), deps({ authCheck: async () => forged }), {
-      allowFrom: ["omar@shahine.com"],
+      allowFrom: ["operator@example.com"],
       minIdentifierAuthentication: "verified",
     });
     assert.equal(r.decision.admission, "drop");
@@ -148,7 +148,7 @@ describe("classifyMessage", () => {
           return {};
         },
       }),
-      { allowFrom: ["omar@shahine.com"], minIdentifierAuthentication: "verified" },
+      { allowFrom: ["operator@example.com"], minIdentifierAuthentication: "verified" },
     );
     assert.equal(called, false);
   });
@@ -156,7 +156,7 @@ describe("classifyMessage", () => {
   it("derives allowlist membership from the configured list", async () => {
     // Greptile P1: startAccount passed constant false, so trusted senders were strangers.
     const r = await classifyMessage(msg(), deps(), {
-      allowFrom: ["OMAR@Shahine.com"],
+      allowFrom: ["operator@example.com"],
       minIdentifierAuthentication: "verified",
     });
     assert.equal(r.decision.admission, "dispatch");
@@ -173,7 +173,7 @@ describe("classifyMessage", () => {
 
   it("activates the loop guard from configured self addresses", async () => {
     const r = await classifyMessage(msg(), deps(), {
-      selfAddresses: ["Omar@Shahine.com"],
+      selfAddresses: ["Operator@example.com"],
       minIdentifierAuthentication: "verified",
     });
     assert.deepEqual(r.decision, { admission: "drop", reason: "self_addressed" });
@@ -229,7 +229,7 @@ describe("thread key and session isolation", () => {
   const records = [
     {
       inboundAnchorIds: ["known-thread@example.com"],
-      addressedRecipients: ["omar@shahine.com"],
+      addressedRecipients: ["operator@example.com"],
     },
   ];
   const deps = {
@@ -261,15 +261,15 @@ describe("thread key and session isolation", () => {
 
   it("does file a real participant into it", async () => {
     const result = await classifyMessage(
-      { messageId: "reply", sender: "omar@shahine.com" },
+      { messageId: "reply", sender: "operator@example.com" },
       {
         ...deps,
         authCheck: async () => ({
           verdict: "untrusted" as const,
-          sender: "omar@shahine.com",
+          sender: "operator@example.com",
           checks: {
-            dkim: { result: "pass", signingDomain: "shahine.com", match: false },
-            spf: { result: "pass", mailFrom: "o@shahine.com", aligned: true, match: true },
+            dkim: { result: "pass", signingDomain: "example.com", match: false },
+            spf: { result: "pass", mailFrom: "o@example.com", aligned: true, match: true },
           },
         }),
       },

--- a/openclaw/src/mail-channel/policy.test.ts
+++ b/openclaw/src/mail-channel/policy.test.ts
@@ -25,7 +25,7 @@ const UNAUTHENTICATED: MailIdentifierStrengths = {
 function ingress(overrides: Partial<IngressInput> = {}): IngressInput {
   return {
     strengths: VERIFIED,
-    senderAddress: "omar@shahine.com",
+    senderAddress: "operator@example.com",
     allowlisted: true,
     minIdentifierAuthentication: "verified",
     selfAddressed: false,
@@ -127,7 +127,7 @@ describe("ingress admission", () => {
 
 describe("egress", () => {
   const base = {
-    operatorAddresses: ["omar@shahine.com"],
+    operatorAddresses: ["operator@example.com"],
     egressAllowlist: ["known@example.com"],
     selfAddresses: ["lobster@example.com"],
     threadPermitted: false,
@@ -135,8 +135,8 @@ describe("egress", () => {
   };
 
   it("E3: always permits the operator", () => {
-    const d = decideEgress({ ...base, recipients: ["omar@shahine.com"] });
-    assert.deepEqual(d.permitted.map((e) => e.address), ["omar@shahine.com"]);
+    const d = decideEgress({ ...base, recipients: ["operator@example.com"] });
+    assert.deepEqual(d.permitted.map((e) => e.address), ["operator@example.com"]);
     assert.equal(d.denied.length, 0);
   });
 
@@ -192,7 +192,7 @@ describe("egress", () => {
     // with threadPermitted set was logged as thread authority it never used.
     const d = decideEgress({
       ...base,
-      recipients: ["omar@shahine.com", "known@example.com"],
+      recipients: ["operator@example.com", "known@example.com"],
       threadPermitted: true,
       threadParticipants: ["someone-else@example.com"],
     });
@@ -203,10 +203,10 @@ describe("egress", () => {
   it("reports each recipient's own basis, not one basis for the send", () => {
     const d = decideEgress({
       ...base,
-      recipients: ["omar@shahine.com", "known@example.com"],
+      recipients: ["operator@example.com", "known@example.com"],
     });
     assert.deepEqual(d.permitted, [
-      { address: "omar@shahine.com", reason: "operator_recipient" },
+      { address: "operator@example.com", reason: "operator_recipient" },
       { address: "known@example.com", reason: "recipient_allowlisted" },
     ]);
   });
@@ -214,9 +214,9 @@ describe("egress", () => {
   it("E8: narrows reply-all instead of leaking to unknown recipients", () => {
     const d = decideEgress({
       ...base,
-      recipients: ["omar@shahine.com", "known@example.com", "stranger@example.com"],
+      recipients: ["operator@example.com", "known@example.com", "stranger@example.com"],
     });
-    assert.deepEqual(d.permitted.map((e) => e.address), ["omar@shahine.com", "known@example.com"]);
+    assert.deepEqual(d.permitted.map((e) => e.address), ["operator@example.com", "known@example.com"]);
     assert.deepEqual(d.denied, [
       { address: "stranger@example.com", reason: "recipient_not_permitted" },
     ]);

--- a/openclaw/src/mail-channel/poll.test.ts
+++ b/openclaw/src/mail-channel/poll.test.ts
@@ -6,10 +6,10 @@ import type { MailAuthCheckResult } from "../mail-auth/strength.ts";
 
 const VERIFIED: MailAuthCheckResult = {
   verdict: "verified",
-  sender: "omar@shahine.com",
+  sender: "operator@example.com",
   checks: {
-    dkim: { result: "pass", signingDomain: "shahine.com", match: true },
-    spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+    dkim: { result: "pass", signingDomain: "example.com", match: true },
+    spf: { result: "pass", mailFrom: "operator@example.com", aligned: true, match: true },
   },
 };
 
@@ -25,7 +25,7 @@ function memoryStore(): CursorStore & { values: Map<string, PollCursor> } {
 }
 
 function msg(id: string, date = "2026-07-28T10:00:00.000Z"): MailboxMessage {
-  return { messageId: id, sender: "Omar <omar@shahine.com>", dateReceived: date };
+  return { messageId: id, sender: "Operator <operator@example.com>", dateReceived: date };
 }
 
 const OPTIONS: PollOptions = {
@@ -33,7 +33,7 @@ const OPTIONS: PollOptions = {
   limit: 25,
   cursorKey: "apple-mail:default",
   classify: {
-    allowFrom: ["omar@shahine.com"],
+    allowFrom: ["operator@example.com"],
     minIdentifierAuthentication: "verified",
   },
 };
@@ -424,7 +424,7 @@ describe("runPollLoop", () => {
 describe("circuit breaker", () => {
   const message = {
     messageId: "m1",
-    sender: "omar@shahine.com",
+    sender: "operator@example.com",
     dateReceived: "2026-07-29T10:00:00Z",
   };
 
@@ -444,10 +444,10 @@ describe("circuit breaker", () => {
             listMessages: async () => [message],
             authCheck: async () => ({
               verdict: "verified" as const,
-              sender: "omar@shahine.com",
+              sender: "operator@example.com",
               checks: {
-                dkim: { result: "pass", signingDomain: "shahine.com", match: true },
-                spf: { result: "pass", mailFrom: "omar@shahine.com", aligned: true, match: true },
+                dkim: { result: "pass", signingDomain: "example.com", match: true },
+                spf: { result: "pass", mailFrom: "operator@example.com", aligned: true, match: true },
               },
             }),
             onAdmitted: async (m) => {

--- a/openclaw/src/mail-channel/scenarios.test.ts
+++ b/openclaw/src/mail-channel/scenarios.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../mail-auth/strength.ts";
 import { decideIngress, type Admission } from "./policy.ts";
 
-const OPERATOR = "omar@shahine.com";
+const OPERATOR = "operator@example.com";
 
 type Row = {
   id: string;
@@ -40,7 +40,7 @@ type Row = {
 
 /** An Authentication-Results header from a trusted authserv-id, DKIM aligned and expected. */
 const GENUINE: MailAuthCheckResult["checks"] = {
-  dkim: { result: "pass", signingDomain: "shahine.com", match: true },
+  dkim: { result: "pass", signingDomain: "example.com", match: true },
   spf: { result: "pass", mailFrom: OPERATOR, aligned: true, match: true },
 };
 
@@ -91,8 +91,8 @@ const ROWS: Row[] = [
     what: "enrolled non-operator (family, colleague)",
     auth: {
       verdict: "verified",
-      sender: "lora@shahine.com",
-      checks: { ...GENUINE, spf: { result: "pass", mailFrom: "lora@shahine.com", match: true } },
+      sender: "family@example.com",
+      checks: { ...GENUINE, spf: { result: "pass", mailFrom: "family@example.com", match: true } },
     },
     allowlisted: true,
     strengths: { address: "verified", domain: "verified" },
@@ -104,8 +104,8 @@ const ROWS: Row[] = [
     what: "allowlisted, domain authenticated, not enrolled in trusted-senders.json",
     auth: {
       verdict: "untrusted",
-      sender: "lora@shahine.com",
-      checks: alignedButUnenrolled("shahine.com"),
+      sender: "family@example.com",
+      checks: alignedButUnenrolled("example.com"),
     },
     allowlisted: true,
     strengths: { address: "asserted", domain: "verified" },

--- a/openclaw/src/mail-channel/thread-store.test.ts
+++ b/openclaw/src/mail-channel/thread-store.test.ts
@@ -18,10 +18,10 @@ describe("foldReply", () => {
   it("records the inbound anchor and the recipient", () => {
     const [record] = foldReply([], {
       inboundMessageId: "<m1@example.com>",
-      recipients: ["Omar@Shahine.com"],
+      recipients: ["Operator@example.com"],
     });
     assert.deepEqual(record?.inboundAnchorIds, ["m1@example.com"]);
-    assert.deepEqual(record?.addressedRecipients, ["omar@shahine.com"]);
+    assert.deepEqual(record?.addressedRecipients, ["operator@example.com"]);
     // Mail.app reports no id, so there is nothing to claim here and it does not pretend.
     assert.deepEqual(record?.sentMessageIds, []);
   });
@@ -30,7 +30,7 @@ describe("foldReply", () => {
     const [record] = foldReply([], {
       inboundMessageId: "m1@example.com",
       sentMessageId: "<agent-1@lobster.example>",
-      recipients: ["omar@shahine.com"],
+      recipients: ["operator@example.com"],
     });
     assert.deepEqual(record?.sentMessageIds, ["agent-1@lobster.example"]);
   });
@@ -40,32 +40,32 @@ describe("foldReply", () => {
     let records = foldReply([], {
       inboundMessageId: "m1@example.com",
       sentMessageId: "agent-1@lobster.example",
-      recipients: ["omar@shahine.com"],
+      recipients: ["operator@example.com"],
     });
     records = foldReply(records, {
       inboundMessageId: "m1@example.com",
       sentMessageId: "agent-2@lobster.example",
-      recipients: ["lora@shahine.com"],
+      recipients: ["family@example.com"],
     });
     assert.equal(records.length, 1);
     assert.deepEqual(records[0]?.sentMessageIds, [
       "agent-1@lobster.example",
       "agent-2@lobster.example",
     ]);
-    assert.deepEqual(records[0]?.addressedRecipients, ["omar@shahine.com", "lora@shahine.com"]);
+    assert.deepEqual(records[0]?.addressedRecipients, ["operator@example.com", "family@example.com"]);
   });
 
   it("recognizes the same thread through the agent's own id when the anchor differs", () => {
     const first = foldReply([], {
       inboundMessageId: "m1@example.com",
       sentMessageId: "agent-1@lobster.example",
-      recipients: ["omar@shahine.com"],
+      recipients: ["operator@example.com"],
     });
     // Next turn: a new inbound message, but the same agent id already on record.
     const merged = foldReply(first, {
       inboundMessageId: "m2@example.com",
       sentMessageId: "agent-1@lobster.example",
-      recipients: ["omar@shahine.com"],
+      recipients: ["operator@example.com"],
     });
     assert.equal(merged.length, 1);
     assert.deepEqual(merged[0]?.inboundAnchorIds, ["m1@example.com", "m2@example.com"]);
@@ -94,10 +94,10 @@ describe("foldReply", () => {
   it("normalizes brackets and case on both sides", () => {
     const [record] = foldReply([], {
       inboundMessageId: "  <M1@Example.COM>  ",
-      recipients: ["  Omar@Shahine.com "],
+      recipients: ["  Operator@example.com "],
     });
     assert.deepEqual(record?.inboundAnchorIds, ["m1@example.com"]);
-    assert.deepEqual(record?.addressedRecipients, ["omar@shahine.com"]);
+    assert.deepEqual(record?.addressedRecipients, ["operator@example.com"]);
   });
 });
 
@@ -118,13 +118,13 @@ describe("ThreadRecords", () => {
     const { store } = fakeStore();
     const first = new ThreadRecords(store, "apple-mail:default");
     await first.hydrate();
-    await first.record({ inboundMessageId: "m1@example.com", recipients: ["omar@shahine.com"] });
+    await first.record({ inboundMessageId: "m1@example.com", recipients: ["operator@example.com"] });
 
     const second = new ThreadRecords(store, "apple-mail:default");
     await second.hydrate();
     assert.equal(
       decideThreadReply(
-        { references: ["<m1@example.com>"], senderAddress: "omar@shahine.com" },
+        { references: ["<m1@example.com>"], senderAddress: "operator@example.com" },
         second.all(),
       ).permitted,
       true,
@@ -135,7 +135,7 @@ describe("ThreadRecords", () => {
     const { store } = fakeStore();
     const a = new ThreadRecords(store, "apple-mail:work");
     await a.hydrate();
-    await a.record({ inboundMessageId: "m1@example.com", recipients: ["omar@shahine.com"] });
+    await a.record({ inboundMessageId: "m1@example.com", recipients: ["operator@example.com"] });
 
     const b = new ThreadRecords(store, "apple-mail:personal");
     await b.hydrate();

--- a/openclaw/src/mail-channel/thread.test.ts
+++ b/openclaw/src/mail-channel/thread.test.ts
@@ -115,12 +115,12 @@ describe("anchor kinds", () => {
   const record = {
     sentMessageIds: ["agent-1@lobster.example"],
     inboundAnchorIds: ["m1@example.com"],
-    addressedRecipients: ["omar@shahine.com"],
+    addressedRecipients: ["operator@example.com"],
   };
 
   it("reports an agent-generated match as the strong anchor", () => {
     const d = decideThreadReply(
-      { inReplyTo: "<agent-1@lobster.example>", senderAddress: "omar@shahine.com" },
+      { inReplyTo: "<agent-1@lobster.example>", senderAddress: "operator@example.com" },
       [record],
     );
     assert.equal(d.permitted, true);
@@ -129,7 +129,7 @@ describe("anchor kinds", () => {
 
   it("reports an inbound-anchor match as the weaker one", () => {
     const d = decideThreadReply(
-      { references: ["m1@example.com"], senderAddress: "omar@shahine.com" },
+      { references: ["m1@example.com"], senderAddress: "operator@example.com" },
       [record],
     );
     assert.equal(d.permitted, true);
@@ -140,7 +140,7 @@ describe("anchor kinds", () => {
     const d = decideThreadReply(
       {
         references: ["m1@example.com", "agent-1@lobster.example"],
-        senderAddress: "omar@shahine.com",
+        senderAddress: "operator@example.com",
       },
       [record],
     );
@@ -149,8 +149,8 @@ describe("anchor kinds", () => {
 
   it("works on a record carrying only an inbound anchor", () => {
     const d = decideThreadReply(
-      { references: ["m1@example.com"], senderAddress: "omar@shahine.com" },
-      [{ inboundAnchorIds: ["m1@example.com"], addressedRecipients: ["omar@shahine.com"] }],
+      { references: ["m1@example.com"], senderAddress: "operator@example.com" },
+      [{ inboundAnchorIds: ["m1@example.com"], addressedRecipients: ["operator@example.com"] }],
     );
     assert.equal(d.permitted, true);
   });


### PR DESCRIPTION
Sweeps the real personal address (`omar@shahine.com` / `shahine.com`), a real family address (`lora@shahine.com`), and a real account UUID out of the mail test fixtures across 10 files, replacing them with neutral placeholders:

- `omar@shahine.com` → `operator@example.com`
- `lora@shahine.com` → `family@example.com`
- `shahine.com` → `example.com` (incl. a comment in `strength.ts`)
- account UUID → all-zero placeholder
- `Omar Shahine` / `Omar` → `Test Operator` / `Operator`

Purely mechanical — string-literal renames only, symmetric across every fixture, no behavior change. `tsc --noEmit` clean; `node --test` 210 pass / 0 fail.

Closes #99.