### PR TITLE
fix(mail): deny reads when the quarantine store exists but node:sqlite does not

### DIFF
--- a/lib/mail-quarantine.js
+++ b/lib/mail-quarantine.js
@@ -36,7 +36,7 @@
  */
 
 import { createRequire } from "node:module";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -66,16 +66,33 @@ function storeDbPath() {
 let db;
 
 /**
- * Opens the shared store, or returns null when `node:sqlite` is unavailable.
- *
- * The gate degrades rather than throws in that case, and it is safe to: the channel cannot
- * run without the same module (`store.ts` requires it), so a runtime that lacks it never
- * produced any admission decision to enforce. The mail tool is being used there in a
- * channel-less mode where its own caller is the trust boundary. Breaking every read and
- * reply instead — as a hard require would — is strictly worse.
+ * Loads `node:sqlite`. Indirected through a binding so a test can simulate a runtime that
+ * lacks it; production never reassigns this.
  *
  * Required at runtime rather than imported, so a bundler targeting an older Node cannot
  * rewrite the specifier to a bare `sqlite` and fail at load. Mirrors the guard in `store.ts`.
+ */
+let loadSqlite = () => createRequire(import.meta.url)("node:sqlite").DatabaseSync;
+
+/**
+ * Opens the shared store, or returns null when `node:sqlite` is unavailable.
+ *
+ * The gate degrades rather than throws in that case, and it is usually safe to: the channel
+ * cannot run without the same module (`store.ts` requires it), so a runtime that lacks it
+ * never produced any admission decision to enforce. The mail tool is being used there in a
+ * channel-less mode where its own caller is the trust boundary. Breaking every read and
+ * reply instead — as a hard require would — is strictly worse.
+ *
+ * That reasoning holds per-process but not per-machine, which is the hole this guard closes
+ * (Greptile, PR #103). The decisions are durable rows, not process state: the channel writes
+ * them on Node >= 22.13, where `node:sqlite` exists, and the standalone MCP server can be
+ * launched later against the same state directory by a Claude Code install running Node 18
+ * or 20 — where it does not. `mcp-server/build.mjs` targets `node18` precisely so that is
+ * allowed. Waving those reads through would silently undo a decision that demonstrably was
+ * made, so when the store file exists the gate denies instead of degrading.
+ *
+ * Keyed on the file rather than on a Node version check because the file is the direct
+ * evidence: no store, no decisions, nothing to bypass, and channel-less users keep working.
  */
 function database() {
   if (db !== undefined) {
@@ -83,7 +100,7 @@ function database() {
   }
   let DatabaseSync;
   try {
-    DatabaseSync = createRequire(import.meta.url)("node:sqlite").DatabaseSync;
+    DatabaseSync = loadSqlite();
   } catch {
     db = null;
     return null;
@@ -111,6 +128,27 @@ function database() {
 const KIND_REFUSED = "refused";
 const KIND_REPLY_BLOCKED = "reply-blocked";
 
+/**
+ * Why this runtime cannot honor the channel's decisions, or undefined when it can.
+ *
+ * Recomputed per lookup rather than cached alongside `db`, because the two facts have
+ * different lifetimes. Whether `node:sqlite` loads is fixed for the process; whether the
+ * store exists is not. A long-lived MCP server can start before the channel has ever written
+ * a decision — caching "nothing to enforce" at that moment would keep the gate open for the
+ * rest of its life, exactly when the channel starts producing decisions to enforce. The
+ * stat only runs on runtimes that already failed to load `node:sqlite`.
+ */
+function unenforceableReason() {
+  if (database() !== null) {
+    return undefined;
+  }
+  const file = storeDbPath();
+  return existsSync(file)
+    ? `this runtime has no node:sqlite, so the Apple Mail channel's admission decisions in ` +
+        `${file} cannot be read; run the MCP server on Node >= 22.13 to enforce them`
+    : undefined;
+}
+
 function record(id, kind, reason) {
   const key = normalize(id);
   const conn = database();
@@ -128,6 +166,14 @@ function record(id, kind, reason) {
 function reasonFor(id, kind) {
   const key = normalize(id);
   const conn = database();
+  // Denies uniformly, before the id is even considered: the question "was this message
+  // refused?" has no answer here, and every caller treats a reason as a refusal. Applying it
+  // to a blank id too keeps `filterQuarantinedResults` from letting rows through on a
+  // missing `messageId`.
+  const blocked = unenforceableReason();
+  if (blocked) {
+    return blocked;
+  }
   if (!key || !conn) {
     return undefined;
   }
@@ -235,5 +281,15 @@ export function resetMailAdmission() {
 /** Test seam. Drops the connection so the next call reopens from disk, proving durability. */
 export function closeMailAdmissionForTest() {
   db?.close();
+  db = undefined;
+}
+
+/**
+ * Test seam. Swaps the `node:sqlite` loader so a suite can exercise the runtimes CI cannot
+ * itself run on — CI is Node 20, which has no `node:sqlite`, and the fail-closed branch has
+ * to be provable on the machines that do. Pass no argument to restore the real loader.
+ */
+export function setSqliteLoaderForTest(fn) {
+  loadSqlite = fn ?? (() => createRequire(import.meta.url)("node:sqlite").DatabaseSync);
   db = undefined;
 }

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -78950,7 +78950,7 @@ function validateDestDir(rawDir) {
 
 // ../lib/mail-quarantine.js
 import { createRequire } from "node:module";
-import { mkdirSync } from "node:fs";
+import { existsSync as existsSync3, mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 function normalize(id) {
@@ -78963,13 +78963,14 @@ function storeDbPath() {
   return path.join(expanded, "apple-pim", "mail-channel.sqlite");
 }
 var db;
+var loadSqlite = () => createRequire(import.meta.url)("node:sqlite").DatabaseSync;
 function database() {
   if (db !== void 0) {
     return db;
   }
   let DatabaseSync;
   try {
-    DatabaseSync = createRequire(import.meta.url)("node:sqlite").DatabaseSync;
+    DatabaseSync = loadSqlite();
   } catch {
     db = null;
     return null;
@@ -78992,9 +78993,20 @@ function database() {
 }
 var KIND_REFUSED = "refused";
 var KIND_REPLY_BLOCKED = "reply-blocked";
+function unenforceableReason() {
+  if (database() !== null) {
+    return void 0;
+  }
+  const file2 = storeDbPath();
+  return existsSync3(file2) ? `this runtime has no node:sqlite, so the Apple Mail channel's admission decisions in ${file2} cannot be read; run the MCP server on Node >= 22.13 to enforce them` : void 0;
+}
 function reasonFor(id, kind) {
   const key = normalize(id);
   const conn = database();
+  const blocked = unenforceableReason();
+  if (blocked) {
+    return blocked;
+  }
   if (!key || !conn) {
     return void 0;
   }

--- a/openclaw/src/mail-channel/quarantine.test.ts
+++ b/openclaw/src/mail-channel/quarantine.test.ts
@@ -22,6 +22,7 @@ import {
   filterQuarantinedResults,
   resetMailAdmission,
   closeMailAdmissionForTest,
+  setSqliteLoaderForTest,
 } from "../../lib/mail-quarantine.js";
 import { runPollLoop } from "./poll.ts";
 
@@ -231,5 +232,74 @@ describe("the poll loop reports what it dropped", () => {
     );
 
     assert.deepEqual(order, ["dropped:unauthenticated_sender"]);
+  });
+});
+
+// The gate reads `node:sqlite`, which does not exist before Node 22.13 — and
+// `mcp-server/build.mjs` targets `node18`, so the standalone MCP server is allowed to run
+// there. What the channel decided still has to bind it, because the decisions are rows on
+// disk written by a different process on a different runtime, not process state.
+describe("runtimes without node:sqlite", () => {
+  const noSqlite = () => {
+    throw new Error("Cannot find module 'node:sqlite'");
+  };
+
+  after(() => setSqliteLoaderForTest());
+
+  it("denies reads when decisions exist that it cannot read", () => {
+    // The channel's process wrote the store on a newer Node; this one cannot open it.
+    recordRefused("<spoofed@example.com>", "unauthenticated_sender");
+    closeMailAdmissionForTest();
+    setSqliteLoaderForTest(noSqlite);
+
+    assert.throws(
+      () => assertMailReadable("anything@example.com", "read"),
+      /no node:sqlite.*Node >= 22\.13/s,
+      "a runtime that cannot read the store must not wave every message through",
+    );
+    assert.throws(() => assertMailRepliable("anything@example.com", "reply to"), /no node:sqlite/);
+  });
+
+  it("withholds every row from a listing rather than returning unscreened mail", () => {
+    recordRefused("<spoofed@example.com>", "unauthenticated_sender");
+    closeMailAdmissionForTest();
+    setSqliteLoaderForTest(noSqlite);
+
+    const filtered = filterQuarantinedResults(
+      { count: 2, messages: [{ messageId: "a@example.com" }, { messageId: "b@example.com" }] },
+      { reportWithheld: true },
+    );
+    assert.deepEqual(filtered.messages, []);
+    assert.equal(filtered.withheldByChannelPolicy, 2);
+  });
+
+  it("still permits when no store exists, because no decision was ever made", () => {
+    // The channel-less case the degrade-open path is for: `store.ts` hard-requires
+    // `node:sqlite`, so a runtime without it never ran a channel. Breaking every read here
+    // would be a regression with no security benefit.
+    setSqliteLoaderForTest(noSqlite);
+    process.env.OPENCLAW_STATE_DIR = path.join(tmp, "never-written");
+
+    assert.doesNotThrow(() => assertMailReadable("anything@example.com", "read"));
+    assert.doesNotThrow(() => assertMailRepliable("anything@example.com", "reply to"));
+
+    process.env.OPENCLAW_STATE_DIR = tmp;
+  });
+
+  it("re-checks the store instead of latching open at first touch", () => {
+    // A long-lived MCP server can start before the channel has written anything. Caching
+    // "nothing to enforce" then would keep the gate open for the rest of its life.
+    process.env.OPENCLAW_STATE_DIR = path.join(tmp, "written-later");
+    setSqliteLoaderForTest(noSqlite);
+    assert.doesNotThrow(() => assertMailReadable("anything@example.com", "read"));
+
+    // The channel comes up and records a decision, as it would on a newer Node.
+    setSqliteLoaderForTest();
+    recordRefused("<spoofed@example.com>", "unauthenticated_sender");
+    closeMailAdmissionForTest();
+    setSqliteLoaderForTest(noSqlite);
+
+    assert.throws(() => assertMailReadable("anything@example.com", "read"), /no node:sqlite/);
+    process.env.OPENCLAW_STATE_DIR = tmp;
   });
 });


### PR DESCRIPTION
Follow-up to #103, where Greptile flagged this. Filed separately so a security behavior change isn't buried in that PR's 200-line generated-bundle diff.

## The gap

`lib/mail-quarantine.js` degrades open when `node:sqlite` will not load, and [documents why](https://github.com/omarshahine/apple-pim/blob/main/lib/mail-quarantine.js): a runtime lacking the module never ran the channel either, since `store.ts` hard-requires it, so there is no admission decision to enforce. Failing closed would break every read and reply for channel-less users with no security benefit.

That reasoning holds per-process but not per-machine. The decisions are **durable rows, not process state**:

1. The channel writes admission rows on Node >= 22.13 (`openclaw/package.json` pins `">=22.13"`).
2. Claude Code later launches the standalone MCP server against the same `OPENCLAW_STATE_DIR` on whatever Node the user has. `mcp-server/build.mjs` targets `node18` and `mcp-server/package.json` sets no `engines`, so 18 and 20 are both allowed. **CI itself runs Node 20**, where `node:sqlite` does not exist.
3. `database()` returns null, `reasonFor()` returns `undefined` for every id, and both `assertMailReadable` and `assertMailRepliable` permit.

Net effect: a message the channel refused as spoofed stayed readable, and an observe-only sender stayed answerable, through `apple_pim_mail`.

## The fix

Key the decision on **the store file**, not on a Node version:

- `node:sqlite` missing **and** store file present → a channel wrote decisions this runtime cannot read. Deny, with an error naming the cause and the remedy.
- `node:sqlite` missing **and** no store file → degrade open exactly as documented today. Channel-less users on older Node are unaffected.

The file is the direct evidence, which is why it beats a version check.

**Recomputed per lookup rather than cached alongside the connection.** The two facts have different lifetimes: whether `node:sqlite` loads is fixed for the process, whether the store exists is not. A long-lived MCP server can start before the channel has ever written a decision, and caching "nothing to enforce" at that moment would hold the gate open for the rest of its life — precisely when the channel starts producing decisions. The `existsSync` only runs on runtimes that already failed to load `node:sqlite`.

### Rejected: `engines: ">=22.13"` on mcp-server

The blunt version of this fix. It would break the MCP server for every Node 18/20 user, including everyone who never touches mail. The gate should constrain the mail paths, not the whole server.

## Tests

Four cases in `openclaw/src/mail-channel/quarantine.test.ts`, via a new `setSqliteLoaderForTest` seam — CI runs Node 20, so the branch has to be provable without depending on the host runtime:

- denies reads *and* replies when unreadable decisions exist
- withholds every row from a listing rather than returning unscreened mail
- still permits when no store exists (the degrade-open case is preserved)
- re-checks rather than latching open at first touch

## Verification

- `openclaw`: 250/250 pass
- `mcp-server`: 74/74 pass, bundle rebuilt
- `evals` with `SKIP_MODEL_EVALS=1`: 140 passed, 8 skipped
- `scripts/check-versions.sh`: OK on 3.11.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)