### PR TITLE
fix(manifest): use `schema` field name core reads for apple-mail channelConfigs

### DIFF
--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -8,9 +8,9 @@
   "channelConfigs": {
     "apple-mail": {
       "label": "Apple Mail",
-      "blurb": "Polls the local Mail.app store and authorizes senders by DKIM/SPF authentication strength.",
+      "description": "Polls the local Mail.app store and authorizes senders by DKIM/SPF authentication strength.",
       "docsPath": "docs/mail-channel-scenarios.md",
-      "configSchema": {
+      "schema": {
         "type": "object",
         "additionalProperties": true,
         "properties": {


### PR DESCRIPTION
## Problem

Every gateway startup logs:

> channel plugin manifest declares apple-mail without channelConfigs metadata; add openclaw.plugin.json#channelConfigs so config schema and setup surfaces work before runtime loads.

…even though the manifest **does** declare `channelConfigs.apple-mail`.

## Root cause

Core's `normalizeChannelConfigs` (`src/plugins/manifest.ts:1634-1636`) requires a `schema` record on each channel config entry and **silently drops** any entry without one:

```ts
const schema = isRecord(rawEntry.schema) ? rawEntry.schema : null;
if (!schema) continue;   // entry dropped
```

The manifest declared the schema under `configSchema`, not `schema`, so `apple-mail` was stripped from the parsed record — and the missing-metadata warning fired. `PluginManifestChannelConfig` reads `schema`, `label`, `description`, `uiHints`, `runtime`; it does not read `configSchema` or `blurb`.

This is not a version issue: beta5 postdates the warning's introduction and already parses `channelConfigs`.

## Fix

Rename in `channelConfigs.apple-mail`: `configSchema` → `schema`, `blurb` → `description`. Manifest-only change. The channel already worked at runtime (verified live); this restores its config-schema/setup surfaces and clears the warning.