### PR TITLE
fix(mail): resolve IMAP account names and scope Gmail mailboxes by label

### DIFF
--- a/swift/Sources/MailCLI/EnvelopeIndex.swift
+++ b/swift/Sources/MailCLI/EnvelopeIndex.swift
@@ -26,6 +26,8 @@ final class EnvelopeIndex {
     private var db: OpaquePointer?
     /// e.g. ~/Library/Mail/V10
     let versionDir: URL
+    /// nil = not yet probed or the probe itself failed; true/false = determined.
+    private var labelsTablePresent: Bool?
 
     // MARK: - Discovery / lifecycle
 
@@ -156,7 +158,17 @@ final class EnvelopeIndex {
         if sqlite3_open_v2(path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let handle {
             defer { sqlite3_close_v2(handle) }
             var stmt: OpaquePointer?
-            let sql = "SELECT ZIDENTIFIER, ZACCOUNTDESCRIPTION, ZUSERNAME FROM ZACCOUNT WHERE ZIDENTIFIER IS NOT NULL"
+            // Mail's mailbox URLs are hosted by the *child* (per-dataclass) account row,
+            // whose own description is NULL for IMAP providers (Google, Yahoo, iCloud);
+            // the human-facing name lives on the parent. Fall back to it.
+            let sql = """
+                SELECT c.ZIDENTIFIER,
+                       COALESCE(c.ZACCOUNTDESCRIPTION, p.ZACCOUNTDESCRIPTION),
+                       c.ZUSERNAME
+                FROM ZACCOUNT c
+                LEFT JOIN ZACCOUNT p ON c.ZPARENTACCOUNT = p.Z_PK
+                WHERE c.ZIDENTIFIER IS NOT NULL
+                """
             if sqlite3_prepare_v2(handle, sql, -1, &stmt, nil) == SQLITE_OK, let stmt {
                 defer { sqlite3_finalize(stmt) }
                 while sqlite3_step(stmt) == SQLITE_ROW {
@@ -225,10 +237,12 @@ final class EnvelopeIndex {
         var binds: [Bind] = []
 
         if let rowIDs = filter.mailboxRowIDs {
-            guard !rowIDs.isEmpty else { return [] }
-            let placeholders = rowIDs.map { _ in "?" }.joined(separator: ",")
-            conditions.append("m.mailbox IN (\(placeholders))")
-            binds.append(contentsOf: rowIDs.map { Bind.int($0) })
+            let includeLabels = anyLabelRows(mailboxRowIDs: rowIDs)
+            guard let scope = mailboxScopeClause(rowIDs: rowIDs, includeLabels: includeLabels) else {
+                return [] // an empty mailbox scope selects nothing
+            }
+            conditions.append(scope.sql)
+            binds.append(contentsOf: scope.rowIDBinds.map { Bind.int($0) })
         }
         if filter.unreadOnly { conditions.append("m.read = 0") }
         if filter.flaggedOnly { conditions.append("m.flagged = 1") }
@@ -307,6 +321,33 @@ final class EnvelopeIndex {
     func messageCount() throws -> Int {
         let rows = try query("SELECT COUNT(*) AS n FROM messages WHERE deleted = 0")
         return Int(rows.first?["n"] as? Int64 ?? 0)
+    }
+
+    /// Whether this Envelope Index has Mail's Gmail `labels` table (absent on installs
+    /// with no Gmail-style account). Probed once; only an answer is cached. A failed
+    /// probe reports `true`: wrongly including the arm fails loudly at prepare, wrongly
+    /// dropping it succeeds with zero rows that read as an empty mailbox.
+    private func hasLabelsTable() -> Bool {
+        if let cached = labelsTablePresent { return cached }
+        guard let rows = try? query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'labels'")
+        else { return true }  // probe failed: include the arm, and do not cache
+        let present = !rows.isEmpty
+        labelsTablePresent = present
+        return present
+    }
+
+    /// Whether any of these mailboxes carry label memberships (covering-index probe).
+    /// When none do, the arm stays off and non-Gmail queries keep their original plan.
+    /// As in `hasLabelsTable`, a failed probe reports `true` rather than risk a silent zero.
+    private func anyLabelRows(mailboxRowIDs: [Int64]) -> Bool {
+        guard !mailboxRowIDs.isEmpty, hasLabelsTable() else { return false }
+        let placeholders = mailboxRowIDs.map { _ in "?" }.joined(separator: ",")
+        guard let rows = try? query(
+            "SELECT 1 AS present FROM labels WHERE mailbox_id IN (\(placeholders)) LIMIT 1",
+            mailboxRowIDs.map { Bind.int($0) })
+        else { return true }  // probe failed: include the arm
+        return !rows.isEmpty
     }
 
     // MARK: - .emlx location

--- a/swift/Sources/MailCLI/EnvelopeIndex.swift
+++ b/swift/Sources/MailCLI/EnvelopeIndex.swift
@@ -26,6 +26,7 @@ final class EnvelopeIndex {
     private var db: OpaquePointer?
     /// e.g. ~/Library/Mail/V10
     let versionDir: URL
+    private let accountsDatabasePath: URL
     /// nil = not yet probed or the probe itself failed; true/false = determined.
     private var labelsTablePresent: Bool?
 
@@ -56,11 +57,19 @@ final class EnvelopeIndex {
                 "Envelope Index not found or not readable under ~/Library/Mail/V*. "
                 + "The SQLite read path requires Full Disk Access.")
         }
-        return try EnvelopeIndex(databasePath: dbPath)
+        return try EnvelopeIndex(
+            databasePath: dbPath,
+            accountsDatabasePath: accountsStorePath(home: home))
     }
 
-    init(databasePath: URL) throws {
+    private static func accountsStorePath(home: URL) -> URL {
+        home.appendingPathComponent("Library/Accounts/Accounts4.sqlite")
+    }
+
+    init(databasePath: URL, accountsDatabasePath: URL? = nil) throws {
         versionDir = databasePath.deletingLastPathComponent().deletingLastPathComponent()
+        self.accountsDatabasePath = accountsDatabasePath
+            ?? Self.accountsStorePath(home: FileManager.default.homeDirectoryForCurrentUser)
         var handle: OpaquePointer?
         let rc = sqlite3_open_v2(databasePath.path, &handle, SQLITE_OPEN_READONLY, nil)
         guard rc == SQLITE_OK, let handle else {
@@ -152,19 +161,18 @@ final class EnvelopeIndex {
     func accountNames() -> [String: (name: String, userName: String?)] {
         if let cachedAccountNames { return cachedAccountNames }
         var map: [String: (name: String, userName: String?)] = [:]
-        let path = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Accounts/Accounts4.sqlite").path
+        let path = accountsDatabasePath.path
         var handle: OpaquePointer?
         if sqlite3_open_v2(path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let handle {
             defer { sqlite3_close_v2(handle) }
             var stmt: OpaquePointer?
             // Mail's mailbox URLs are hosted by the *child* (per-dataclass) account row,
-            // whose own description is NULL for IMAP providers (Google, Yahoo, iCloud);
-            // the human-facing name lives on the parent. Fall back to it.
+            // whose own description and username are NULL for IMAP providers (Google,
+            // Yahoo, iCloud); the human-facing values live on the parent. Fall back to it.
             let sql = """
                 SELECT c.ZIDENTIFIER,
                        COALESCE(c.ZACCOUNTDESCRIPTION, p.ZACCOUNTDESCRIPTION),
-                       c.ZUSERNAME
+                       COALESCE(c.ZUSERNAME, p.ZUSERNAME)
                 FROM ZACCOUNT c
                 LEFT JOIN ZACCOUNT p ON c.ZPARENTACCOUNT = p.Z_PK
                 WHERE c.ZIDENTIFIER IS NOT NULL
@@ -234,6 +242,8 @@ final class EnvelopeIndex {
 
     func messages(filter: MessageFilter, limit: Int) throws -> [[String: Any]] {
         var conditions = ["m.deleted = 0", "g.message_id_header IS NOT NULL"]
+        var selectedColumns = Self.messageColumns
+        var selectedColumnBinds: [Bind] = []
         var binds: [Bind] = []
 
         if let rowIDs = filter.mailboxRowIDs {
@@ -243,6 +253,9 @@ final class EnvelopeIndex {
             }
             conditions.append(scope.sql)
             binds.append(contentsOf: scope.rowIDBinds.map { Bind.int($0) })
+            selectedColumns += ", \(scope.logicalMailboxSQL) AS logical_mailbox_rowid"
+            selectedColumnBinds.append(
+                contentsOf: scope.logicalMailboxRowIDBinds.map { Bind.int($0) })
         }
         if filter.unreadOnly { conditions.append("m.read = 0") }
         if filter.flaggedOnly { conditions.append("m.flagged = 1") }
@@ -272,14 +285,14 @@ final class EnvelopeIndex {
         }
 
         let sql = """
-            SELECT \(Self.messageColumns)
+            SELECT \(selectedColumns)
             \(Self.messageJoins)
             WHERE \(conditions.joined(separator: " AND "))
             ORDER BY m.date_received \(filter.oldestFirst ? "ASC" : "DESC")
             LIMIT ?
             """
         binds.append(.int(Int64(limit)))
-        return try query(sql, binds)
+        return try query(sql, selectedColumnBinds + binds)
     }
 
     /// All non-deleted copies of a message by RFC 2822 Message-ID, newest first.

--- a/swift/Sources/MailCLI/EnvelopeIndex.swift
+++ b/swift/Sources/MailCLI/EnvelopeIndex.swift
@@ -10,12 +10,14 @@ enum EnvelopeIndexError: Error, LocalizedError {
     case notAvailable(String)
     case queryFailed(String)
     case notFound(String)
+    case ambiguous(String)
 
     var errorDescription: String? {
         switch self {
         case .notAvailable(let msg): return msg
         case .queryFailed(let msg): return msg
         case .notFound(let msg): return msg
+        case .ambiguous(let msg): return msg
         }
     }
 }
@@ -156,11 +158,19 @@ final class EnvelopeIndex {
     /// Account UUID -> (displayName, userName) via the system Accounts store
     /// (same Full Disk Access umbrella as the mail directory). Best-effort:
     /// returns an empty map when unreadable, and callers fall back to UUIDs.
-    private var cachedAccountNames: [String: (name: String, userName: String?)]?
+    private var cachedAccountNames: [String: (
+        name: String,
+        userName: String?,
+        logicalAccountID: String
+    )]?
 
-    func accountNames() -> [String: (name: String, userName: String?)] {
+    func accountNames() -> [String: (
+        name: String,
+        userName: String?,
+        logicalAccountID: String
+    )] {
         if let cachedAccountNames { return cachedAccountNames }
-        var map: [String: (name: String, userName: String?)] = [:]
+        var map: [String: (name: String, userName: String?, logicalAccountID: String)] = [:]
         let path = accountsDatabasePath.path
         var handle: OpaquePointer?
         if sqlite3_open_v2(path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let handle {
@@ -172,7 +182,8 @@ final class EnvelopeIndex {
             let sql = """
                 SELECT c.ZIDENTIFIER,
                        COALESCE(c.ZACCOUNTDESCRIPTION, p.ZACCOUNTDESCRIPTION),
-                       COALESCE(c.ZUSERNAME, p.ZUSERNAME)
+                       COALESCE(c.ZUSERNAME, p.ZUSERNAME),
+                       COALESCE(p.ZIDENTIFIER, c.ZIDENTIFIER)
                 FROM ZACCOUNT c
                 LEFT JOIN ZACCOUNT p ON c.ZPARENTACCOUNT = p.Z_PK
                 WHERE c.ZIDENTIFIER IS NOT NULL
@@ -184,7 +195,12 @@ final class EnvelopeIndex {
                     let uuid = String(cString: idText)
                     let name = sqlite3_column_text(stmt, 1).map { String(cString: $0) }
                     let user = sqlite3_column_text(stmt, 2).map { String(cString: $0) }
-                    map[uuid] = (name: name ?? uuid, userName: user)
+                    let logicalAccountID = sqlite3_column_text(stmt, 3)
+                        .map { String(cString: $0) } ?? uuid
+                    map[uuid] = (
+                        name: name ?? uuid,
+                        userName: user,
+                        logicalAccountID: logicalAccountID)
                 }
             }
         } else if let handle {
@@ -200,11 +216,37 @@ final class EnvelopeIndex {
         let target = name.lowercased()
         let names = accountNames()
         let allUUIDs = Set(try mailboxes().map { $0.accountUUID })
-        return allUUIDs.filter { uuid in
-            if uuid.lowercased() == target { return true }
-            guard let entry = names[uuid] else { return false }
-            return entry.name.lowercased() == target || entry.userName?.lowercased() == target
-        }.sorted()
+        if let exactUUID = allUUIDs.first(where: { $0.lowercased() == target }) {
+            return [exactUUID]
+        }
+
+        let displayNameMatches = allUUIDs.filter {
+            names[$0]?.name.lowercased() == target
+        }
+        if !displayNameMatches.isEmpty {
+            return try accountUUIDsWithinOneLogicalAccount(
+                displayNameMatches, metadata: names, requestedName: name)
+        }
+
+        let userNameMatches = allUUIDs.filter {
+            names[$0]?.userName?.lowercased() == target
+        }
+        return try accountUUIDsWithinOneLogicalAccount(
+            userNameMatches, metadata: names, requestedName: name)
+    }
+
+    private func accountUUIDsWithinOneLogicalAccount(
+        _ matches: Set<String>,
+        metadata: [String: (name: String, userName: String?, logicalAccountID: String)],
+        requestedName: String
+    ) throws -> [String] {
+        let logicalAccountIDs = Set(matches.compactMap { metadata[$0]?.logicalAccountID })
+        guard logicalAccountIDs.count <= 1 else {
+            throw EnvelopeIndexError.ambiguous(
+                "Account matches multiple logical accounts: \(requestedName). "
+                + "Use the display name or account UUID instead.")
+        }
+        return matches.sorted()
     }
 
     // MARK: - Messages

--- a/swift/Sources/MailCLI/EnvelopeQueries.swift
+++ b/swift/Sources/MailCLI/EnvelopeQueries.swift
@@ -82,20 +82,38 @@ func escapeLikePattern(_ text: String) -> String {
         .replacingOccurrences(of: "_", with: "\\_")
 }
 
-/// SQL scope clause for a set of mailbox ROWIDs, plus the ROWID binds in the order the
-/// clause consumes them; `nil` for an empty list (an empty scope selects nothing).
-/// `includeLabels` ORs in the Gmail arm: the physical copy lives under [Gmail]/All Mail
-/// and folder membership lives in `labels`, so `messages.mailbox` alone matches nothing.
-func mailboxScopeClause(rowIDs: [Int64], includeLabels: Bool) -> (sql: String, rowIDBinds: [Int64])? {
+/// SQL scope for a set of mailbox ROWIDs, including the projection that identifies the
+/// logical mailbox matched by the scope. `nil` means an empty scope selects nothing.
+/// Gmail stores the physical copy under [Gmail]/All Mail and folder membership in
+/// `labels`, so the label arm selects IDs separately and keeps both branches indexable.
+func mailboxScopeClause(rowIDs: [Int64], includeLabels: Bool) -> (
+    sql: String,
+    rowIDBinds: [Int64],
+    logicalMailboxSQL: String,
+    logicalMailboxRowIDBinds: [Int64]
+)? {
     guard !rowIDs.isEmpty else { return nil }
     let placeholders = rowIDs.map { _ in "?" }.joined(separator: ",")
     guard includeLabels else {
-        return (sql: "m.mailbox IN (\(placeholders))", rowIDBinds: rowIDs)
+        return (
+            sql: "m.mailbox IN (\(placeholders))",
+            rowIDBinds: rowIDs,
+            logicalMailboxSQL: "m.mailbox",
+            logicalMailboxRowIDBinds: [])
     }
     return (
-        sql: "(m.mailbox IN (\(placeholders)) OR m.ROWID IN "
-            + "(SELECT l.message_id FROM labels l WHERE l.mailbox_id IN (\(placeholders))))",
-        rowIDBinds: rowIDs + rowIDs
+        sql: "m.ROWID IN ("
+            + "SELECT scoped.ROWID FROM messages scoped "
+            + "WHERE scoped.mailbox IN (\(placeholders)) "
+            + "UNION ALL "
+            + "SELECT l.message_id FROM labels l "
+            + "WHERE l.mailbox_id IN (\(placeholders)))",
+        rowIDBinds: rowIDs + rowIDs,
+        logicalMailboxSQL: "CASE WHEN m.mailbox IN (\(placeholders)) THEN m.mailbox "
+            + "ELSE (SELECT l.mailbox_id FROM labels l "
+            + "WHERE l.message_id = m.ROWID AND l.mailbox_id IN (\(placeholders)) "
+            + "ORDER BY l.mailbox_id LIMIT 1) END",
+        logicalMailboxRowIDBinds: rowIDs + rowIDs
     )
 }
 

--- a/swift/Sources/MailCLI/EnvelopeQueries.swift
+++ b/swift/Sources/MailCLI/EnvelopeQueries.swift
@@ -82,6 +82,23 @@ func escapeLikePattern(_ text: String) -> String {
         .replacingOccurrences(of: "_", with: "\\_")
 }
 
+/// SQL scope clause for a set of mailbox ROWIDs, plus the ROWID binds in the order the
+/// clause consumes them; `nil` for an empty list (an empty scope selects nothing).
+/// `includeLabels` ORs in the Gmail arm: the physical copy lives under [Gmail]/All Mail
+/// and folder membership lives in `labels`, so `messages.mailbox` alone matches nothing.
+func mailboxScopeClause(rowIDs: [Int64], includeLabels: Bool) -> (sql: String, rowIDBinds: [Int64])? {
+    guard !rowIDs.isEmpty else { return nil }
+    let placeholders = rowIDs.map { _ in "?" }.joined(separator: ",")
+    guard includeLabels else {
+        return (sql: "m.mailbox IN (\(placeholders))", rowIDBinds: rowIDs)
+    }
+    return (
+        sql: "(m.mailbox IN (\(placeholders)) OR m.ROWID IN "
+            + "(SELECT l.message_id FROM labels l WHERE l.mailbox_id IN (\(placeholders))))",
+        rowIDBinds: rowIDs + rowIDs
+    )
+}
+
 /// Mailbox names Mail.app treats as junk destinations.
 private let junkMailboxNames: Set<String> = ["Junk", "Junk Mail", "Junk E-mail", "Junk Email", "Spam", "Bulk Mail"]
 

--- a/swift/Sources/MailCLI/SQLiteEngine.swift
+++ b/swift/Sources/MailCLI/SQLiteEngine.swift
@@ -33,11 +33,18 @@ struct SQLiteEngine {
     let index: EnvelopeIndex
     let allMailboxes: [MailboxRef]
     private let mailboxByURL: [String: MailboxRef]
+    private let mailboxByRowID: [Int64: MailboxRef]
 
     init() throws {
-        index = try EnvelopeIndex.open()
-        allMailboxes = try index.mailboxes()
+        let index = try EnvelopeIndex.open()
+        self.init(index: index, allMailboxes: try index.mailboxes())
+    }
+
+    init(index: EnvelopeIndex, allMailboxes: [MailboxRef]) {
+        self.index = index
+        self.allMailboxes = allMailboxes
         mailboxByURL = Dictionary(uniqueKeysWithValues: allMailboxes.map { ($0.url, $0) })
+        mailboxByRowID = Dictionary(uniqueKeysWithValues: allMailboxes.map { ($0.rowid, $0) })
     }
 
     private func accountDisplayName(_ uuid: String) -> String {
@@ -62,8 +69,12 @@ struct SQLiteEngine {
         return candidates
     }
 
-    private func mailboxRef(forURL url: String?) -> MailboxRef? {
-        url.flatMap { mailboxByURL[$0] }
+    private func mailboxRef(forRow row: [String: Any]) -> MailboxRef? {
+        if let logicalRowID = row["logical_mailbox_rowid"] as? Int64,
+           let logicalMailbox = mailboxByRowID[logicalRowID] {
+            return logicalMailbox
+        }
+        return (row["mailbox_url"] as? String).flatMap { mailboxByURL[$0] }
     }
 
     // MARK: - Row mapping
@@ -71,7 +82,7 @@ struct SQLiteEngine {
     /// Shared row -> message summary mapping (the `messages` command shape).
     private func summaryDict(_ row: [String: Any], includeJunkAndAttachments: Bool,
                              includeLocation: Bool) -> [String: Any] {
-        let mailbox = mailboxRef(forURL: row["mailbox_url"] as? String)
+        let mailbox = mailboxRef(forRow: row)
         var dict: [String: Any] = [
             "messageId": stripAngleBrackets(row["message_id"] as? String ?? ""),
             "sender": formatAddress(address: row["sender_address"] as? String ?? "",
@@ -205,7 +216,7 @@ struct SQLiteEngine {
             let hintedAccountUUIDs = accountHint.flatMap { try? index.accountUUIDs(matching: $0) } ?? []
             var bestScore = -1
             for candidate in rows {
-                guard let mailbox = mailboxRef(forURL: candidate["mailbox_url"] as? String) else { continue }
+                guard let mailbox = mailboxRef(forRow: candidate) else { continue }
                 var score = 0
                 if let hint = mailboxHint, mailbox.name.caseInsensitiveCompare(hint) == .orderedSame { score += 2 }
                 if hintedAccountUUIDs.contains(mailbox.accountUUID) { score += 1 }
@@ -218,7 +229,7 @@ struct SQLiteEngine {
         guard let row = bestRow, let rowid = row["rowid"] as? Int64 else {
             throw EnvelopeIndexError.notFound("Message not found: \(id)")
         }
-        guard let mailbox = mailboxRef(forURL: row["mailbox_url"] as? String),
+        guard let mailbox = mailboxRef(forRow: row),
               let emlxURL = index.emlxPath(forMessageRowID: rowid, mailbox: mailbox) else {
             // Message metadata exists but the body isn't on disk (not yet
             // downloaded); the JXA engine can still fetch it from Mail.app.

--- a/swift/Tests/MailCLITests/EnvelopeIndexAccountTests.swift
+++ b/swift/Tests/MailCLITests/EnvelopeIndexAccountTests.swift
@@ -35,6 +35,28 @@ final class EnvelopeIndexAccountTests: XCTestCase {
         XCTAssertEqual(try index.accountUUIDs(matching: "child@example.com"), ["NAMED-CHILD"])
     }
 
+    func testSharedUsernameWithinOneLogicalAccountReturnsAllMailboxUUIDs() throws {
+        let index = try openFixture()
+
+        XCTAssertEqual(
+            try index.accountUUIDs(matching: "Shared A"),
+            ["SHARED-CHILD-A", "SHARED-CHILD-A2"])
+        XCTAssertEqual(
+            try index.accountUUIDs(matching: "SHARED-CHILD-A2"),
+            ["SHARED-CHILD-A2"])
+    }
+
+    func testSharedUsernameAcrossLogicalAccountsIsRejected() throws {
+        let index = try openFixture()
+
+        XCTAssertThrowsError(try index.accountUUIDs(matching: "shared@example.com")) { error in
+            guard case EnvelopeIndexError.ambiguous(let message) = error else {
+                return XCTFail("Expected ambiguous account error, got \(error)")
+            }
+            XCTAssertTrue(message.contains("multiple logical accounts"))
+        }
+    }
+
     private func openFixture() throws -> EnvelopeIndex {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         let envelopePath = tempDir.appendingPathComponent("Envelope Index")
@@ -50,7 +72,10 @@ final class EnvelopeIndexAccountTests: XCTestCase {
             INSERT INTO mailboxes (ROWID, url) VALUES
                 (1, 'imap://IMAP-CHILD/INBOX'),
                 (2, 'ews://EXCHANGE/Inbox'),
-                (3, 'imap://NAMED-CHILD/INBOX');
+                (3, 'imap://NAMED-CHILD/INBOX'),
+                (4, 'imap://SHARED-CHILD-A/INBOX'),
+                (5, 'imap://SHARED-CHILD-A2/Archive'),
+                (6, 'imap://SHARED-CHILD-B/INBOX');
             """)
 
         try createDatabase(at: accountsPath, sql: """
@@ -69,7 +94,12 @@ final class EnvelopeIndexAccountTests: XCTestCase {
                 (3, 'EXCHANGE', 'Work Exchange', 'person@example.com', NULL),
                 (4, 'NAMED-PARENT', 'Parent Name', 'parent@example.com', NULL),
                 (5, 'NAMED-CHILD', 'Child Override', 'child@example.com', 4),
-                (6, NULL, 'Ignored', 'ignored@example.com', NULL);
+                (6, NULL, 'Ignored', 'ignored@example.com', NULL),
+                (7, 'SHARED-PARENT-A', 'Shared A', 'shared@example.com', NULL),
+                (8, 'SHARED-CHILD-A', NULL, NULL, 7),
+                (9, 'SHARED-CHILD-A2', NULL, NULL, 7),
+                (10, 'SHARED-PARENT-B', 'Shared B', 'shared@example.com', NULL),
+                (11, 'SHARED-CHILD-B', NULL, NULL, 10);
             """)
 
         return try EnvelopeIndex(

--- a/swift/Tests/MailCLITests/EnvelopeIndexAccountTests.swift
+++ b/swift/Tests/MailCLITests/EnvelopeIndexAccountTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import SQLite3
+import XCTest
+@testable import MailCLI
+
+/// Regression coverage for resolving Mail mailbox UUIDs through Accounts4.sqlite.
+final class EnvelopeIndexAccountTests: XCTestCase {
+    private lazy var tempDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("mailcli-accounts-\(UUID().uuidString)")
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    func testChildAccountInheritsParentDisplayName() throws {
+        let index = try openFixture()
+
+        let names = index.accountNames()
+
+        XCTAssertEqual(names["IMAP-CHILD"]?.name, "Personal Gmail")
+        XCTAssertEqual(names["IMAP-CHILD"]?.userName, "personal@example.com")
+        XCTAssertEqual(try index.accountUUIDs(matching: "Personal Gmail"), ["IMAP-CHILD"])
+        XCTAssertEqual(try index.accountUUIDs(matching: "personal@example.com"), ["IMAP-CHILD"])
+    }
+
+    func testTopLevelAndChildOwnedNamesStillWin() throws {
+        let index = try openFixture()
+
+        let names = index.accountNames()
+
+        XCTAssertEqual(names["EXCHANGE"]?.name, "Work Exchange")
+        XCTAssertEqual(names["EXCHANGE"]?.userName, "person@example.com")
+        XCTAssertEqual(names["NAMED-CHILD"]?.name, "Child Override")
+        XCTAssertEqual(try index.accountUUIDs(matching: "child@example.com"), ["NAMED-CHILD"])
+    }
+
+    private func openFixture() throws -> EnvelopeIndex {
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let envelopePath = tempDir.appendingPathComponent("Envelope Index")
+        let accountsPath = tempDir.appendingPathComponent("Accounts4.sqlite")
+
+        try createDatabase(at: envelopePath, sql: """
+            CREATE TABLE mailboxes (
+                ROWID INTEGER PRIMARY KEY,
+                url TEXT NOT NULL,
+                total_count INTEGER NOT NULL DEFAULT 0,
+                unread_count INTEGER NOT NULL DEFAULT 0
+            );
+            INSERT INTO mailboxes (ROWID, url) VALUES
+                (1, 'imap://IMAP-CHILD/INBOX'),
+                (2, 'ews://EXCHANGE/Inbox'),
+                (3, 'imap://NAMED-CHILD/INBOX');
+            """)
+
+        try createDatabase(at: accountsPath, sql: """
+            CREATE TABLE ZACCOUNT (
+                Z_PK INTEGER PRIMARY KEY,
+                ZIDENTIFIER TEXT,
+                ZACCOUNTDESCRIPTION TEXT,
+                ZUSERNAME TEXT,
+                ZPARENTACCOUNT INTEGER
+            );
+            INSERT INTO ZACCOUNT
+                (Z_PK, ZIDENTIFIER, ZACCOUNTDESCRIPTION, ZUSERNAME, ZPARENTACCOUNT)
+            VALUES
+                (1, 'IMAP-PARENT', 'Personal Gmail', 'personal@example.com', NULL),
+                (2, 'IMAP-CHILD', NULL, NULL, 1),
+                (3, 'EXCHANGE', 'Work Exchange', 'person@example.com', NULL),
+                (4, 'NAMED-PARENT', 'Parent Name', 'parent@example.com', NULL),
+                (5, 'NAMED-CHILD', 'Child Override', 'child@example.com', 4),
+                (6, NULL, 'Ignored', 'ignored@example.com', NULL);
+            """)
+
+        return try EnvelopeIndex(
+            databasePath: envelopePath,
+            accountsDatabasePath: accountsPath)
+    }
+
+    private func createDatabase(at path: URL, sql: String) throws {
+        var handle: OpaquePointer?
+        let openResult = sqlite3_open_v2(
+            path.path, &handle, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil)
+        guard openResult == SQLITE_OK, let handle else {
+            if let handle { sqlite3_close_v2(handle) }
+            throw EnvelopeIndexError.notAvailable("Fixture open failed: code \(openResult)")
+        }
+
+        let result = sqlite3_exec(handle, sql, nil, nil, nil)
+        let detail = result == SQLITE_OK ? "" : String(cString: sqlite3_errmsg(handle))
+        sqlite3_close_v2(handle)
+        guard result == SQLITE_OK else {
+            throw EnvelopeIndexError.queryFailed("Fixture setup failed: \(detail)")
+        }
+    }
+}

--- a/swift/Tests/MailCLITests/EnvelopeIndexLabelsTests.swift
+++ b/swift/Tests/MailCLITests/EnvelopeIndexLabelsTests.swift
@@ -31,9 +31,11 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
         // 101-104 sit in All Mail and reach INBOX only through `labels`; 106 is stored in
         // INBOX directly; 105 is in All Mail with no label and must stay out.
         XCTAssertEqual(rowIDs(rows), [101, 102, 103, 104, 106])
-        // 106 matches both arms. They are an OR over a single `messages` row rather than a
-        // UNION, so it comes back once.
+        // 106 matches both indexable branches. The outer IN membership still returns it once.
         XCTAssertEqual(rows.count, 5)
+        // Label-backed rows must report the mailbox the caller scoped to, not the
+        // physical [Gmail]/All Mail store that owns the message row.
+        XCTAssertEqual(Set(rows.compactMap { $0["logical_mailbox_rowid"] as? Int64 }), [inboxRowID])
     }
 
     func testWithoutTheLabelsArmTheGmailInboxLooksEmpty() throws {
@@ -61,7 +63,7 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
 
         let allMail = try index.messages(
             filter: EnvelopeIndex.MessageFilter(mailboxRowIDs: [allMailRowID]), limit: 50)
-        XCTAssertEqual(rowIDs(allMail), [101, 102, 103, 104, 105])
+        XCTAssertEqual(rowIDs(allMail), [101, 102, 103, 104, 105, 108])
     }
 
     func testMailboxWithNoLabelRowsKeepsTheDirectClause() throws {
@@ -90,6 +92,42 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
         // 105 has no label, 106's subject has no match. A one-slot drift binds the cutoff
         // or the pattern to the wrong placeholder and this set changes.
         XCTAssertEqual(rowIDs(rows), [101])
+    }
+
+    func testLabelsArmUsesBothMailboxIndexes() throws {
+        let index = try openFixture(includeLabels: true)
+        let scope = try XCTUnwrap(
+            mailboxScopeClause(rowIDs: [inboxRowID], includeLabels: true))
+        let rows = try index.query(
+            """
+            EXPLAIN QUERY PLAN
+            SELECT m.ROWID FROM messages m
+            WHERE m.deleted = 0 AND \(scope.sql)
+            ORDER BY m.date_received DESC LIMIT 25
+            """,
+            scope.rowIDBinds.map { EnvelopeIndex.Bind.int($0) })
+        let plan = rows.compactMap { $0["detail"] as? String }.joined(separator: "\n")
+
+        XCTAssertTrue(plan.contains("messages_mailbox_date_received_index"), plan)
+        XCTAssertTrue(plan.contains("labels_mailbox_id_index"), plan)
+    }
+
+    func testSQLiteEngineUsesLogicalMailboxForLocationAndJunkStatus() throws {
+        let index = try openFixture(includeLabels: true)
+        let engine = SQLiteEngine(index: index, allMailboxes: try index.mailboxes())
+
+        let search = try engine.search(
+            query: "Needle", field: "subject", mailbox: "INBOX", account: nil,
+            limit: 50, since: nil)
+        let searchMessages = try XCTUnwrap(search["messages"] as? [[String: Any]])
+        XCTAssertFalse(searchMessages.isEmpty)
+        XCTAssertTrue(searchMessages.allSatisfy { $0["mailbox"] as? String == "INBOX" })
+
+        let spam = try engine.messages(
+            mailbox: "Spam", account: nil, limit: 50, filter: nil)
+        let spamMessages = try XCTUnwrap(spam["messages"] as? [[String: Any]])
+        XCTAssertEqual(spamMessages.count, 1)
+        XCTAssertEqual(spamMessages.first?["isJunk"] as? Bool, true)
     }
 
     // MARK: - Fixture
@@ -166,6 +204,9 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
         automated_conversation INTEGER DEFAULT 0,
         root_status INTEGER DEFAULT -1);
 
+        CREATE INDEX messages_mailbox_date_received_index
+        ON messages(mailbox, date_received);
+
         CREATE TABLE mailboxes (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
         url TEXT COLLATE BINARY NOT NULL,
         total_count INTEGER NOT NULL DEFAULT 0,
@@ -227,7 +268,8 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
         INSERT INTO mailboxes (ROWID, url) VALUES
         (1, 'imap://GMAIL-ACCOUNT/%5BGmail%5D/All%20Mail'),
         (2, 'imap://GMAIL-ACCOUNT/INBOX'),
-        (3, 'ews://OTHER-ACCOUNT/Inbox');
+        (3, 'ews://OTHER-ACCOUNT/Inbox'),
+        (4, 'imap://GMAIL-ACCOUNT/Spam');
 
         INSERT INTO addresses (ROWID, address, comment) VALUES
         (1, 'sender@example.com', 'Example Sender');
@@ -239,7 +281,8 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
         (4, 'Nothing here'),
         (5, 'Needle five'),
         (6, 'Direct mailbox message'),
-        (7, 'Exchange direct message');
+        (7, 'Exchange direct message'),
+        (8, 'Spam offer');
 
         INSERT INTO message_global_data (ROWID, message_id_header) VALUES
         (1, '<m1@example.com>'),
@@ -248,7 +291,8 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
         (4, '<m4@example.com>'),
         (5, '<m5@example.com>'),
         (6, '<m6@example.com>'),
-        (7, '<m7@example.com>');
+        (7, '<m7@example.com>'),
+        (8, '<m8@example.com>');
 
         -- 101-105 are the Gmail copies: physically in All Mail, reaching INBOX only
         -- through `labels`. A real Gmail INBOX owns no messages rows at all; 106 is put
@@ -263,13 +307,14 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
         (104, 4, 1, 4, 2000, 2000, 1, 0, 0),
         (105, 5, 1, 5, 2000, 2000, 1, 0, 0),
         (106, 6, 1, 6, 2000, 2000, 2, 0, 0),
-        (107, 7, 1, 7, 2000, 2000, 3, 0, 0);
+        (107, 7, 1, 7, 2000, 2000, 3, 0, 0),
+        (108, 8, 1, 8, 2000, 2000, 1, 0, 0);
 
         """
 
     private static let labelRows = """
         INSERT INTO labels (message_id, mailbox_id) VALUES
-        (101, 2), (102, 2), (103, 2), (104, 2), (106, 2);
+        (101, 2), (102, 2), (103, 2), (104, 2), (106, 2), (108, 4);
 
         """
 }

--- a/swift/Tests/MailCLITests/EnvelopeIndexLabelsTests.swift
+++ b/swift/Tests/MailCLITests/EnvelopeIndexLabelsTests.swift
@@ -122,6 +122,7 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
         let searchMessages = try XCTUnwrap(search["messages"] as? [[String: Any]])
         XCTAssertFalse(searchMessages.isEmpty)
         XCTAssertTrue(searchMessages.allSatisfy { $0["mailbox"] as? String == "INBOX" })
+        XCTAssertTrue(searchMessages.allSatisfy { $0["account"] as? String == "GMAIL-ACCOUNT" })
 
         let spam = try engine.messages(
             mailbox: "Spam", account: nil, limit: 50, filter: nil)
@@ -163,7 +164,12 @@ final class EnvelopeIndexLabelsTests: XCTestCase {
             throw EnvelopeIndexError.queryFailed("Fixture setup failed: \(detail)")
         }
 
-        return try EnvelopeIndex(databasePath: dbPath)
+        // Keep this integration fixture hermetic. `SQLiteEngine.search` resolves account
+        // names, so point it at a deliberately absent fixture path rather than the user's
+        // real ~/Library/Accounts/Accounts4.sqlite.
+        return try EnvelopeIndex(
+            databasePath: dbPath,
+            accountsDatabasePath: tempDir.appendingPathComponent("Accounts4.sqlite"))
     }
 
     /// Mail's own CREATE TABLE statements, copied from a live Envelope Index. Its indexes

--- a/swift/Tests/MailCLITests/EnvelopeIndexLabelsTests.swift
+++ b/swift/Tests/MailCLITests/EnvelopeIndexLabelsTests.swift
@@ -1,0 +1,275 @@
+import Foundation
+import SQLite3
+import XCTest
+@testable import MailCLI
+
+/// End-to-end cover for the Gmail labels arm in `EnvelopeIndex.messages`, run against a
+/// throwaway Envelope Index built from Mail's own table definitions. The clause-shape
+/// tests in `EnvelopeQueriesTests` only pin the SQL text; these pin what it returns.
+final class EnvelopeIndexLabelsTests: XCTestCase {
+
+    // Fixture mailbox ROWIDs.
+    private let allMailRowID: Int64 = 1    // the physical Gmail store
+    private let inboxRowID: Int64 = 2      // the Gmail INBOX label
+    private let otherInboxRowID: Int64 = 3 // a non-Gmail mailbox, direct storage
+
+    private lazy var tempDir: URL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("mailcli-envelope-\(UUID().uuidString)")
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Behavior
+
+    func testLabelsArmFindsGmailInboxMessagesStoredUnderAllMail() throws {
+        let index = try openFixture(includeLabels: true)
+        let rows = try index.messages(
+            filter: EnvelopeIndex.MessageFilter(mailboxRowIDs: [inboxRowID]), limit: 50)
+
+        // 101-104 sit in All Mail and reach INBOX only through `labels`; 106 is stored in
+        // INBOX directly; 105 is in All Mail with no label and must stay out.
+        XCTAssertEqual(rowIDs(rows), [101, 102, 103, 104, 106])
+        // 106 matches both arms. They are an OR over a single `messages` row rather than a
+        // UNION, so it comes back once.
+        XCTAssertEqual(rows.count, 5)
+    }
+
+    func testWithoutTheLabelsArmTheGmailInboxLooksEmpty() throws {
+        // The regression the arm exists to prevent: scoping by mailbox alone hides every
+        // Gmail INBOX message, and hides them by succeeding with no rows.
+        let index = try openFixture(includeLabels: true)
+        let scope = try XCTUnwrap(mailboxScopeClause(rowIDs: [inboxRowID], includeLabels: false))
+        let rows = try index.query(
+            "SELECT m.ROWID AS rowid FROM messages m WHERE m.deleted = 0 AND \(scope.sql)",
+            scope.rowIDBinds.map { EnvelopeIndex.Bind.int($0) })
+
+        XCTAssertFalse(rowIDs(rows).contains(101))
+        XCTAssertEqual(rowIDs(rows), [106])
+    }
+
+    func testMissingLabelsTableStillReturnsDirectMailboxMessages() throws {
+        // A non-Gmail install has no `labels` table at all. The arm must stay off: naming
+        // the table would fail in sqlite3_prepare_v2, and `messages` would throw rather
+        // than return, so reaching these assertions is itself the prepare check.
+        let index = try openFixture(includeLabels: false)
+
+        let inbox = try index.messages(
+            filter: EnvelopeIndex.MessageFilter(mailboxRowIDs: [inboxRowID]), limit: 50)
+        XCTAssertEqual(rowIDs(inbox), [106])
+
+        let allMail = try index.messages(
+            filter: EnvelopeIndex.MessageFilter(mailboxRowIDs: [allMailRowID]), limit: 50)
+        XCTAssertEqual(rowIDs(allMail), [101, 102, 103, 104, 105])
+    }
+
+    func testMailboxWithNoLabelRowsKeepsTheDirectClause() throws {
+        // `labels` exists because some other account is Gmail, but this mailbox has no
+        // memberships in it, so the arm stays off and the mailbox reads as it always did.
+        let index = try openFixture(includeLabels: true)
+        let rows = try index.messages(
+            filter: EnvelopeIndex.MessageFilter(mailboxRowIDs: [otherInboxRowID]), limit: 50)
+        XCTAssertEqual(rowIDs(rows), [107])
+    }
+
+    func testLabelsArmKeepsBindsAlignedWithUnreadSinceAndSubjectFilters() throws {
+        // The arm doubles the mailbox placeholders, so every later bind shifts if the
+        // clause and its bind list ever disagree. Stack the three bound filters at once.
+        let index = try openFixture(includeLabels: true)
+        var filter = EnvelopeIndex.MessageFilter(mailboxRowIDs: [inboxRowID])
+        filter.unreadOnly = true
+        filter.sinceEpoch = 1000
+        filter.queryText = "needle"
+        filter.queryField = "subject"
+
+        let rows = try index.messages(filter: filter, limit: 50)
+
+        // Only 101 clears all four: labelled INBOX, unread, after the cutoff, subject
+        // matches. 102 is read, 103 predates the cutoff, 104's subject has no match,
+        // 105 has no label, 106's subject has no match. A one-slot drift binds the cutoff
+        // or the pattern to the wrong placeholder and this set changes.
+        XCTAssertEqual(rowIDs(rows), [101])
+    }
+
+    // MARK: - Fixture
+
+    private func rowIDs(_ rows: [[String: Any]]) -> Set<Int64> {
+        Set(rows.compactMap { $0["rowid"] as? Int64 })
+    }
+
+    /// Build a throwaway Envelope Index and open it through the production reader.
+    /// `includeLabels` controls whether the Gmail `labels` table exists at all; its
+    /// absence is what a non-Gmail install looks like.
+    private func openFixture(includeLabels: Bool) throws -> EnvelopeIndex {
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let dbPath = tempDir.appendingPathComponent("Envelope Index")
+
+        var handle: OpaquePointer?
+        let openResult = sqlite3_open_v2(
+            dbPath.path, &handle, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil)
+        guard openResult == SQLITE_OK, let handle else {
+            if let handle { sqlite3_close_v2(handle) }
+            throw EnvelopeIndexError.notAvailable("Fixture open failed: code \(openResult)")
+        }
+
+        var sql = Self.schema
+        if includeLabels { sql += Self.labelsSchema }
+        sql += Self.rows
+        if includeLabels { sql += Self.labelRows }
+
+        let rc = sqlite3_exec(handle, sql, nil, nil, nil)
+        let detail = rc == SQLITE_OK ? "" : String(cString: sqlite3_errmsg(handle))
+        sqlite3_close_v2(handle)
+        guard rc == SQLITE_OK else {
+            throw EnvelopeIndexError.queryFailed("Fixture setup failed: \(detail)")
+        }
+
+        return try EnvelopeIndex(databasePath: dbPath)
+    }
+
+    /// Mail's own CREATE TABLE statements, copied from a live Envelope Index. Its indexes
+    /// and its count-keeping triggers are left out: the triggers reference bookkeeping
+    /// tables these queries never touch, and `messages` filters the dedicated `read` and
+    /// `deleted` columns rather than the `flags` bitfield the triggers maintain.
+    private static let schema = """
+        CREATE TABLE messages (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id INTEGER NOT NULL DEFAULT 0,
+        global_message_id INTEGER NOT NULL,
+        remote_id INTEGER,
+        document_id TEXT COLLATE BINARY,
+        sender INTEGER,
+        subject_prefix TEXT COLLATE BINARY,
+        subject INTEGER NOT NULL,
+        summary INTEGER,
+        date_sent INTEGER,
+        date_received INTEGER,
+        mailbox INTEGER NOT NULL,
+        remote_mailbox INTEGER,
+        flags INTEGER NOT NULL DEFAULT 0,
+        read INTEGER NOT NULL DEFAULT 0,
+        flagged INTEGER NOT NULL DEFAULT 0,
+        deleted INTEGER NOT NULL DEFAULT 0,
+        size INTEGER NOT NULL DEFAULT 0,
+        conversation_id INTEGER NOT NULL DEFAULT 0,
+        date_last_viewed INTEGER,
+        list_id_hash INTEGER,
+        unsubscribe_type INTEGER,
+        searchable_message INTEGER,
+        brand_indicator INTEGER,
+        display_date INTEGER,
+        flag_color INTEGER,
+        is_urgent INTEGER NOT NULL DEFAULT 0,
+        color TEXT COLLATE BINARY,
+        type INTEGER,
+        fuzzy_ancestor INTEGER,
+        automated_conversation INTEGER DEFAULT 0,
+        root_status INTEGER DEFAULT -1);
+
+        CREATE TABLE mailboxes (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        url TEXT COLLATE BINARY NOT NULL,
+        total_count INTEGER NOT NULL DEFAULT 0,
+        unread_count INTEGER NOT NULL DEFAULT 0,
+        deleted_count INTEGER NOT NULL DEFAULT 0,
+        unseen_count INTEGER NOT NULL DEFAULT 0,
+        unread_count_adjusted_for_duplicates INTEGER NOT NULL DEFAULT 0,
+        change_identifier TEXT COLLATE BINARY,
+        source INTEGER,
+        alleged_change_identifier TEXT COLLATE BINARY,
+        UNIQUE(url) ON CONFLICT ABORT);
+
+        CREATE TABLE message_global_data (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id INTEGER,
+        follow_up_start_date INTEGER,
+        follow_up_end_date INTEGER,
+        follow_up_jsonstringformodelevaluationforsuggestions TEXT COLLATE BINARY,
+        download_state INTEGER NOT NULL DEFAULT 0,
+        read_later_date INTEGER,
+        send_later_date INTEGER,
+        validation_state INTEGER NOT NULL DEFAULT 0,
+        model_category INTEGER,
+        model_subcategory INTEGER,
+        category_model_version INTEGER,
+        category_is_temporary INTEGER,
+        model_analytics TEXT COLLATE BINARY,
+        model_high_impact INTEGER NOT NULL DEFAULT 0,
+        generated_summary INTEGER,
+        urgent INTEGER,
+        message_id_header TEXT COLLATE BINARY,
+        UNIQUE(message_id) ON CONFLICT ABORT);
+
+        CREATE TABLE subjects (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        subject TEXT COLLATE RTRIM NOT NULL,
+        UNIQUE(subject) ON CONFLICT ABORT);
+
+        CREATE TABLE addresses (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        address TEXT COLLATE NOCASE NOT NULL,
+        comment TEXT COLLATE BINARY NOT NULL,
+        UNIQUE(address, comment) ON CONFLICT ABORT);
+
+        CREATE TABLE attachments (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        message INTEGER NOT NULL REFERENCES messages(ROWID) ON DELETE CASCADE,
+        attachment_id TEXT COLLATE BINARY,
+        name TEXT COLLATE BINARY,
+        UNIQUE(message, attachment_id) ON CONFLICT ABORT);
+
+        """
+
+    private static let labelsSchema = """
+        CREATE TABLE labels (message_id INTEGER REFERENCES messages(ROWID) ON DELETE CASCADE,
+        mailbox_id INTEGER REFERENCES mailboxes(ROWID) ON DELETE CASCADE,
+        PRIMARY KEY(message_id, mailbox_id)) WITHOUT ROWID;
+        CREATE INDEX labels_mailbox_id_index on labels(mailbox_id);
+
+        """
+
+    private static let rows = """
+        INSERT INTO mailboxes (ROWID, url) VALUES
+        (1, 'imap://GMAIL-ACCOUNT/%5BGmail%5D/All%20Mail'),
+        (2, 'imap://GMAIL-ACCOUNT/INBOX'),
+        (3, 'ews://OTHER-ACCOUNT/Inbox');
+
+        INSERT INTO addresses (ROWID, address, comment) VALUES
+        (1, 'sender@example.com', 'Example Sender');
+
+        INSERT INTO subjects (ROWID, subject) VALUES
+        (1, 'Needle in a haystack'),
+        (2, 'Needle two'),
+        (3, 'Needle three'),
+        (4, 'Nothing here'),
+        (5, 'Needle five'),
+        (6, 'Direct mailbox message'),
+        (7, 'Exchange direct message');
+
+        INSERT INTO message_global_data (ROWID, message_id_header) VALUES
+        (1, '<m1@example.com>'),
+        (2, '<m2@example.com>'),
+        (3, '<m3@example.com>'),
+        (4, '<m4@example.com>'),
+        (5, '<m5@example.com>'),
+        (6, '<m6@example.com>'),
+        (7, '<m7@example.com>');
+
+        -- 101-105 are the Gmail copies: physically in All Mail, reaching INBOX only
+        -- through `labels`. A real Gmail INBOX owns no messages rows at all; 106 is put
+        -- there anyway so the direct arm still has something to match, and so a row
+        -- matched by both arms can be checked for duplication. 107 is the non-Gmail case.
+        INSERT INTO messages
+        (ROWID, global_message_id, sender, subject, date_received, date_sent, mailbox, read, deleted)
+        VALUES
+        (101, 1, 1, 1, 2000, 2000, 1, 0, 0),
+        (102, 2, 1, 2, 2000, 2000, 1, 1, 0),
+        (103, 3, 1, 3,  100,  100, 1, 0, 0),
+        (104, 4, 1, 4, 2000, 2000, 1, 0, 0),
+        (105, 5, 1, 5, 2000, 2000, 1, 0, 0),
+        (106, 6, 1, 6, 2000, 2000, 2, 0, 0),
+        (107, 7, 1, 7, 2000, 2000, 3, 0, 0);
+
+        """
+
+    private static let labelRows = """
+        INSERT INTO labels (message_id, mailbox_id) VALUES
+        (101, 2), (102, 2), (103, 2), (104, 2), (106, 2);
+
+        """
+}

--- a/swift/Tests/MailCLITests/EnvelopeQueriesTests.swift
+++ b/swift/Tests/MailCLITests/EnvelopeQueriesTests.swift
@@ -108,6 +108,8 @@ final class EnvelopeQueriesTests: XCTestCase {
         let scope = try XCTUnwrap(mailboxScopeClause(rowIDs: [297], includeLabels: false))
         XCTAssertEqual(scope.sql, "m.mailbox IN (?)")
         XCTAssertEqual(scope.rowIDBinds, [297])
+        XCTAssertEqual(scope.logicalMailboxSQL, "m.mailbox")
+        XCTAssertEqual(scope.logicalMailboxRowIDBinds, [])
     }
 
     func testMailboxScopeClauseWithLabelsAddsGmailArm() throws {
@@ -116,17 +118,25 @@ final class EnvelopeQueriesTests: XCTestCase {
         let scope = try XCTUnwrap(mailboxScopeClause(rowIDs: [297], includeLabels: true))
         XCTAssertEqual(
             scope.sql,
-            "(m.mailbox IN (?) OR m.ROWID IN "
-                + "(SELECT l.message_id FROM labels l WHERE l.mailbox_id IN (?)))")
-        // Direct arm bound first, label arm second: the clause consumes them in that order.
+            "m.ROWID IN (SELECT scoped.ROWID FROM messages scoped "
+                + "WHERE scoped.mailbox IN (?) UNION ALL "
+                + "SELECT l.message_id FROM labels l WHERE l.mailbox_id IN (?))")
         XCTAssertEqual(scope.rowIDBinds, [297, 297])
+        XCTAssertEqual(
+            scope.logicalMailboxSQL,
+            "CASE WHEN m.mailbox IN (?) THEN m.mailbox "
+                + "ELSE (SELECT l.mailbox_id FROM labels l "
+                + "WHERE l.message_id = m.ROWID AND l.mailbox_id IN (?) "
+                + "ORDER BY l.mailbox_id LIMIT 1) END")
+        XCTAssertEqual(scope.logicalMailboxRowIDBinds, [297, 297])
     }
 
     func testMailboxScopeClauseMultipleRowIDs() throws {
         let scope = try XCTUnwrap(mailboxScopeClause(rowIDs: [1, 2, 3], includeLabels: true))
-        XCTAssertTrue(scope.sql.contains("m.mailbox IN (?,?,?)"))
+        XCTAssertTrue(scope.sql.contains("scoped.mailbox IN (?,?,?)"))
         XCTAssertTrue(scope.sql.contains("l.mailbox_id IN (?,?,?)"))
         XCTAssertEqual(scope.rowIDBinds, [1, 2, 3, 1, 2, 3])
+        XCTAssertEqual(scope.logicalMailboxRowIDBinds, [1, 2, 3, 1, 2, 3])
     }
 
     func testMailboxScopeClauseBindCountInvariant() {

--- a/swift/Tests/MailCLITests/EnvelopeQueriesTests.swift
+++ b/swift/Tests/MailCLITests/EnvelopeQueriesTests.swift
@@ -102,6 +102,61 @@ final class EnvelopeQueriesTests: XCTestCase {
         XCTAssertEqual(escapeLikePattern("plain"), "plain")
     }
 
+    // MARK: - Mailbox scope clause
+
+    func testMailboxScopeClauseWithoutLabels() throws {
+        let scope = try XCTUnwrap(mailboxScopeClause(rowIDs: [297], includeLabels: false))
+        XCTAssertEqual(scope.sql, "m.mailbox IN (?)")
+        XCTAssertEqual(scope.rowIDBinds, [297])
+    }
+
+    func testMailboxScopeClauseWithLabelsAddsGmailArm() throws {
+        // Gmail keeps the single physical copy under [Gmail]/All Mail and records
+        // INBOX membership in `labels`, so the direct arm alone matches nothing.
+        let scope = try XCTUnwrap(mailboxScopeClause(rowIDs: [297], includeLabels: true))
+        XCTAssertEqual(
+            scope.sql,
+            "(m.mailbox IN (?) OR m.ROWID IN "
+                + "(SELECT l.message_id FROM labels l WHERE l.mailbox_id IN (?)))")
+        // Direct arm bound first, label arm second: the clause consumes them in that order.
+        XCTAssertEqual(scope.rowIDBinds, [297, 297])
+    }
+
+    func testMailboxScopeClauseMultipleRowIDs() throws {
+        let scope = try XCTUnwrap(mailboxScopeClause(rowIDs: [1, 2, 3], includeLabels: true))
+        XCTAssertTrue(scope.sql.contains("m.mailbox IN (?,?,?)"))
+        XCTAssertTrue(scope.sql.contains("l.mailbox_id IN (?,?,?)"))
+        XCTAssertEqual(scope.rowIDBinds, [1, 2, 3, 1, 2, 3])
+    }
+
+    func testMailboxScopeClauseBindCountInvariant() {
+        // Binds are positional: the mailbox condition is appended first, so a drift
+        // between placeholder count and bind count shifts every later bind.
+        for rowIDs in [[297], [10, 11], [1, 2, 3]] as [[Int64]] {
+            XCTAssertEqual(
+                mailboxScopeClause(rowIDs: rowIDs, includeLabels: false)?.rowIDBinds.count,
+                rowIDs.count)
+            XCTAssertEqual(
+                mailboxScopeClause(rowIDs: rowIDs, includeLabels: true)?.rowIDBinds.count,
+                rowIDs.count * 2)
+        }
+    }
+
+    func testMailboxScopeClauseLabelsOffIsByteIdenticalToUpstream() throws {
+        // Installs with no Gmail labels must emit exactly the clause they emitted before.
+        let scope = try XCTUnwrap(mailboxScopeClause(rowIDs: [4, 5], includeLabels: false))
+        XCTAssertEqual(scope.sql, "m.mailbox IN (?,?)")
+        XCTAssertEqual(scope.rowIDBinds, [4, 5])
+    }
+
+    func testMailboxScopeClauseEmptyRowIDsReturnsNil() {
+        // An empty scope selects nothing, so there is no clause to emit and no query to
+        // run. SQLite would accept the `IN ()` this used to build, but only as a
+        // non-standard always-false expression, and both arms would still be dead weight.
+        XCTAssertNil(mailboxScopeClause(rowIDs: [], includeLabels: false))
+        XCTAssertNil(mailboxScopeClause(rowIDs: [], includeLabels: true))
+    }
+
     // MARK: - Message ID normalization
 
     func testMessageIDCandidates() {


### PR DESCRIPTION
## What

Two defects made the SQLite read path (`--engine sqlite` / `auto`) unreliable for IMAP accounts.

**1. Resolve IMAP accounts through their logical parent.** Mail hosts IMAP mailboxes on per-dataclass child rows whose description and username can both be null. The readable values live on the parent. Account discovery now self-joins `ZACCOUNT` and inherits both fields.

Multiple mailbox UUIDs are allowed when they belong to the same logical parent. If one username belongs to different logical parents, account selection fails with an ambiguity error instead of silently combining mailboxes from distinct accounts. An exact UUID always selects only that UUID.

**2. Scope Gmail mailboxes through labels.** Gmail keeps the physical message under `[Gmail]/All Mail` and stores folder membership in `labels`. The query now builds two indexable ID branches, direct mailbox rows and label membership, with `UNION ALL` inside an outer `IN` membership test. The outer query applies filtering, ordering, and `LIMIT` once and cannot duplicate results.

The query also projects the logical mailbox that matched. Inbox searches now report Inbox instead of All Mail, and Spam messages receive the correct junk status.

## Failure behavior

The labels arm is gated by `hasLabelsTable()` and `anyLabelRows(mailboxRowIDs:)`. Probe failures include the labels arm because dropping it can silently return zero Gmail rows, while including it against an unavailable table fails loudly and lets `auto` fall back to JXA.

Installs without a `labels` table keep the original direct-mailbox query.

## Query plan

The scoped query keeps both membership branches indexable:

- direct branch: `messages_mailbox_date_received_index`
- label branch: `labels_mailbox_id_index`
- outer membership deduplicates a message present in both branches

## Tests

All tests are headless. Fixtures use throwaway SQLite databases in `FileManager.temporaryDirectory` and do not read Mail.app data or the user's Accounts database.

- `EnvelopeIndexAccountTests` covers parent inheritance, top-level and child overrides, same-parent multi-UUID resolution, exact UUID selection, and cross-parent username ambiguity.
- `EnvelopeIndexLabelsTests` covers label-backed Inbox results, direct and label deduplication, missing labels tables, bind alignment, logical mailbox location, Spam junk status, hermetic account fallback, and both mailbox indexes in `EXPLAIN QUERY PLAN`.
- `EnvelopeQueriesTests` pins the generated SQL and bind shapes.

Validation:

- `swift test`: 167 XCTest cases and 132 Swift Testing cases passed
- `swift build -c release`: passed with only the repository's known Secure Transport deprecation warnings
- Three parallel Codex review passes completed. Two findings were fixed and the focused re-review passed.

## Live verification

Against a read-only V10 Envelope Index, a Gmail Inbox had 0 rows by `messages.mailbox` and 26,885 rows by label. The schema and both expected indexes were also verified locally.

Co-signed: **Claude Fable 5** (Anthropic), original analysis and implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
