### PR TITLE
feat(mail): gate agent-originated send behind egress approval (#98)

### DIFF
--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -208,6 +208,34 @@ who sent you a message says nothing about who you may contact.
 | E9 | Mail with attachments | separately gated | Attachment policy is default-deny with explicit allowed roots |
 | E10 | Mail to the agent's own address | no | Loop guard |
 
+### Enforcing egress on `send`
+
+The reply path is contained by the admission store: an `observe`-only sender cannot be
+answered, because the channel records that decision and the `apple_pim_mail` tool honors it.
+`send` originates a fresh message to arbitrary recipients with no message id, so that store
+has nothing to key on. Left ungoverned, `send` would be a hole straight through default-deny:
+an agent that read a stranger's mail could email that stranger, or anyone, without ever
+touching the reply gate.
+
+A `before_tool_call` hook closes it by running the send's recipients through the same
+`decideEgress` the reply path uses, so the two cannot disagree about who the agent may
+originate mail to. A fresh send is neither a thread the agent started nor proof the operator
+asked for this exact message, so only two grants apply silently: the operator, and the
+explicit egress allowlist. Everything else resolves to one of:
+
+- **operator or allowlisted recipient** — the send proceeds.
+- **any recipient off the allowlist** — the operator is asked to approve, over their regular
+  channel (the same approval surface as `/approve`), naming the recipients and subject. The
+  send fails closed on deny or timeout. Approval is `allow-once`: adding a correspondent
+  permanently is an `egressAllowlist` edit the operator makes deliberately, not a one-tap
+  side effect.
+- **the agent's own address** — hard-denied without an approval prompt. Emailing itself is a
+  loop (E10, I13), never a decision to delegate.
+
+The hook runs inside the OpenClaw runtime, where the channel config and the approval surfaces
+live. A bare MCP deployment of the tool has neither, so there the tool's own caller is the
+trust boundary, exactly as it is for the read/reply gate when the shared store is absent.
+
 ### The thread rule
 
 A reply is permitted when both hold:

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -9,6 +9,11 @@
 
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { appleMailChannelEntry } from "./mail-channel/entry.js";
+import {
+  describeSendApproval,
+  evaluateSend,
+  resolveSendEgressPolicy,
+} from "./mail-channel/send-approval.js";
 import { createCLIRunner, findSwiftBinDir } from "../lib/cli-runner.js";
 import { tools } from "../lib/schemas.js";
 import { markToolResult, getDatamarkingPreamble } from "../lib/sanitize.js";
@@ -154,6 +159,54 @@ export default definePluginEntry({
     // has to be reached from here or defineChannelPluginEntry never runs and the
     // channel is silently absent at runtime.
     appleMailChannelEntry.register(api);
+
+    // Govern agent-originated mail (`apple_pim_mail action:"send"`) against the same egress
+    // policy the channel's reply path enforces. Without this, envelope-only containment covers
+    // replies but not sends: an agent could originate mail to anyone, outside the allowlist and
+    // loop guard (#98). Reply is already gated in the tool handler and cannot add recipients, so
+    // only `send` needs a hook. Runs in the gateway, where `api.config` carries the channel
+    // block the tool process never sees.
+    api.on("before_tool_call", (event) => {
+      if (event.toolName !== "apple_pim_mail") {
+        return;
+      }
+      if ((event.params as { action?: unknown }).action !== "send") {
+        return;
+      }
+      // Scope the policy to the sender identity the send claims (`from`), so a multi-account
+      // install cannot let one account's allowlist authorize a send as another.
+      const from = typeof event.params.from === "string" ? event.params.from : undefined;
+      const policy = resolveSendEgressPolicy(api.config, from);
+      // No apple-mail channel configured: the send tool stays ungoverned, as it was before the
+      // channel existed. Containment is the channel's contribution, not the bare tool's.
+      if (!policy) {
+        return;
+      }
+      const decision = evaluateSend(event.params, policy);
+      if (decision.kind === "allow") {
+        return;
+      }
+      if (decision.kind === "loop") {
+        return {
+          block: true,
+          blockReason:
+            `Refusing to send: ${decision.addresses.join(", ")} is one of the agent's own ` +
+            `addresses, so this send would loop mail back into the channel.`,
+        };
+      }
+      const subject = typeof event.params.subject === "string" ? event.params.subject : "";
+      return {
+        requireApproval: {
+          title: "Send email to unlisted recipient",
+          description: describeSendApproval(decision.unlisted, subject),
+          severity: "warning",
+          // No allow-always: persisting an arbitrary recipient into the egress allowlist is a
+          // config decision the operator should make deliberately, not a one-tap side effect.
+          allowedDecisions: ["allow-once", "deny"],
+          timeoutMs: 120_000,
+        },
+      };
+    });
 
     const config = api.pluginConfig as PluginConfig | undefined;
     const binDir = resolveBinDir(config);

--- a/openclaw/src/mail-channel/send-approval.test.ts
+++ b/openclaw/src/mail-channel/send-approval.test.ts
@@ -1,0 +1,292 @@
+/**
+ * The send gate closes the reply/send asymmetry (#98): agent-originated mail runs through the
+ * same egress policy as replies. These tests pin the three outcomes and the config reading,
+ * so a policy change cannot quietly reopen the gap.
+ */
+
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  classifySend,
+  collectSendRecipients,
+  describeSendApproval,
+  evaluateSend,
+  resolveSendEgressPolicy,
+  type SendEgressPolicy,
+} from "./send-approval.ts";
+
+const policy: SendEgressPolicy = {
+  operatorAddresses: ["operator@example.com"],
+  egressAllowlist: ["known@example.com"],
+  selfAddresses: ["agent@example.com"],
+};
+
+describe("classifySend", () => {
+  it("allows a send to the operator", () => {
+    assert.deepEqual(classifySend({ recipients: ["operator@example.com"], policy }), { kind: "allow" });
+  });
+
+  it("allows a send to an allowlisted recipient", () => {
+    assert.deepEqual(classifySend({ recipients: ["known@example.com"], policy }), { kind: "allow" });
+  });
+
+  it("asks for approval for an unlisted recipient", () => {
+    assert.deepEqual(classifySend({ recipients: ["stranger@example.com"], policy }), {
+      kind: "approve",
+      unlisted: ["stranger@example.com"],
+    });
+  });
+
+  it("asks for approval when any single recipient is unlisted", () => {
+    // A mixed send is not silently narrowed to the permitted recipients: the operator approves
+    // the send as addressed, or it is denied. Reporting every unlisted address lets them see
+    // exactly who would be mailed.
+    const result = classifySend({
+      recipients: ["operator@example.com", "stranger@example.com", "other@example.com"],
+      policy,
+    });
+    assert.deepEqual(result, { kind: "approve", unlisted: ["stranger@example.com", "other@example.com"] });
+  });
+
+  it("hard-blocks a send to the agent's own address, outranking approval", () => {
+    // Even alongside an unlisted recipient, the loop guard wins: emailing itself is never an
+    // approval question.
+    assert.deepEqual(classifySend({ recipients: ["agent@example.com", "stranger@example.com"], policy }), {
+      kind: "loop",
+      addresses: ["agent@example.com"],
+    });
+  });
+
+  it("matches recipients regardless of case", () => {
+    assert.deepEqual(classifySend({ recipients: ["KNOWN@Example.COM"], policy }), { kind: "allow" });
+    assert.deepEqual(classifySend({ recipients: ["Agent@EXAMPLE.com"], policy }), {
+      kind: "loop",
+      addresses: ["Agent@EXAMPLE.com"],
+    });
+  });
+
+  it("treats an empty recipient list as allow, leaving validation to the tool handler", () => {
+    assert.deepEqual(classifySend({ recipients: [], policy }), { kind: "allow" });
+  });
+
+  it("asks for approval for everyone when the allowlist is empty", () => {
+    // Deny-by-default: an apple-mail install with no egressAllowlist governs every send.
+    const empty: SendEgressPolicy = { operatorAddresses: [], egressAllowlist: [], selfAddresses: [] };
+    assert.deepEqual(classifySend({ recipients: ["anyone@example.com"], policy: empty }), {
+      kind: "approve",
+      unlisted: ["anyone@example.com"],
+    });
+  });
+});
+
+describe("evaluateSend", () => {
+  it("collects recipients and delegates to classifySend", () => {
+    assert.deepEqual(evaluateSend({ to: "known@example.com", subject: "hi" }, policy), { kind: "allow" });
+    assert.deepEqual(evaluateSend({ to: "stranger@example.com", subject: "hi" }, policy), {
+      kind: "approve",
+      unlisted: ["stranger@example.com"],
+    });
+  });
+
+  it("skips the gate for a dry-run send, which never delivers mail", () => {
+    // withAgentDX returns a preview for any truthy dryRun and never calls the CLI, so an
+    // unlisted recipient must not trigger an approval that governs a send that cannot happen.
+    assert.deepEqual(evaluateSend({ to: "stranger@example.com", dryRun: true }, policy), { kind: "allow" });
+    assert.deepEqual(evaluateSend({ to: "stranger@example.com", dryRun: 1 }, policy), { kind: "allow" });
+  });
+
+  it("still gates a real send when dryRun is falsy", () => {
+    assert.deepEqual(evaluateSend({ to: "stranger@example.com", dryRun: false }, policy), {
+      kind: "approve",
+      unlisted: ["stranger@example.com"],
+    });
+  });
+});
+
+describe("collectSendRecipients", () => {
+  it("gathers to, cc, and bcc, accepting string or array", () => {
+    const params = {
+      to: "a@example.com",
+      cc: ["b@example.com", "c@example.com"],
+      bcc: "d@example.com",
+    };
+    assert.deepEqual(collectSendRecipients(params), [
+      "a@example.com",
+      "b@example.com",
+      "c@example.com",
+      "d@example.com",
+    ]);
+  });
+
+  it("ignores missing and non-string fields", () => {
+    assert.deepEqual(collectSendRecipients({ to: "a@example.com", cc: [42, "b@example.com"], bcc: null }), [
+      "a@example.com",
+      "b@example.com",
+    ]);
+  });
+
+  it("returns nothing for a send with no recipients", () => {
+    assert.deepEqual(collectSendRecipients({ subject: "x", body: "y" }), []);
+  });
+});
+
+describe("resolveSendEgressPolicy", () => {
+  const asConfig = (channels: Record<string, unknown>): OpenClawConfig => ({ channels }) as OpenClawConfig;
+
+  it("returns undefined when the apple-mail channel is not configured", () => {
+    assert.equal(resolveSendEgressPolicy(asConfig({})), undefined);
+    assert.equal(resolveSendEgressPolicy({} as OpenClawConfig), undefined);
+  });
+
+  const topLevel = () =>
+    asConfig({
+      "apple-mail": {
+        operatorAddresses: ["op@example.com"],
+        egressAllowlist: ["ok@example.com"],
+        selfAddresses: ["me@example.com"],
+      },
+    });
+
+  it("reads the top-level channel block for a single-account install", () => {
+    assert.deepEqual(resolveSendEgressPolicy(topLevel()), {
+      operatorAddresses: ["op@example.com"],
+      egressAllowlist: ["ok@example.com"],
+      selfAddresses: ["me@example.com"],
+    });
+  });
+
+  it("uses the top-level policy when `from` is a managed self address", () => {
+    assert.deepEqual(resolveSendEgressPolicy(topLevel(), "me@example.com")?.egressAllowlist, ["ok@example.com"]);
+  });
+
+  it("fails closed when `from` is not a managed self address, even top-level", () => {
+    // The scoping added for multi-account must not be defeatable by the common top-level shape:
+    // a send claiming an identity the channel does not own inherits no allowlist.
+    const resolved = resolveSendEgressPolicy(topLevel(), "impostor@example.com");
+    assert.deepEqual(resolved?.egressAllowlist, []);
+    assert.deepEqual(resolved?.operatorAddresses, []);
+    assert.deepEqual(resolved?.selfAddresses, ["me@example.com"]);
+  });
+
+  const multiAccount = () =>
+    asConfig({
+      "apple-mail": {
+        selfAddresses: ["top@example.com"],
+        accounts: {
+          work: { egressAllowlist: ["w@example.com"], selfAddresses: ["work-self@example.com"] },
+          home: { egressAllowlist: ["h@example.com"], selfAddresses: ["home-self@example.com"], operatorAddresses: ["op@example.com"] },
+        },
+      },
+    });
+
+  it("scopes the allowlist to the account the sender is attributed to", () => {
+    // The whole point of scoping: `work`'s allowlist must not carry over to a send from `home`.
+    const work = resolveSendEgressPolicy(multiAccount(), "work-self@example.com");
+    assert.deepEqual(work?.egressAllowlist, ["w@example.com"]);
+    const home = resolveSendEgressPolicy(multiAccount(), "home-self@example.com");
+    assert.deepEqual(home?.egressAllowlist, ["h@example.com"]);
+    assert.deepEqual(home?.operatorAddresses, ["op@example.com"]);
+  });
+
+  it("unions self addresses across every account so any self-send is a loop", () => {
+    const resolved = resolveSendEgressPolicy(multiAccount(), "work-self@example.com");
+    assert.deepEqual(resolved?.selfAddresses.sort(), [
+      "home-self@example.com",
+      "top@example.com",
+      "work-self@example.com",
+    ]);
+  });
+
+  it("fails closed to an empty allowlist when a multi-account sender cannot be attributed", () => {
+    // Unknown `from`, and no `from` with no default account: nothing may be sent without approval,
+    // but the loop guard still holds.
+    for (const from of ["stranger@example.com", undefined]) {
+      const resolved = resolveSendEgressPolicy(multiAccount(), from);
+      assert.deepEqual(resolved?.egressAllowlist, []);
+      assert.deepEqual(resolved?.operatorAddresses, []);
+      assert.equal(resolved?.selfAddresses.includes("work-self@example.com"), true);
+    }
+  });
+
+  it("fails closed when a `from` matches more than one account", () => {
+    // Both accounts inherit the top-level self address, so `shared@example.com` is ambiguous:
+    // it must not silently take whichever account is listed first.
+    const cfg = asConfig({
+      "apple-mail": {
+        selfAddresses: ["shared@example.com"],
+        accounts: {
+          work: { egressAllowlist: ["w@example.com"] },
+          home: { egressAllowlist: ["h@example.com"] },
+        },
+      },
+    });
+    const resolved = resolveSendEgressPolicy(cfg, "shared@example.com");
+    assert.deepEqual(resolved?.egressAllowlist, []);
+  });
+
+  it("attributes to a single named account even when `from` is omitted", () => {
+    const resolved = resolveSendEgressPolicy(
+      asConfig({
+        "apple-mail": {
+          accounts: { personal: { egressAllowlist: ["p@example.com"], selfAddresses: ["me@example.com"] } },
+        },
+      }),
+      undefined,
+    );
+    assert.deepEqual(resolved?.egressAllowlist, ["p@example.com"]);
+  });
+
+  it("fails closed when `from` names an identity the sole account does not own", () => {
+    const resolved = resolveSendEgressPolicy(
+      asConfig({
+        "apple-mail": {
+          accounts: { personal: { egressAllowlist: ["p@example.com"], selfAddresses: ["me@example.com"] } },
+        },
+      }),
+      "someone-else@example.com",
+    );
+    assert.deepEqual(resolved?.egressAllowlist, []);
+  });
+
+  it("attributes a send with no `from` to the default account", () => {
+    const resolved = resolveSendEgressPolicy(
+      asConfig({
+        "apple-mail": {
+          accounts: {
+            default: { egressAllowlist: ["d@example.com"], selfAddresses: ["default-self@example.com"] },
+            other: { egressAllowlist: ["o@example.com"], selfAddresses: ["other-self@example.com"] },
+          },
+        },
+      }),
+      undefined,
+    );
+    assert.deepEqual(resolved?.egressAllowlist, ["d@example.com"]);
+  });
+
+  it("de-duplicates an address that appears in the top-level and the resolved account", () => {
+    const resolved = resolveSendEgressPolicy(
+      asConfig({
+        "apple-mail": {
+          egressAllowlist: ["dup@example.com"],
+          accounts: { a: { selfAddresses: ["a-self@example.com"] } },
+        },
+      }),
+      "a-self@example.com",
+    );
+    // `a` has no allowlist of its own, so it inherits the top-level one; no duplication.
+    assert.deepEqual(resolved?.egressAllowlist, ["dup@example.com"]);
+  });
+});
+
+describe("describeSendApproval", () => {
+  it("names the recipients and the subject", () => {
+    const text = describeSendApproval(["stranger@example.com"], "Lunch?");
+    assert.match(text, /stranger@example\.com/);
+    assert.match(text, /Lunch\?/);
+  });
+
+  it("falls back to a placeholder for an empty subject", () => {
+    assert.match(describeSendApproval(["x@example.com"], "   "), /\(no subject\)/);
+  });
+});

--- a/openclaw/src/mail-channel/send-approval.ts
+++ b/openclaw/src/mail-channel/send-approval.ts
@@ -1,0 +1,205 @@
+/**
+ * The gate that governs agent-originated mail (`apple_pim_mail action:"send"`).
+ *
+ * The reply path is already contained: an `observe`-only sender cannot be answered, because
+ * the channel writes that decision to the shared admission store and the tool honors it. But
+ * `send` originates a fresh message to arbitrary recipients with no message id, so nothing
+ * tied it to the channel's egress policy. That left an asymmetry (issue #98): an agent that
+ * read an `observe` sender's mail could still email that sender — or anyone — through `send`.
+ *
+ * This module closes it by running the same `decideEgress` the reply path uses, so send and
+ * reply cannot disagree about who the agent may originate mail to. It is pure: it maps an
+ * egress decision to one of three outcomes and leaves delivery, approval, and I/O to the
+ * `before_tool_call` hook that consumes it.
+ *
+ *   - `allow`   — every recipient is the operator or on the egress allowlist. Send proceeds.
+ *   - `loop`    — a recipient is one of the agent's own addresses. Hard-denied: emailing
+ *                 itself is a loop, not an approval question.
+ *   - `approve` — a recipient is off the allowlist. The operator is asked first, over their
+ *                 regular channel, and the send fails closed on deny or timeout.
+ */
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { decideEgress } from "./policy.ts";
+
+const CHANNEL_ID = "apple-mail";
+
+export type SendEgressPolicy = {
+  operatorAddresses: string[];
+  egressAllowlist: string[];
+  selfAddresses: string[];
+};
+
+type ChannelBlock = { accounts?: Record<string, Partial<SendEgressPolicy>> } & Partial<SendEgressPolicy>;
+
+const dedupe = (values: readonly unknown[]): string[] => [...new Set(values.map((value) => String(value)))];
+const lower = (values: readonly unknown[]): string[] => values.map((value) => String(value).trim().toLowerCase());
+
+/**
+ * Reads the egress policy out of `channels.apple-mail`, scoped to the sender account, or
+ * returns undefined when the channel is not configured.
+ *
+ * Undefined means the send tool is being used without the Apple Mail channel governing this
+ * install, so it stays ungoverned exactly as it was before the channel existed — the channel
+ * is what introduces outbound containment, and its absence is not a policy of its own.
+ *
+ * The allowlist and operator set are scoped to one sender identity, never unioned across
+ * accounts: `send` exposes `from`, so unioning would let a recipient allowlisted for one
+ * account authorize a send as any other account. `from` is matched against each account's self
+ * addresses (accounts inherit the top-level block). A single-account install (the norm) reads
+ * the top-level block directly. A multi-account send whose sender cannot be attributed fails
+ * closed to an empty allowlist — every recipient then needs approval.
+ *
+ * The loop guard is the one exception: self addresses are unioned across every account, because
+ * a send to any managed identity's own address is a loop no matter which account it claims to
+ * be from, and that must hold even when the sender is unattributable.
+ */
+export function resolveSendEgressPolicy(cfg: OpenClawConfig, from?: string): SendEgressPolicy | undefined {
+  const channels = (cfg as { channels?: Record<string, unknown> }).channels ?? {};
+  const channel = channels[CHANNEL_ID] as ChannelBlock | undefined;
+  if (!channel) {
+    return undefined;
+  }
+  const accounts = channel.accounts ?? {};
+  const accountIds = Object.keys(accounts);
+  const allSelf = dedupe(
+    [channel.selfAddresses ?? [], ...Object.values(accounts).map((account) => account?.selfAddresses ?? [])].flat(),
+  );
+  // An account block overrides the top-level block field-by-field, matching how the channel
+  // resolves an account (`{ ...channel, ...account }`). Self addresses are always the union.
+  const scoped = (account: Partial<SendEgressPolicy> | undefined): SendEgressPolicy => ({
+    operatorAddresses: dedupe(account?.operatorAddresses ?? channel.operatorAddresses ?? []),
+    egressAllowlist: dedupe(account?.egressAllowlist ?? channel.egressAllowlist ?? []),
+    selfAddresses: allSelf,
+  });
+
+  const failClosed: SendEgressPolicy = { operatorAddresses: [], egressAllowlist: [], selfAddresses: allSelf };
+  const fromAddr = from ? String(from).trim().toLowerCase() : "";
+
+  // A supplied `from` must name a managed self identity in every config shape, top-level or
+  // multi-account. A `from` we do not own is a send claiming an identity outside the channel,
+  // so it inherits no allowlist and falls to approval — the same fail-closed stance as an
+  // unattributable named-account send. Only the loop guard survives.
+  if (fromAddr && !lower(allSelf).includes(fromAddr)) {
+    return failClosed;
+  }
+
+  // Single-account install: the top-level block is the whole policy (its `from`, if any, is a
+  // managed identity per the check above).
+  if (accountIds.length === 0) {
+    return scoped(undefined);
+  }
+
+  // Multi-account: attribute the send to exactly one identity so one account's allowlist cannot
+  // authorize a send as another.
+  if (fromAddr) {
+    // Unique match only. An address shared across accounts — commonly because several inherit
+    // the top-level `selfAddresses` — is ambiguous, and picking whichever appears first would
+    // silently grant one account's allowlist to a send claiming that shared identity.
+    const matches = accountIds.filter((id) =>
+      lower(accounts[id]?.selfAddresses ?? channel.selfAddresses ?? []).includes(fromAddr),
+    );
+    if (matches.length === 1) {
+      return scoped(accounts[matches[0]]);
+    }
+  } else if (accountIds.length === 1) {
+    // A single named account is the only possible sender, so no `from` is needed to attribute it.
+    return scoped(accounts[accountIds[0]]);
+  } else if (accounts.default) {
+    // No `from` addresses the default account, mirroring the channel's own `accountId ?? "default"`.
+    return scoped(accounts.default);
+  }
+  // Ambiguous or absent sender across multiple accounts: fail closed, but keep the loop guard.
+  return failClosed;
+}
+
+/** Collects every recipient a send addresses, across `to`, `cc`, and `bcc`. */
+export function collectSendRecipients(params: Record<string, unknown>): string[] {
+  const recipients: string[] = [];
+  for (const key of ["to", "cc", "bcc"] as const) {
+    const value = params[key];
+    if (typeof value === "string") {
+      recipients.push(value);
+    } else if (Array.isArray(value)) {
+      for (const address of value) {
+        if (typeof address === "string") {
+          recipients.push(address);
+        }
+      }
+    }
+  }
+  return recipients;
+}
+
+export type SendClassification =
+  | { kind: "allow" }
+  | { kind: "loop"; addresses: string[] }
+  | { kind: "approve"; unlisted: string[] };
+
+/**
+ * Classifies a send against the egress policy.
+ *
+ * Delegates the per-recipient matching to `decideEgress` so this and the reply path share one
+ * policy. A fresh send is neither inside a thread the agent originated nor proof the operator
+ * asked for this specific message, so both of those grants are false: the only silent
+ * approvals are the operator and the explicit egress allowlist.
+ */
+export function classifySend(params: {
+  recipients: readonly string[];
+  policy: SendEgressPolicy;
+}): SendClassification {
+  const { recipients, policy } = params;
+  // Nothing to govern; the tool handler's own required-recipient validation speaks instead.
+  if (recipients.length === 0) {
+    return { kind: "allow" };
+  }
+  const decision = decideEgress({
+    recipients,
+    operatorAddresses: policy.operatorAddresses,
+    egressAllowlist: policy.egressAllowlist,
+    selfAddresses: policy.selfAddresses,
+    threadPermitted: false,
+    operatorInstructed: false,
+  });
+  // The loop guard outranks approval: no operator decision can make emailing the agent's own
+  // address anything but a loop, so it is denied outright rather than surfaced for approval.
+  const loop = decision.denied
+    .filter((entry) => entry.reason === "self_addressed")
+    .map((entry) => entry.address);
+  if (loop.length > 0) {
+    return { kind: "loop", addresses: loop };
+  }
+  const unlisted = decision.denied
+    .filter((entry) => entry.reason === "recipient_not_permitted")
+    .map((entry) => entry.address);
+  if (unlisted.length > 0) {
+    return { kind: "approve", unlisted };
+  }
+  return { kind: "allow" };
+}
+
+/**
+ * The full send-gate decision from raw tool params and the resolved policy.
+ *
+ * Folds in the dry-run skip so a validation-only send is never gated: `withAgentDX` returns a
+ * preview and skips the CLI for any truthy `dryRun`, so there is no send to govern and asking
+ * for approval would block a preview for the whole timeout. The truthy check mirrors
+ * `withAgentDX` exactly, keeping the skip and the no-send in lockstep. Callers still gate on
+ * tool name and `action:"send"` before reaching here.
+ */
+export function evaluateSend(params: Record<string, unknown>, policy: SendEgressPolicy): SendClassification {
+  if (params.dryRun) {
+    return { kind: "allow" };
+  }
+  return classifySend({ recipients: collectSendRecipients(params), policy });
+}
+
+/** Prompt text naming the unlisted recipients and the subject, for the operator who approves. */
+export function describeSendApproval(unlisted: readonly string[], subject: string): string {
+  const who = unlisted.join(", ");
+  const what = subject.trim().length > 0 ? subject.trim() : "(no subject)";
+  return (
+    `Lobster wants to send an email to ${who}, which is not on your egress allowlist. ` +
+    `Subject: "${what}". Approve only if you meant for the agent to originate this message.`
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

The Apple Mail channel governs the agent's **replies** (an `observe`-only sender can't be answered), but `apple_pim_mail action:"send"` originated fresh mail to any recipient with nothing tying it to the channel's egress policy. That left an asymmetry (#98): an agent that read an `observe`-only sender's mail could still email that sender — or anyone — outside the `egressAllowlist`, `operatorAddresses`, and loop guard.

## Why This Change Was Made

Whether the agent may originate mail unprompted is a policy decision, not just a bug. The chosen policy: allow operator + allowlist silently, hard-block self-loops, and require **operator approval over the regular channel** (iMessage) for anyone else — failing closed on deny/timeout.

## User Impact

- A `send` to an operator or `egressAllowlist` recipient proceeds unchanged.
- A `send` to an unlisted recipient pauses for an operator approval delivered over the configured approval channel; denied or timed-out sends are blocked.
- A `send` to the agent's own address is hard-denied (loop guard).
- Policy is scoped to the sender identity (`from`) and fails closed for any unmanaged or ambiguous sender, so one account's allowlist can't authorize a send as another.
- Dry-run sends skip the gate (they never deliver).
- Installs without the apple-mail channel are unaffected (send stays ungoverned, as before).

## Evidence

- New `before_tool_call` hook reuses the channel's existing `decideEgress`, so send and reply share one egress policy.
- 26 new unit tests; full mail-channel suite **226/226 pass**; `tsc --noEmit` clean; `tsup` production build succeeds.
- **Codex review: clean** after iterating on four findings (dry-run gating, multi-account allowlist union, ambiguous `from` match, top-level `from` validation). Final verdict: "fail-closed, scopes multi-account policies appropriately, skips non-delivering dry runs, and preserves the self-address loop guard."

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxM7Yy33nFJM71NCaBqhyz
